### PR TITLE
fix an error for building action

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -108,7 +108,9 @@ jobs:
 
       - name: Install gtk for Linux
         if: runner.os == 'Linux'
-        run: sudo apt -y install libgtk-3-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install libgtk-3-dev
 
       - name: Build exe for Windows
         if: runner.os == 'Windows'


### PR DESCRIPTION
I forgot to replace `apt` with `apt-get` in `build_all.yml`.
And apt doesn't seem to work anymore.