### PR TITLE
Support affixes

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,5 @@
+- Added "optional" to ignore some options when a text box is empty.
+- Added "prefix" and "suffix" options to append strings to user inputs.
 - Removed unused functions from release builds.
 - Re-enabled exception handlings for the std library.
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -2,6 +2,7 @@
 - Added "prefix" and "suffix" options to append strings to user inputs.
 - Removed unused functions from release builds.
 - Re-enabled exception handlings for the std library.
+- Optimized some functions for binary size.
 
 ver 0.7.1
 - Added support for C-style comments and trailing commas in JSON files.

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,6 +33,8 @@ Examples for component options.
 -   [Placeholders](./comp_options/placeholder/): An option to show a message when the text box is empty.
 -   [Validators](./comp_options/validator/): Options to validate input strings before execution.
 -   [Renaming Buttons](./comp_options/button/): An option to rename buttons of path pickers.
+-   [Affixes](./comp_options/affix/): Options to append strings to user intpus.
+-   [Optional Components](./comp_options/optional/): An option to ignore affixes and validators when a text box is empty.
 
 ![tooltip](https://github.com/matyalatte/tuw/assets/69258547/8c7244ee-48ce-4492-973c-a3e6c628b8ed)  
 

--- a/examples/all_keys/gui_definition.json
+++ b/examples/all_keys/gui_definition.json
@@ -100,7 +100,6 @@
                     "default": "test.txt",
                     "add_quotes": true,
                     "tooltip": "Tooltip!",
-                    "platforms": ["win", "linux", "mac"],
                     "validator": {
                         "exist": true,
                         "exist_error": "File not found.",
@@ -110,7 +109,11 @@
                         "regex_error": "PNG or JPG.",
                         "wildcard": "*.*",
                         "wildcard_error": "File does not have extension."
-                    }
+                    },
+                    "optional": false,
+                    "prefix": "",
+                    "suffix": "",
+                    "platforms": ["win", "linux", "mac"]
                 },
                 {
                     "type": "folder",
@@ -121,6 +124,9 @@
                     "default": "testdir",
                     "add_quotes": true,
                     "tooltip": "Tooltip?",
+                    "optional": false,
+                    "prefix": "",
+                    "suffix": "",
                     "platforms": ["win", "linux", "mac"]
                 },
                 {
@@ -209,6 +215,9 @@
                     "placeholder": "type here!",
                     "default": "remove this text!",
                     "tooltip": "text box.",
+                    "optional": false,
+                    "prefix": "",
+                    "suffix": "",
                     "platforms": ["win", "linux", "mac"]
                 },
                 {

--- a/examples/comp_options/affix/README.md
+++ b/examples/comp_options/affix/README.md
@@ -1,0 +1,24 @@
+# Affixes
+
+`prefix` and `suffix` can append strings to user inputs.
+
+![Affix](https://github.com/user-attachments/assets/15910d56-26b5-4f90-8294-602bec9383d3)
+
+```json
+{
+    "gui": [
+        {
+            "label": "Affix example",
+            "command": "echo %-%",
+            "components": [
+                {
+                    "type": "text",
+                    "label": "Text box",
+                    "prefix": "-pre=",
+                    "suffix": " -suf"
+                }
+            ]
+        }
+    ]
+}
+```

--- a/examples/comp_options/affix/README.md
+++ b/examples/comp_options/affix/README.md
@@ -1,5 +1,8 @@
 # Affixes
 
+> [!WARNING]
+> Released builds do not support this feature yet.
+
 `prefix` and `suffix` can append strings to user inputs.
 
 ![Affix](https://github.com/user-attachments/assets/15910d56-26b5-4f90-8294-602bec9383d3)

--- a/examples/comp_options/affix/gui_definition.json
+++ b/examples/comp_options/affix/gui_definition.json
@@ -1,0 +1,16 @@
+{
+    "gui": [
+        {
+            "label": "Affix example",
+            "command": "echo %-%",
+            "components": [
+                {
+                    "type": "text",
+                    "label": "Text box",
+                    "prefix": "-pre=",
+                    "suffix": " -suf"
+                }
+            ]
+        }
+    ]
+}

--- a/examples/comp_options/optional/README.md
+++ b/examples/comp_options/optional/README.md
@@ -1,0 +1,28 @@
+# Optional Components
+
+`optional` is an option to ignore `"add_quotes"`, `"prefix"`, `"suffix"`, and `"validator"` when a text box is empty.
+
+![optional](https://github.com/user-attachments/assets/a7c94cc7-cb84-4ca9-a1a1-ed1e6babc18e)
+
+```json
+{
+    "gui": [
+        {
+            "label": "Optional component",
+            "command": "echo %-%",
+            "components": [
+                {
+                    "type": "text",
+                    "label": "Text box",
+                    "optional": true,
+                    "prefix": "-pre=",
+                    "suffix": " -suf",
+                    "validator": {
+                        "regex": ".+"
+                    }
+                }
+            ]
+        }
+    ]
+}
+```

--- a/examples/comp_options/optional/README.md
+++ b/examples/comp_options/optional/README.md
@@ -1,5 +1,8 @@
 # Optional Components
 
+> [!WARNING]
+> Released builds do not support this feature yet.
+
 `optional` is an option to ignore `"add_quotes"`, `"prefix"`, `"suffix"`, and `"validator"` when a text box is empty.
 
 ![optional](https://github.com/user-attachments/assets/a7c94cc7-cb84-4ca9-a1a1-ed1e6babc18e)

--- a/examples/comp_options/optional/gui_definition.json
+++ b/examples/comp_options/optional/gui_definition.json
@@ -1,0 +1,20 @@
+{
+    "gui": [
+        {
+            "label": "Optional component",
+            "command": "echo %-%",
+            "components": [
+                {
+                    "type": "text",
+                    "label": "Text box",
+                    "optional": true,
+                    "prefix": "-pre=",
+                    "suffix": " -suf",
+                    "validator": {
+                        "regex": ".+"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/include/component.h
+++ b/include/component.h
@@ -17,6 +17,9 @@ class Component {
     bool m_is_wide;
     Validator m_validator;
     uiLabel* m_error_widget;
+    bool m_optional;
+    std::string m_prefix;
+    std::string m_suffix;
 
  private:
     bool m_add_quotes;

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -142,6 +142,9 @@
             "label": { "type": "string" },
             "id": { "type": "string" },
             "add_quotes": { "type": "boolean" },
+            "optional": { "type": "boolean" },
+            "prefix": { "type": "string" },
+            "suffix": { "type": "string" },
             "platforms": {
               "type": "array",
               "items": {

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -223,8 +223,8 @@ std::string FilePicker::GetRawString() {
 
 static void setConfigForTextBox(const rapidjson::Value& config,
                                 const std::string& id, void *widget) {
-    if (config.HasMember(id.c_str()) && config[id.c_str()].IsString()) {
-        const char* str = config[id.c_str()].GetString();
+    const char* str = json_utils::GetString(config, id.c_str(), nullptr);
+    if (str) {
         uiEntry* entry = static_cast<uiEntry*>(widget);
         uiEntrySetText(entry, str);
     }

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -195,20 +195,18 @@ namespace json_utils {
             "\"label\":\"Default GUI\","
     #ifdef _WIN32
             "\"command\":\"dir\","
-            "\"command_str\":\"dir\","
-            "\"command_splitted\":[\"dir\"],"
             "\"button\":\"run 'dir'\","
     #else
             "\"command\":\"ls\","
-            "\"command_str\":\"ls\","
-            "\"command_splitted\":[\"ls\"],"
             "\"button\":\"run 'ls'\","
     #endif
-            "\"components\":[],"
-            "\"command_ids\":[]"
+            "\"components\":[]"
             "}]}";
         rapidjson::ParseResult ok = definition.Parse(def_str);
         assert(ok);
+        JsonResult result = JSON_RESULT_OK;
+        CheckDefinition(result, definition);
+        assert(result.ok);
     }
 
     static void CorrectKey(rapidjson::Value& j,

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -538,6 +538,10 @@ namespace json_utils {
             CheckJsonType(result, c, "id", JsonType::STRING, label, OPTIONAL);
             CheckJsonType(result, c, "tooltip", JsonType::STRING, label, OPTIONAL);
 
+            CheckJsonType(result, c, "optional", JsonType::BOOLEAN, label, OPTIONAL);
+            CheckJsonType(result, c, "prefix", JsonType::STRING, label, OPTIONAL);
+            CheckJsonType(result, c, "suffix", JsonType::STRING, label, OPTIONAL);
+
             bool ignore = false;
             CorrectKey(c, "platform", "platforms", alloc);
             CorrectKey(c, "platform_array", "platforms", alloc);

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -77,12 +77,9 @@ MainFrame::MainFrame(const rapidjson::Document& definition, const rapidjson::Doc
     if (!result.ok)
         json_utils::GetDefaultDefinition(m_definition);
 
-    unsigned definition_id = 0;
-    if (m_config.HasMember("_mode") && m_config["_mode"].IsInt()) {
-        unsigned mode = m_config["_mode"].GetInt();
-        if (mode < m_definition["gui"].Size())
-            definition_id = mode;
-    }
+    unsigned definition_id = json_utils::GetInt(m_config, "_mode", 0);
+    if (definition_id >= m_definition["gui"].Size())
+        definition_id = 0;
 
     CreateMenu();
     CreateFrame();
@@ -195,9 +192,11 @@ void MainFrame::CreateMenu() {
     menu = uiNewMenu("Menu");
     if (m_definition["gui"].Size() > 1) {
 #endif  // __APPLE__
-        for (unsigned i = 0; i < m_definition["gui"].Size(); i++) {
-            item = uiMenuAppendItem(menu, m_definition["gui"][i]["label"].GetString());
+        int i = 0;
+        for (const rapidjson::Value& j : m_definition["gui"].GetArray()) {
+            item = uiMenuAppendItem(menu, j["label"].GetString());
             uiMenuItemOnClicked(item, OnUpdatePanel, new MenuData(this, i));
+            i++;
         }
     }
     item = uiMenuAppendQuitItem(menu);
@@ -206,9 +205,11 @@ void MainFrame::CreateMenu() {
     if (m_definition.HasMember("help") && m_definition["help"].Size() > 0) {
         menu = uiNewMenu("Help");
 
-        for (unsigned i = 0; i < m_definition["help"].Size(); i++) {
-            item = uiMenuAppendItem(menu, m_definition["help"][i]["label"].GetString());
+        int i = 0;
+        for (const rapidjson::Value& j : m_definition["help"].GetArray()) {
+            item = uiMenuAppendItem(menu, j["label"].GetString());
             uiMenuItemOnClicked(item, OnOpenURL, new MenuData(this, i));
+            i++;
         }
     }
     menu = uiNewMenu("Debug");


### PR DESCRIPTION
Related to #23.

You can append strings to user inputs with `"prefix"` and `"suffix"`. Also, `"optional": true` ignores `"add_quotes"`, `"prefix"`, `"suffix"`, and `"validator"` when a text box is empty.

![optional](https://github.com/user-attachments/assets/a7c94cc7-cb84-4ca9-a1a1-ed1e6babc18e)

![Affix](https://github.com/user-attachments/assets/15910d56-26b5-4f90-8294-602bec9383d3)

```json
{
    "gui": [
        {
            "label": "Optional component",
            "command": "echo %-%",
            "components": [
                {
                    "type": "text",
                    "label": "Text box",
                    "optional": true,
                    "prefix": "-pre=",
                    "suffix": " -suf",
                    "validator": {
                        "regex": ".+"
                    }
                }
            ]
        }
    ]
}
```
