### PR TITLE
Support Universal CRT for Windows 10 or later

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -64,6 +64,11 @@ jobs:
             zip_ext: zip
             arch: ARM
             arch_suffix: -arm64
+          - os: windows-2022
+            exe_ext: .exe
+            zip_ext: zip
+            arch: UCRT
+            arch_suffix: -x64-ucrt
           - os: ubuntu-20.04
             exe_ext: ""
             zip_ext: tar.bz2
@@ -105,7 +110,6 @@ jobs:
       - name: Build exe for Windows
         if: runner.os == 'Windows'
         run: batch_files/build.bat Release ${{ matrix.arch }}
-
       - name: Build exe for Unix
         if: runner.os != 'Windows'
         run: bash shell_scripts/build.sh Release

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create Release Draft
         id: create-release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.check-tag.outputs.tag }}
           name: ${{ steps.check-tag.outputs.tag }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,7 +137,7 @@ jobs:
         shell: bash
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tests-windows-arm64
           path: workspace
@@ -147,7 +147,7 @@ jobs:
     needs: [lint, build_tests_windows_arm64]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: tests-windows-arm64
           path: workspace

--- a/batch_files/build.bat
+++ b/batch_files/build.bat
@@ -16,10 +16,14 @@ if /I "%~2"=="ARM" (
     )
 )
 
+if /I "%~2"=="UCRT" (
+    set OPT="-Duse_ucrt=true"
+)
+
 echo Build type: %BUILD_TYPE%
 
 @pushd %~dp0\..
-    meson setup build\%BUILD_TYPE%%~2 --backend=vs %PRESET%
+    meson setup build\%BUILD_TYPE%%~2 --backend=vs %PRESET% %OPT%
     if %ERRORLEVEL% neq 0 goto :buildend
     cd build\%BUILD_TYPE%%~2
     meson compile -v

--- a/batch_files/build_with_ucrt.bat
+++ b/batch_files/build_with_ucrt.bat
@@ -1,0 +1,6 @@
+REM Build with Universal CRT.
+REM This option makes exe much smaller. But the built binary only supports Windows10 or later.
+
+@pushd %~dp0
+build.bat Release UCRT
+popd

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,5 @@
+ver 0.6.4
+- Added Universal CRT version for Windows 10 or later
 - Fixed a bug that the execution button still says "processing" after getting errors.
 
 ver 0.6.3

--- a/include/tuw_constants.h
+++ b/include/tuw_constants.h
@@ -10,8 +10,8 @@ namespace tuw_constants {
         "       CLI tools\n";
     constexpr char TOOL_NAME[] = "Tuw";
     constexpr char AUTHOR[] = "matyalatte";
-    constexpr char VERSION[] = "0.6.3";
-    constexpr int VERSION_INT = 603;
+    constexpr char VERSION[] = "0.6.4";
+    constexpr int VERSION_INT = 604;
 
 #ifdef _WIN32
     constexpr char OS[] = "win";

--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,11 @@ if tuw_OS == 'windows'
             '/INCREMENTAL:NO',
             '/ENTRY:wmainCRTStartup'
         ]
+        if get_option('use_ucrt')
+            # These linker options make exe much smaller with UCRT,
+            # but the built binary only supports Windows10 or later.
+            tuw_link_args += ['/NODEFAULTLIB:libucrt.lib', '/DEFAULTLIB:ucrt.lib']
+        endif
         if meson.version().version_compare('<1.4.0')
             tuw_link_args += ['/MANIFEST:NO']
         endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,3 +2,5 @@ option('build_exe', type : 'boolean', value : true, description : 'Build executa
 option('build_test', type : 'boolean', value : false, description : 'Build tests')
 option('macosx_version_min', type : 'string', value : '10.9',
        description : 'Deployment target for macOS. This will affect to subprojects')
+option('use_ucrt', type : 'boolean', value : false,
+       description : 'Use Universal CRT for Windows 10 or later')


### PR DESCRIPTION
From Windows10, many vcruntime functions moved to a preinstalled library: [Universal CRT](https://learn.microsoft.com/en-US/cpp/porting/upgrade-your-code-to-the-universal-crt?view=msvc-170).
It means, you can make portable binaries smaller with the dynamic linked UCRT.

In tuw project, you can use `-Duse_ucrt=true` option to build tuw with UCRT.
The built binary only supports Windows10 or later, but it has half the size of v0.6.3.