### PR TITLE
Fix typos, update CI workflow

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
-  
+
 env:
   TOOL_NAME: Tuw
 
@@ -16,7 +16,7 @@ jobs:
       tag: ${{ steps.check-tag.outputs.tag }}
       wx_version: ${{ steps.wx-version.outputs.version }}
     steps:
-    
+
       - name: Check tag
         id: check-tag
         run: |
@@ -27,8 +27,8 @@ jobs:
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
         shell: bash
-      
-      - uses: actions/checkout@v3
+
+      - uses: actions/checkout@v4
 
       - name: Create Release Draft
         id: create-release
@@ -79,8 +79,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: setup
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
 
       - name: Install Meson for Windows
         if: runner.os == 'Windows'
@@ -103,7 +105,7 @@ jobs:
       - name: Build exe for Windows
         if: runner.os == 'Windows'
         run: batch_files/build.bat Release ${{ matrix.arch }}
-          
+
       - name: Build exe for Unix
         if: runner.os != 'Windows'
         run: bash shell_scripts/build.sh Release
@@ -145,7 +147,7 @@ jobs:
     env:
       zip_ext: tar.bz2
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build ARM64 version on Ubuntu
         run: |
           sudo apt-get update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,15 +6,22 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  TOOL_NAME: Tuw
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-      - run: pip3 install cpplint
-      - run: cpplint --recursive --quiet .
-          
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: |
+          pip3 install cpplint codespell
+          cpplint --recursive --quiet .
+          codespell -S subprojects
+
   test:
     strategy:
       fail-fast: false
@@ -23,8 +30,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: lint
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
 
       - name: Install Meson for Windows
         if: runner.os == 'Windows'
@@ -73,7 +82,7 @@ jobs:
       matrix:
         os: [ubuntu, alpine]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run tests on arm64 image
         run: |
           sudo apt-get update
@@ -85,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run tests on alpine
         run: |
           docker build -t tuw_alpine_test -f docker/alpine.dockerfile ./
@@ -95,8 +104,10 @@ jobs:
     runs-on: windows-2022
     needs: lint
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
 
       - name: Install Meson
         run: pip install meson
@@ -135,7 +146,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, build_tests_windows_arm64]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v3
         with:
           name: tests-windows-arm64

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -9,8 +9,8 @@ filter=-build/c++11, -build/include_subdir
 # No need copyrights
 filter=-legal/copyright
 
-# We use wxWidgets objects that raise these warnings
-filter=-runtime/int, -runtime/references
+# No need this kind of warnings (https://github.com/cpplint/cpplint/issues/148)
+filter=-runtime/references
 
 # Exclude output directories
 exclude_files=build

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -21,7 +21,7 @@ Also, you can see [some examples](../examples/tips/multi_lines/) about it.
 It saves the previously executed arguments.  
 The executable will use them as default values when launching.  
 
-## My Linux machine says `Could Not Display` when lauching the executable.
+## My Linux machine says `Could Not Display` when launching the executable.
 
 Check `Allow executing file as program.` (Properties->Permissions->Execute)  
 You will be able to launch the executable by double-click.  

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,6 @@
+ver 0.6.2
+- Fixed typos.
+
 ver 0.6.1
 - Added radio buttons to GUI components
 - "placeholder" became the standard spelling for the placeholders option.
@@ -16,7 +19,7 @@ ver 0.6.0
 
 ver 0.5.1
 - Added a predefined ID for the user's home directory.
-- Added an option to rename the "Browse" button for path pickers. 
+- Added an option to rename the "Browse" button for path pickers.
 - Disabled c++ exceptions.
 - Removed more codes from wxWidgets.
 - Fixed crashes when opening URLs or files via the help menu.
@@ -33,14 +36,14 @@ ver 0.5.0
 - Fixed an error when the size of ["gui"] is zero.
 - Fixed a GTK warning about component sizes.
 - Removed more codes from wxWidgets.
-- Applied optimazation for objective-c++ files.
+- Applied optimization for objective-c++ files.
 - Applied link time optimization.
 - Used cstdio instead of iostream.
 - Removed compressed version from releases.
 
 ver 0.4.1
 - Raise errors when the command requires more components or there are unused components.
-- Error messages bacame more detailed when failed to parse commands.
+- Error messages became more detailed when failed to parse commands.
 - Commands will be shown in the log when loading definitions.
 - Fixed a bug that "%%" won't escsape the "%" symbol.
 - Fixed a bug that the window is resizable on macOS and Linux.
@@ -106,7 +109,7 @@ ver0.1.3
 - Added "empty_message" option to text box and pickers. They can show messages when their text boxes are empty.
 - Added "default" option to check box and text box
 - Fixed errors when failing to read json files
-- Removed dependancies from macOS build
+- Removed dependencies from macOS build
 
 ver0.1.2
 - Fixed a bug it needs dll for runtime libs

