### PR TITLE
add `codepage` option to support UTF-8 outputs on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 *.sh
 !shell_scripts/*.sh
 
+*.ps1
+!examples/**/*.ps1
+
 # subprojects
 subprojects/libui
 subprojects/packagecache

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,5 @@
+- Added "codepage" option to support UTF-8 outputs on Windows.
+
 ver 0.7.0
 - Added options for string validation.
 - Added support for colorized output on Windows.

--- a/examples/README.md
+++ b/examples/README.md
@@ -47,6 +47,7 @@ There are more features you can use.
 -   [Version Checking](./other_features/version_check/): Constraints on the tool version.
 -   [Alternate Spellings](./other_features/alternate_spellings/): Tuw supports multiple spellings for some JSON keys and values.
 -   [Skip Success Dialog](./other_features/skip_dialog/): You can skip the success dialog.
+-   [UTF-8 Outputs on Windows](./other_features/codepage/): Tuw requires an option when using UTF-8 outputs on Windows.
 
 ![help](https://github.com/matyalatte/tuw/assets/69258547/e408a179-6f9f-4769-ab3d-57f87d392a4f)  
 

--- a/examples/other_features/codepage/README.md
+++ b/examples/other_features/codepage/README.md
@@ -1,0 +1,25 @@
+# UTF-8 Outputs on Windows
+
+> [!WARNING]
+> Released builds do not support this feature yet.
+
+Tuw expects user's default locale for stdout on Windows. If you want to use UTF-8 outputs on Windows, you should use `"codepage": "utf8"` (or `"codepage": "utf-8"`) as an option.  
+
+```json
+{
+    "gui": [
+        {
+            "label": "Use UTF-8 outputs on Windows",
+            "command": "powershell -ExecutionPolicy Bypass -File \"utf.ps1\"",
+            "codepage": "utf8",
+            "components": []
+        }
+    ]
+}
+```
+
+```ps1
+# utf.ps1
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+Write-Output "あいうえお"
+```

--- a/examples/other_features/codepage/gui_definition.json
+++ b/examples/other_features/codepage/gui_definition.json
@@ -1,0 +1,10 @@
+{
+    "gui": [
+        {
+            "label": "Use UTF-8 outputs on Windows",
+            "command": "powershell -ExecutionPolicy Bypass -File \"utf.ps1\"",
+            "codepage": "utf8",
+            "components": []
+        }
+    ]
+}

--- a/examples/other_features/codepage/utf.ps1
+++ b/examples/other_features/codepage/utf.ps1
@@ -1,0 +1,2 @@
+﻿[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+Write-Output "あいうえお"

--- a/include/exec.h
+++ b/include/exec.h
@@ -7,5 +7,7 @@ struct ExecuteResult {
     std::string last_line;
 };
 
-ExecuteResult Execute(const std::string& cmd);
+// When use_utf8_on_windows is true,
+// Tuw converts output strings from UTF-8 to UTF-16 on Windows.
+ExecuteResult Execute(const std::string& cmd, bool use_utf8_on_windows = false);
 ExecuteResult LaunchDefaultApp(const std::string& url);

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -24,6 +24,10 @@
           "show_success_dialog": { "type": "boolean" },
           "check_exit_code": { "type": "boolean" },
           "exit_success": { "type": "integer" },
+          "codepage": {
+            "type": "string",
+            "enum": [ "default", "utf8", "utf-8" ]
+          },
           "components": { "$ref": "#/definitions/types/components" },
           "component_array": { "$ref": "#/definitions/types/components" }
         },

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -68,7 +68,7 @@ void DestroyProcess(subprocess_s &process, int *return_code, std::string &err_ms
     }
 }
 
-ExecuteResult Execute(const std::string& cmd) {
+ExecuteResult Execute(const std::string& cmd, bool use_utf8_on_windows) {
 #ifdef _WIN32
     std::wstring wcmd = UTF8toUTF16(cmd.c_str());
 
@@ -113,7 +113,12 @@ ExecuteResult Execute(const std::string& cmd) {
         out_read_size = ReadIO(process, READ_STDOUT, out_buf, BUF_SIZE, last_line, BUF_SIZE);
         err_read_size = ReadIO(process, READ_STDERR, err_buf, BUF_SIZE, err_msg, BUF_SIZE * 2);
 #ifdef _WIN32
-        printf("%s", out_buf);
+        if (use_utf8_on_windows) {
+            std::wstring wout = UTF8toUTF16(out_buf);
+            printf("%ls", wout.c_str());
+        } else {
+            printf("%s", out_buf);
+        }
 #else
         PrintFmt("%s", out_buf);
 #endif

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -423,6 +423,15 @@ namespace json_utils {
         CheckJsonType(result, sub_definition, "show_last_line", JsonType::BOOLEAN, "", CAN_SKIP);
         CheckJsonType(result, sub_definition,
                       "show_success_dialog", JsonType::BOOLEAN, "", CAN_SKIP);
+        CheckJsonType(result, sub_definition, "codepage", JsonType::STRING, "", CAN_SKIP);
+        if (sub_definition.HasMember("codepage")) {
+            std::string codepage = sub_definition["codepage"].GetString();
+            if (codepage != "utf8" && codepage != "utf-8" && codepage != "default") {
+                result.ok = false;
+                result.msg = "Unknown codepage: " + codepage;
+                return;
+            }
+        }
 
         CorrectKey(sub_definition, "component", "components", alloc);
         CorrectKey(sub_definition, "component_array", "components", alloc);

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -449,10 +449,14 @@ void MainFrame::RunCommand() {
 #elif defined(__TUW_UNIX__)
     uiUnixWaitEvents();
 #endif
-    ExecuteResult result = Execute(cmd);
+    rapidjson::Value& sub_definition = m_definition["gui"][m_definition_id];
+
+    std::string codepage = json_utils::GetString(sub_definition, "codepage", "");
+    bool use_utf8_on_windows = codepage == "utf8" || codepage == "utf-8";
+
+    ExecuteResult result = Execute(cmd, use_utf8_on_windows);
     uiButtonSetText(m_run_button, text);
 
-    rapidjson::Value& sub_definition = m_definition["gui"][m_definition_id];
     bool check_exit_code = json_utils::GetBool(sub_definition, "check_exit_code", false);
     int exit_success = json_utils::GetInt(sub_definition, "exit_success", 0);
     bool show_last_line = json_utils::GetBool(sub_definition, "show_last_line", false);


### PR DESCRIPTION
Related to #36.

Added `codepage` option to convert UTF-8 outputs to wstrings on Windows.
You should use `"codepage": "utf8"` or `"codepage": "utf-8"` when your command outputs UTF-8 strings on Windows.