### PR TITLE
rename `*-Windows-x64-ucrt.zip` to `*-Windows10-x64.zip`

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -46,7 +46,6 @@ jobs:
 
             - Linux builds only support distributions using glibc.
               [Build the executable](https://github.com/matyalatte/${{ env.TOOL_NAME }}/blob/main/docs/Building.md) by yourself if you want to use it on unsupported distros.
-            - `Tuw-*-Windows-x64-ucrt.zip` is much smaller than the standard version, but it only works on Windows10 or later.
             - Tuw supports more unix-like systems (BSD, Haiku, illumos, etc.)
               [Building Workflow for Other Platforms - matyalatte/tuw](https://github.com/matyalatte/${{ env.TOOL_NAME }}/blob/main/docs/Build-on-Other.md)
           draft: true
@@ -71,7 +70,7 @@ jobs:
             exe_ext: .exe
             zip_ext: zip
             arch: UCRT
-            arch_suffix: -x64-ucrt
+            arch_suffix: 10-x64
           - os: ubuntu-20.04
             exe_ext: ""
             zip_ext: tar.bz2

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,9 +39,10 @@ All you need is a JSON file and a tiny executable.
 
 You can download executables from [the release page](https://github.com/matyalatte/tuw/releases)
 
--   `Tuw*-Windows*.zip` is for Windows (7 or later.)  
--   `Tuw*-macOS*.tar.bz2` is for macOS (10.9 or later.)  
--   `Tuw*-Linux*.tar.bz2` is for Linux (with GTK3.14, GLIBC2.15, and GLIBCXX3.4.21, or later versions of the libraries.)  
+-   `Tuw-*-Windows-*.zip` is for Windows (7 or later.)  
+-   `Tuw-*-Windows10-*.zip` requires Windows 10 or later, but it's much smaller than the standard version.  
+-   `Tuw-*-macOS.tar.bz2` is for macOS (10.9 or later.)  
+-   `Tuw-*-Linux-*.tar.bz2` is for Linux (with GTK3.14, GLIBC2.15, and GLIBCXX3.4.21, or later versions of the libraries.)  
 
 ## Examples
 


### PR DESCRIPTION
I think `Windows-x64-ucrt.zip` is a little bit confusing for users when there is `Windows-x64.zip`. `Windows10-x64.zip` would be better file name for the build using dynamic linked UCRT.