--- a/examples/all_keys/gui_definition.json
+++ b/examples/all_keys/gui_definition.json
@@ -87,7 +87,7 @@
             "components": [
                 {
                     "type": "static_text",
-                    "label": "All components with their optinal keys.",
+                    "label": "All components with their optional keys.",
                     "platforms": ["win", "linux", "mac"]
                 },
                 {

--- a/examples/components/path_pickers/README.md
+++ b/examples/components/path_pickers/README.md
@@ -1,7 +1,7 @@
 # Path Pickers
 
 You can use file pickers and folder pickers.  
-Of course, you can drop files on the pickers to specifiy the paths.  
+Of course, you can drop files on the pickers to specify the paths.  
 
 ![PathPikcers](https://github.com/matyalatte/tuw/assets/69258547/47bf541f-7ac4-465b-8bff-512c48d9d2a9)
 
@@ -33,7 +33,7 @@ Of course, you can drop files on the pickers to specifiy the paths.
 
 ## Components
 
-`compoents` is an array of GUI components (e.g. file pickers).  
+`components` is an array of GUI components (e.g. file pickers).  
 Each component should be defined as a dictionary.  
 
 -   `type` is component type. `file` for a file picker, and `folder` for a dir picker.

--- a/examples/other_features/cross_platform/README.md
+++ b/examples/other_features/cross_platform/README.md
@@ -1,6 +1,6 @@
 # Cross-platform Support
 
-There are optional keys to make platfrom specific GUIs.  
+There are optional keys to make platform specific GUIs.  
 No need to write JSON files for each platform.  
 
 ## "command_'os'"

--- a/meson.build
+++ b/meson.build
@@ -140,7 +140,7 @@ if get_option('build_test')
         include_directories: include_directories('include'),
         build_rpath: '',
         install_rpath: '',
-        name_prefix: 'lib',		# always call it libui, even in Windows DLLs
+        name_prefix: 'lib',
         install: false,
         gnu_symbol_visibility: 'hidden',
         soversion: '',

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -331,7 +331,7 @@ namespace json_utils {
                 if (id.GetInt() == j) { found = true; break; }
             if (!found) {
                 result.ok = false;
-                result.msg = "[\"commponents\"][" + std::to_string(j)
+                result.msg = "[\"components\"][" + std::to_string(j)
                              + "] is unused in the command; " + cmd_str;
                 if (comp_ids[j] != "")
                     result.msg = "The ID of " + result.msg;
@@ -427,7 +427,7 @@ namespace json_utils {
             CorrectKey(c, "item_array", "items", alloc);
             switch (type) {
                 case COMP_FILE:
-                    CheckJsonType(result, c, "extention", JsonType::STRING, label, CAN_SKIP);
+                    CheckJsonType(result, c, "extension", JsonType::STRING, label, CAN_SKIP);
                 case COMP_FOLDER:
                     CheckJsonType(result, c, "button", JsonType::STRING, label, CAN_SKIP);
                 case COMP_TEXT:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,10 +39,10 @@ int main_app() {
 bool AskOverwrite(const std::string& path) {
     if (!env_utils::FileExists(path)) return true;
     PrintFmt("Overwrite %s? (y/n)\n", path.c_str());
-    char ans;
-    int ret = scanf("%c", &ans);
+    char answer;
+    int ret = scanf("%c", &answer);
     fseek(stdin, 0, SEEK_END);
-    return ret == 1 && (ans == "y"[0] || ans == "Y"[0]);
+    return ret == 1 && (answer == "y"[0] || answer == "Y"[0]);
 }
 
 json_utils::JsonResult Merge(const std::string& exe_path, const std::string& json_path,

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -247,7 +247,7 @@ void MainFrame::UpdatePanel(int definition_id) {
     m_definition_id = definition_id;
     rapidjson::Value& sub_definition = m_definition["gui"][m_definition_id];
     const char* label = sub_definition["label"].GetString();
-    PrintFmt("[UpdatePanel] Lable: %s\n", label);
+    PrintFmt("[UpdatePanel] Label: %s\n", label);
     const char* cmd_str = sub_definition["command_str"].GetString();
     PrintFmt("[UpdatePanel] Command: %s\n", cmd_str);
     const char* window_name = json_utils::GetString(sub_definition,

--- a/tests/json_check/main.cpp
+++ b/tests/json_check/main.cpp
@@ -153,7 +153,7 @@ TEST(JsonCheckTest, checkGUIFail7) {
     GetTestJson(test_json);
     test_json["gui"][0]["components"][1].AddMember("id", "aaa", test_json.GetAllocator());
     CheckGUIError(test_json,
-        "The ID of [\"commponents\"][1] is unused in the command;"
+        "The ID of [\"components\"][1] is unused in the command;"
         " echo file: __comp2__ & echo folder: __comp3__ & echo combo: __comp4__"
         " & echo radio: __comp5__ & echo check: __comp6__ & echo check_array: __comp7__"
         " & echo textbox: __comp8__ & echo int: __comp9__ & echo float: __comp???__");


### PR DESCRIPTION
- Fixed typos.
- Added [codespell](https://github.com/codespell-project/codespell) to the CI workflow to remove typos from PRs.
- Updated some actions in the workflows to remove warnings.