### PR TITLE
Remove unused functions from release builds, and re-enable exception handlings for std lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,8 @@ subprojects/tiny_str_match
 *.new
 *.zip
 
-Tuw*
+Tuw
+Tuw.exe
 SimpleCommandRunner
 *.tar.*
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,6 @@
+- Removed unused functions from release builds.
+- Re-enabled exception handlings for the std library.
+
 ver 0.7.1
 - Added support for C-style comments and trailing commas in JSON files.
 - Added support for .jsonc files.

--- a/meson.build
+++ b/meson.build
@@ -48,7 +48,7 @@ if tuw_OS == 'windows'
 
         if tuw_is_release
             # Note: b_lto doesn't seem to work with MSVC.
-            tuw_cpp_args += ['/GL', '/D_HAS_EXCEPTIONS=0']
+            tuw_cpp_args += ['/GL']
             tuw_link_args += ['/OPT:REF', '/OPT:ICF', '/LTCG']
         endif
     else

--- a/presets/release.ini
+++ b/presets/release.ini
@@ -4,14 +4,12 @@ default_library = 'static'
 b_vscrt = 'mt'
 b_ndebug = 'true'
 cpp_rtti = false
-cpp_eh = 'none'
 debug = false
 optimization = 's'
 
 [libui:built-in options]
 buildtype = 'custom'
 default_library = 'static'
-cpp_eh = 'none'
 
 [libui:project options]
 tests = false
@@ -20,7 +18,6 @@ examples = false
 [env_utils:built-in options]
 buildtype = 'custom'
 default_library = 'static'
-cpp_eh = 'none'
 
 [env_utils:project options]
 cli = false

--- a/presets/release.ini
+++ b/presets/release.ini
@@ -14,6 +14,7 @@ default_library = 'static'
 [libui:project options]
 tests = false
 examples = false
+no_area_colorbtn_fontbtn = true
 
 [env_utils:built-in options]
 buildtype = 'custom'

--- a/subprojects/env_utils.wrap
+++ b/subprojects/env_utils.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/matyalatte/c-env-utils.git
-revision = 5f9109be396bc2047878a22d40e01a2a17bdd351
+revision = f52f3a99ef3e989d79c272bd4004adc8e364bf33
 depth = 1
 
 [provide]

--- a/subprojects/libui.wrap
+++ b/subprojects/libui.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/matyalatte/libui-ng.git
-revision = ba11b3a232b661318a0c819ce147a02fdd0a6a6c
+revision = 1627edd47447d50acbd11cff018ed579cf216ebe
 depth = 1
 
 [provide]

--- a/subprojects/libui.wrap
+++ b/subprojects/libui.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/matyalatte/libui-ng.git
-revision = 1627edd47447d50acbd11cff018ed579cf216ebe
+revision = 4a4f6e0412e91e4cf9a11ed84bc8ecc14d38f0b0
 depth = 1
 
 [provide]

--- a/subprojects/tiny_str_match.wrap
+++ b/subprojects/tiny_str_match.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/matyalatte/tiny-str-match.git
-revision = a8c6ae67b97eb9061c7909d0007ce1579324fa13
+revision = b0d341188c3461d9b0ce302757b8bef8a0f79c17
 depth = 1
 
 [provide]


### PR DESCRIPTION
- Re-enabled exception handlings for the standard library. (054961c2d7d09f0a8b5f3aa42b02af56b4294935)
- Hid symbols for static linked libraries to make MSVC possible to remove unused APIs. (https://github.com/matyalatte/libui-ng/commit/1627edd47447d50acbd11cff018ed579cf216ebe, https://github.com/matyalatte/c-env-utils/pull/2, https://github.com/matyalatte/tiny-str-match/pull/1)
- Removed some unnecessary function calls from core features of libui. (https://github.com/matyalatte/libui-ng/commit/4a4f6e0412e91e4cf9a11ed84bc8ecc14d38f0b0)

Exception handling was disabled to reduce the binary size of wxWidgets at old versions of Tuw, but it has been re-enabled as the current binaries are small enough. Also, Windows and macOS binaries have been made smaller by removing some expressions that were preventing compiler optimization.
