### PR TITLE
Support JSON with Comments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,7 @@ jobs:
           mkdir workspace
           cp build/ReleaseARM-Test/tests/unit_test.exe workspace
           mkdir workspace/json
-          cp build/ReleaseARM-Test/tests/json/*.json workspace/json
+          cp build/ReleaseARM-Test/tests/json/*.json* workspace/json
         shell: bash
 
       - name: Upload artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 !examples/**/gui_definition.json
 !tests/**/*.json
 !schema/*.json
+*.jsonc
+!examples/**/gui_definition.jsonc
+!tests/**/*.jsonc
 
 *.txt
 !changelog.txt

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,6 @@
+- Added support for C-style comments and trailing commas in JSON files.
+- Added support for .jsonc files.
+
 ver 0.7.0
 - Added options for string validation.
 - Added support for colorized output on Windows.

--- a/examples/README.md
+++ b/examples/README.md
@@ -61,3 +61,4 @@ Not about the JSON format, but they might help you.
 -   [Multiple Lines](./tips/multi_lines): How to run multiple commands in a process.
 -   [Unicode Characters](./tips/unicode): Tuw supports UTF-8!
 -   [Safe Mode](./tips/safe_mode): You can check commands without executing them.
+-   [JSON with Comments](./tips/comments): Tuw supports C-style comments in JSON files.

--- a/examples/get_start/minimal/README.md
+++ b/examples/get_start/minimal/README.md
@@ -1,7 +1,6 @@
 # Minimal GUI
 
-Tuw will read `./gui_definition.json` when launching the executable.  
-You can define a GUI in the JSON file.  
+Tuw will read `./gui_definition.json` (or `./gui_definition.jsonc`) when launching the executable. You can define a GUI in the JSON file.  
   
 The following JSON is for a minimal GUI that you can create.  
 It has only a button to echo `Hello!`.  

--- a/examples/tips/comments/README.md
+++ b/examples/tips/comments/README.md
@@ -1,0 +1,24 @@
+# JSON with Comments
+
+> [!WARNING]
+> Released builds do not support this feature yet.
+
+Tuw supports the [JSON with Comments](https://code.visualstudio.com/docs/languages/json#_json-with-comments) format. It allows C-style comments (`//` and `/**/`) and trailing commas in addition to the standard JSON format. You can also use `.jsonc` as a file extension to let code editors know that it uses the extended JSON format.  
+
+```jsonc
+{
+    // Single-line comment
+    /*
+     * Multi-line comment
+     */
+    "gui": [
+        {
+            "label": "JSON with Comments",
+            "command": "echo Hello!",
+            "components": [],
+            // You can put a trailing comma after the last element.
+            "": "",
+        }
+    ]
+}
+```

--- a/examples/tips/comments/gui_definition.jsonc
+++ b/examples/tips/comments/gui_definition.jsonc
@@ -1,0 +1,15 @@
+{
+    // Single-line comment
+    /*
+     * Multi-line comment
+     */
+    "gui": [
+        {
+            "label": "JSON with Comments",
+            "command": "echo Hello!",
+            "components": [],
+            // You can put a trailing comma after the last element.
+            "": "",
+        }
+    ]
+}

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -29,6 +29,10 @@ namespace json_utils {
         COMP_MAX
     };
 
+    // JSON parser allows c style comments and trailing commas.
+    constexpr auto JSONC_FLAGS =
+        rapidjson::kParseCommentsFlag | rapidjson::kParseTrailingCommasFlag;
+
     JsonResult LoadJson(const std::string& file, rapidjson::Document& json) {
         FILE* fp = fopen(file.c_str(), "rb");
         if (!fp)
@@ -37,7 +41,7 @@ namespace json_utils {
         char readBuffer[65536];
         rapidjson::FileReadStream is(fp, readBuffer, sizeof(readBuffer));
 
-        rapidjson::ParseResult ok = json.ParseStream(is);
+        rapidjson::ParseResult ok = json.ParseStream<JSONC_FLAGS>(is);
         fclose(fp);
 
         if (!ok) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,7 +40,6 @@ int main_app() {
     return 0;
 }
 
-
 bool AskOverwrite(const char *path) {
     if (!envuFileExists(path)) return true;
     PrintFmt("Overwrite %s? (y/n)\n", path);
@@ -293,6 +292,11 @@ int main(int argc, char* argv[]) {
 
     switch (cmd_int) {
         case CMD_MERGE:
+            if (!envuFileExists(json_path.c_str()) &&
+                envuFileExists((json_path + "c").c_str())) {
+                // Not found .json but found .jsonc
+                json_path.push_back('c');
+            }
             result = Merge(exe_path, json_path, new_exe_path, force);
             break;
         case CMD_SPLIT:

--- a/tests/json/meson.build
+++ b/tests/json/meson.build
@@ -2,7 +2,8 @@
 files = [
     'broken.json',
     'config_ascii.json',
-    'config_utf.json'
+    'config_utf.json',
+    'relaxed.jsonc',
 ]
 
 foreach f : files

--- a/tests/json/relaxed.jsonc
+++ b/tests/json/relaxed.jsonc
@@ -1,0 +1,10 @@
+{
+    // Single-line comment
+    /*
+     * Multi-line comments
+     */
+    "ary": [
+        "",
+        "trailing_comma",
+    ]
+}

--- a/tests/json_check_test.h
+++ b/tests/json_check_test.h
@@ -26,6 +26,13 @@ TEST(JsonCheckTest, LoadJsonFail2) {
     EXPECT_STREQ(expected, result.msg.substr(0, 68).c_str());
 }
 
+TEST(JsonCheckTest, LoadJsonWithComments) {
+    // Check if json parser supports c-style comments and trailing commas.
+    rapidjson::Document test_json;
+    json_utils::JsonResult result = json_utils::LoadJson(JSON_RELAXED, test_json);
+    EXPECT_TRUE(result.ok);
+}
+
 void GetTestJson(rapidjson::Document& json);
 
 TEST(JsonCheckTest, LoadJsonSuccess) {

--- a/tests/json_paths.h
+++ b/tests/json_paths.h
@@ -6,3 +6,4 @@ const char *JSON_ALL_KEYS = "./json/gui_definition.json";
 const char *JSON_BROKEN = "./json/broken.json";
 const char *JSON_CONFIG_ASCII = "./json/config_ascii.json";
 const char *JSON_CONFIG_UTF = "./json/config_utf.json";
+const char *JSON_RELAXED = "./json/relaxed.jsonc";


### PR DESCRIPTION
Related to #41.

Added support for the [JSON with Comments](https://code.visualstudio.com/docs/languages/json#_json-with-comments) format. It allows C-style comments (`//` and `/**/`) and trailing commas in addition to the standard JSON format. You can also use `.jsonc` as a file extension to let code editors know that it uses the extended JSON format.  

```jsonc
{
    // Single-line comment
    /*
     * Multi-line comment
     */
    "gui": [
        {
            "label": "JSON with Comments",
            "command": "echo Hello!",
            "components": [],
            // You can put a trailing comma after the last element.
            "": "",
        }
    ]
}
```