### PR TITLE
fix a bug that empty strings are removed from args on Windows

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,5 @@
+- Fixed a bug that empty strings were removed from arguments on Windows.
+
 ver 0.6.4
 - Added Universal CRT version for Windows 10 or later
 - Fixed a bug that the execution button still says "processing" after getting errors.

--- a/subprojects/subprocess.wrap
+++ b/subprojects/subprocess.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/matyalatte/subprocess.h.git
-revision = 822b7564a60b233ac36f6c35e20d9b26c47b9d56
+revision = 35754225e32b739c72bd24a5a73720d8bab1fa56
 depth=1
 patch_directory = subprocess
 


### PR DESCRIPTION
I noticed [subprocess.h](https://github.com/sheredom/subprocess.h) had an issue that empty strings were removed from arguments on Windows.
This PR applies a fix for the issue. (https://github.com/matyalatte/subprocess.h/commit/35754225e32b739c72bd24a5a73720d8bab1fa56)