### PR TITLE
Fix text for execution button

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,5 @@
+- Fixed a bug that the execution button still says "processing" after getting errors.
+
 ver 0.6.3
 - Supported Unix-like systems (FreeBSD, Haiku, etc).
 - Added URL validation for safety.

--- a/license.txt
+++ b/license.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2023 matyalatte
+Copyright (c) 2022-2024 matyalatte
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -384,14 +384,6 @@ std::string MainFrame::GetCommand() {
 }
 
 void MainFrame::RunCommand() {
-    char* text = uiButtonText(m_run_button);
-    uiButtonSetText(m_run_button, "Processing...");
-#ifdef __APPLE__
-    uiMainStep(1);
-#elif defined(__TUW_UNIX__)
-    uiUnixWaitEvents();
-#endif
-
     std::string cmd = GetCommand();
     PrintFmt("[RunCommand] Command: %s\n", cmd.c_str());
 
@@ -402,7 +394,15 @@ void MainFrame::RunCommand() {
                           "Command: " + cmd;
         ShowSuccessDialog(msg, "Safe Mode");
     } else {
+        char* text = uiButtonText(m_run_button);
+        uiButtonSetText(m_run_button, "Processing...");
+    #ifdef __APPLE__
+        uiMainStep(1);
+    #elif defined(__TUW_UNIX__)
+        uiUnixWaitEvents();
+    #endif
         ExecuteResult result = Execute(cmd);
+        uiButtonSetText(m_run_button, text);
 
         rapidjson::Value& sub_definition = m_definition["gui"][m_definition_id];
         bool check_exit_code = json_utils::GetBool(sub_definition, "check_exit_code", false);
@@ -432,8 +432,6 @@ void MainFrame::RunCommand() {
             ShowSuccessDialog("Success!");
         }
     }
-
-    uiButtonSetText(m_run_button, text);
 }
 
 // read gui_definition.json


### PR DESCRIPTION
Fixed a bug that the execution button says `Processing...` after getting errors.
![fix_button_text](https://github.com/matyalatte/tuw/assets/69258547/6b5003b4-6b83-4328-b16a-26784899969d)

This PR makes Tuw update the text after executing commands.
![fixed](https://github.com/matyalatte/tuw/assets/69258547/905d425d-2158-40ff-9f69-d277f22a3561)
