### PR TITLE
Allow a value instead of an array of a value.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,8 +20,8 @@ Tuw provides a very simple GUI for your scripts.
 All you need is a JSON file and a tiny executable.  
 **No need for compilers, browsers, or huge executables!**  
 
-![sample](https://github.com/matyalatte/tuw/assets/69258547/9b3c8487-010e-497b-b66c-95af84906dd0)
-<img src=https://user-images.githubusercontent.com/69258547/192090797-f5e5b52d-59aa-4942-a361-2c8b5c7bd746.png width=387></img>  
+![sample](https://github.com/user-attachments/assets/17894d27-64fc-45c7-89bf-7f55d505508f)
+<img src=https://github.com/user-attachments/assets/249b954f-e66e-46a8-8451-ad39e700d564 width=397></img>  
 
 ## Features
 

--- a/examples/comp_options/affix/README.md
+++ b/examples/comp_options/affix/README.md
@@ -6,19 +6,17 @@
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Affix example",
-            "command": "echo %-%",
-            "components": [
-                {
-                    "type": "text",
-                    "label": "Text box",
-                    "prefix": "-pre=",
-                    "suffix": " -suf"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Affix example",
+        "command": "echo %-%",
+        "components": [
+            {
+                "type": "text",
+                "label": "Text box",
+                "prefix": "-pre=",
+                "suffix": " -suf"
+            }
+        ]
+    }
 }
 ```

--- a/examples/comp_options/affix/gui_definition.json
+++ b/examples/comp_options/affix/gui_definition.json
@@ -1,16 +1,14 @@
 {
-    "gui": [
-        {
-            "label": "Affix example",
-            "command": "echo %-%",
-            "components": [
-                {
-                    "type": "text",
-                    "label": "Text box",
-                    "prefix": "-pre=",
-                    "suffix": " -suf"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Affix example",
+        "command": "echo %-%",
+        "components": [
+            {
+                "type": "text",
+                "label": "Text box",
+                "prefix": "-pre=",
+                "suffix": " -suf"
+            }
+        ]
+    }
 }

--- a/examples/comp_options/button/README.md
+++ b/examples/comp_options/button/README.md
@@ -7,24 +7,22 @@ It allows you to rename the button associated with the picker component.
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Button",
-            "window_name": "Button sample",
-            "command": "echo %-% %-%",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "Some file",
-                    "button": "..."
-                },
-                {
-                    "type": "folder",
-                    "label": "Some folder",
-                    "button": "Open"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Button",
+        "window_name": "Button sample",
+        "command": "echo %-% %-%",
+        "components": [
+            {
+                "type": "file",
+                "label": "Some file",
+                "button": "..."
+            },
+            {
+                "type": "folder",
+                "label": "Some folder",
+                "button": "Open"
+            }
+        ]
+    }
 }
 ```

--- a/examples/comp_options/button/gui_definition.json
+++ b/examples/comp_options/button/gui_definition.json
@@ -1,21 +1,19 @@
 {
-    "gui": [
-        {
-            "label": "Button",
-            "window_name": "Button sample",
-            "command": "echo %-% %-%",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "Some file",
-                    "button": "..."
-                },
-                {
-                    "type": "folder",
-                    "label": "Some folder",
-                    "button": "Open"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Button",
+        "window_name": "Button sample",
+        "command": "echo %-% %-%",
+        "components": [
+            {
+                "type": "file",
+                "label": "Some file",
+                "button": "..."
+            },
+            {
+                "type": "folder",
+                "label": "Some folder",
+                "button": "Open"
+            }
+        ]
+    }
 }

--- a/examples/comp_options/default/gui_definition.json
+++ b/examples/comp_options/default/gui_definition.json
@@ -1,34 +1,32 @@
 {
-    "gui": [
-        {
-            "label": "Sample GUI",
-            "command": "echo file: %-% & echo options: %-%",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "Some file path",
-                    "extension": "any files (*)|*",
-                    "default": "./foo/bar"
-                },
-                {
-                    "type": "check_array",
-                    "label": "options",
-                    "items": [
-                        {
-                            "label": "falg1",
-                            "default": true
-                        },
-                        {
-                            "label": "falg2",
-                            "default": false
-                        },
-                        {
-                            "label": "falg3",
-                            "default": true
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Sample GUI",
+        "command": "echo file: %-% & echo options: %-%",
+        "components": [
+            {
+                "type": "file",
+                "label": "Some file path",
+                "extension": "any files (*)|*",
+                "default": "./foo/bar"
+            },
+            {
+                "type": "check_array",
+                "label": "options",
+                "items": [
+                    {
+                        "label": "falg1",
+                        "default": true
+                    },
+                    {
+                        "label": "falg2",
+                        "default": false
+                    },
+                    {
+                        "label": "falg3",
+                        "default": true
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/examples/comp_options/optional/README.md
+++ b/examples/comp_options/optional/README.md
@@ -6,23 +6,21 @@
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Optional component",
-            "command": "echo %-%",
-            "components": [
-                {
-                    "type": "text",
-                    "label": "Text box",
-                    "optional": true,
-                    "prefix": "-pre=",
-                    "suffix": " -suf",
-                    "validator": {
-                        "regex": ".+"
-                    }
+    "gui": {
+        "label": "Optional component",
+        "command": "echo %-%",
+        "components": [
+            {
+                "type": "text",
+                "label": "Text box",
+                "optional": true,
+                "prefix": "-pre=",
+                "suffix": " -suf",
+                "validator": {
+                    "regex": ".+"
                 }
-            ]
-        }
-    ]
+            }
+        ]
+    }
 }
 ```

--- a/examples/comp_options/optional/gui_definition.json
+++ b/examples/comp_options/optional/gui_definition.json
@@ -1,20 +1,18 @@
 {
-    "gui": [
-        {
-            "label": "Optional component",
-            "command": "echo %-%",
-            "components": [
-                {
-                    "type": "text",
-                    "label": "Text box",
-                    "optional": true,
-                    "prefix": "-pre=",
-                    "suffix": " -suf",
-                    "validator": {
-                        "regex": ".+"
-                    }
+    "gui": {
+        "label": "Optional component",
+        "command": "echo %-%",
+        "components": [
+            {
+                "type": "text",
+                "label": "Text box",
+                "optional": true,
+                "prefix": "-pre=",
+                "suffix": " -suf",
+                "validator": {
+                    "regex": ".+"
                 }
-            ]
-        }
-    ]
+            }
+        ]
+    }
 }

--- a/examples/comp_options/placeholder/README.md
+++ b/examples/comp_options/placeholder/README.md
@@ -7,29 +7,27 @@ It displays a message when the text box is empty.
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Placeholder",
-            "window_name": "Placeholder sample",
-            "command": "echo %-% %-% %-%",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "Some file",
-                    "placeholder": "Drop a file here!"
-                },
-                {
-                    "type": "folder",
-                    "label": "Some folder",
-                    "placeholder": "Drop a folder here!"
-                },
-                {
-                    "type": "text",
-                    "label": "Some text",
-                    "placeholder": "Type here!"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Placeholder",
+        "window_name": "Placeholder sample",
+        "command": "echo %-% %-% %-%",
+        "components": [
+            {
+                "type": "file",
+                "label": "Some file",
+                "placeholder": "Drop a file here!"
+            },
+            {
+                "type": "folder",
+                "label": "Some folder",
+                "placeholder": "Drop a folder here!"
+            },
+            {
+                "type": "text",
+                "label": "Some text",
+                "placeholder": "Type here!"
+            }
+        ]
+    }
 }
 ```

--- a/examples/comp_options/placeholder/gui_definition.json
+++ b/examples/comp_options/placeholder/gui_definition.json
@@ -1,26 +1,24 @@
 {
-    "gui": [
-        {
-            "label": "Placeholder",
-            "window_name": "Placeholder sample",
-            "command": "echo %-% %-% %-%",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "Some file",
-                    "placeholder": "Drop a file here!"
-                },
-                {
-                    "type": "folder",
-                    "label": "Some folder",
-                    "placeholder": "Drop a folder here!"
-                },
-                {
-                    "type": "text",
-                    "label": "Some text",
-                    "placeholder": "Type here!"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Placeholder",
+        "window_name": "Placeholder sample",
+        "command": "echo %-% %-% %-%",
+        "components": [
+            {
+                "type": "file",
+                "label": "Some file",
+                "placeholder": "Drop a file here!"
+            },
+            {
+                "type": "folder",
+                "label": "Some folder",
+                "placeholder": "Drop a folder here!"
+            },
+            {
+                "type": "text",
+                "label": "Some text",
+                "placeholder": "Type here!"
+            }
+        ]
+    }
 }

--- a/examples/comp_options/tooltip/gui_definition.json
+++ b/examples/comp_options/tooltip/gui_definition.json
@@ -1,43 +1,41 @@
 {
-    "gui": [
-        {
-            "label": "Sample GUI",
-            "command": "echo file: %-% & echo folder: %-% & echo options: %-%",
-            "components": [
-                {
-                    "type": "static_text",
-                    "label": "Move the mouse cursor to components to see tooltip messages!"
-                },
-                {
-                    "type": "file",
-                    "label": "Some file path",
-                    "extension": "any files (*)|*",
-                    "tooltip": "tooltip for file path!"
-                },
-                {
-                    "type": "folder",
-                    "label": "Some folder path",
-                    "tooltip": "tooltip for folder path!"
-                },
-                {
-                    "type": "check_array",
-                    "label": "options",
-                    "items": [
-                        {
-                            "label": "falg1",
-                            "tooltip": "tooltip for flag1!"
-                        },
-                        {
-                            "label": "falg2",
-                            "tooltip": "flag2!"
-                        },
-                        {
-                            "label": "falg3",
-                            "tooltip": "flag3..."
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Sample GUI",
+        "command": "echo file: %-% & echo folder: %-% & echo options: %-%",
+        "components": [
+            {
+                "type": "static_text",
+                "label": "Move the mouse cursor to components to see tooltip messages!"
+            },
+            {
+                "type": "file",
+                "label": "Some file path",
+                "extension": "any files (*)|*",
+                "tooltip": "tooltip for file path!"
+            },
+            {
+                "type": "folder",
+                "label": "Some folder path",
+                "tooltip": "tooltip for folder path!"
+            },
+            {
+                "type": "check_array",
+                "label": "options",
+                "items": [
+                    {
+                        "label": "falg1",
+                        "tooltip": "tooltip for flag1!"
+                    },
+                    {
+                        "label": "falg2",
+                        "tooltip": "flag2!"
+                    },
+                    {
+                        "label": "falg3",
+                        "tooltip": "flag3..."
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/examples/components/check_boxes/gui_definition.json
+++ b/examples/components/check_boxes/gui_definition.json
@@ -1,34 +1,32 @@
 {
-    "gui": [
-        {
-            "label": "Check Boxes",
-            "command": "echo checkbox: %-% & echo options:%-%",
-            "button": "Echo!",
-            "components": [
-                {
-                    "type": "check",
-                    "label": "checkbox",
-                    "value": "checked!"
-                },
-                {
-                    "type": "check_array",
-                    "label": "options",
-                    "items": [
-                        {
-                            "label": "flag1",
-                            "value": " -f1"
-                        },
-                        {
-                            "label": "flag2",
-                            "value": " -f2"
-                        },
-                        {
-                            "label": "flag3",
-                            "value": " -f3"
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Check Boxes",
+        "command": "echo checkbox: %-% & echo options:%-%",
+        "button": "Echo!",
+        "components": [
+            {
+                "type": "check",
+                "label": "checkbox",
+                "value": "checked!"
+            },
+            {
+                "type": "check_array",
+                "label": "options",
+                "items": [
+                    {
+                        "label": "flag1",
+                        "value": " -f1"
+                    },
+                    {
+                        "label": "flag2",
+                        "value": " -f2"
+                    },
+                    {
+                        "label": "flag3",
+                        "value": " -f3"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/examples/components/choices/gui_definition.json
+++ b/examples/components/choices/gui_definition.json
@@ -1,45 +1,43 @@
 {
-    "gui": [
-        {
-            "label": "Component Sample",
-            "command": "echo combo: %a% & echo radio: %b%",
-            "button": "Echo!",
-            "components": [
-                {
-                    "type": "combo",
-                    "label": "Combo box",
-                    "items": [
-                        {
-                            "label": "one",
-                            "value": "1"
-                        },
-                        {
-                            "label": "two",
-                            "value": "2"
-                        },
-                        {
-                            "label": "3"
-                        }
-                    ]
-                },
-                {
-                    "type": "radio",
-                    "label": "Radio buttons",
-                    "items": [
-                        {
-                            "label": "one",
-                            "value": "1"
-                        },
-                        {
-                            "label": "two",
-                            "value": "2"
-                        },
-                        {
-                            "label": "3"
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Component Sample",
+        "command": "echo combo: %a% & echo radio: %b%",
+        "button": "Echo!",
+        "components": [
+            {
+                "type": "combo",
+                "label": "Combo box",
+                "items": [
+                    {
+                        "label": "one",
+                        "value": "1"
+                    },
+                    {
+                        "label": "two",
+                        "value": "2"
+                    },
+                    {
+                        "label": "3"
+                    }
+                ]
+            },
+            {
+                "type": "radio",
+                "label": "Radio buttons",
+                "items": [
+                    {
+                        "label": "one",
+                        "value": "1"
+                    },
+                    {
+                        "label": "two",
+                        "value": "2"
+                    },
+                    {
+                        "label": "3"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/examples/components/num_pickers/gui_definition.json
+++ b/examples/components/num_pickers/gui_definition.json
@@ -1,27 +1,25 @@
 {
-    "gui": [
-        {
-            "label": "Select numbers",
-            "window_name": "Picker sample",
-            "command": "echo int: %-% & echo float: %-%",
-            "components": [
-                {
-                    "type": "int",
-                    "label": "Integer",
-                    "min": 0,
-                    "max": 100,
-                    "inc": 10,
-                    "wrap": true
-                },
-                {
-                    "type": "float",
-                    "label": "Floating-point number",
-                    "min": 0,
-                    "max": 1,
-                    "inc": 0.01,
-                    "digits": 2
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Select numbers",
+        "window_name": "Picker sample",
+        "command": "echo int: %-% & echo float: %-%",
+        "components": [
+            {
+                "type": "int",
+                "label": "Integer",
+                "min": 0,
+                "max": 100,
+                "inc": 10,
+                "wrap": true
+            },
+            {
+                "type": "float",
+                "label": "Floating-point number",
+                "min": 0,
+                "max": 1,
+                "inc": 0.01,
+                "digits": 2
+            }
+        ]
+    }
 }

--- a/examples/components/other_components/gui_definition.json
+++ b/examples/components/other_components/gui_definition.json
@@ -1,19 +1,17 @@
 {
-    "gui": [
-        {
-            "label": "Component Sample",
-            "command": "echo textbox: %c%",
-            "button": "Echo!",
-            "components": [
-                {
-                    "type": "static_text",
-                    "label": "This is a sample GUI. Edit 'gui_definition.json' for your scripts."
-                },
-                {
-                    "type": "text",
-                    "label": "Some text"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Component Sample",
+        "command": "echo textbox: %c%",
+        "button": "Echo!",
+        "components": [
+            {
+                "type": "static_text",
+                "label": "This is a sample GUI. Edit 'gui_definition.json' for your scripts."
+            },
+            {
+                "type": "text",
+                "label": "Some text"
+            }
+        ]
+    }
 }

--- a/examples/components/path_pickers/README.md
+++ b/examples/components/path_pickers/README.md
@@ -7,27 +7,25 @@ Of course, you can drop files on the pickers to specify the paths.
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Copy file",
-            "window_name": "Picker sample",
-            "command": "copy %foo% %bar%",
-            "button": "copy",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "PNG file you want to copy",
-                    "extension": "PNG files (*.png)|*.png",
-                    "add_quotes": true
-                },
-                {
-                    "type": "folder",
-                    "label": "Output path",
-                    "add_quotes": true
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Copy file",
+        "window_name": "Picker sample",
+        "command": "copy %foo% %bar%",
+        "button": "copy",
+        "components": [
+            {
+                "type": "file",
+                "label": "PNG file you want to copy",
+                "extension": "PNG files (*.png)|*.png",
+                "add_quotes": true
+            },
+            {
+                "type": "folder",
+                "label": "Output path",
+                "add_quotes": true
+            }
+        ]
+    }
 }
 ```
 

--- a/examples/components/path_pickers/gui_definition.json
+++ b/examples/components/path_pickers/gui_definition.json
@@ -1,23 +1,21 @@
 {
-    "gui": [
-        {
-            "label": "Copy file",
-            "window_name": "Picker sample",
-            "command": "copy %foo% %bar%",
-            "button": "copy",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "PNG file you want to copy",
-                    "extension": "PNG files (*.png)|*.png",
-                    "add_quotes": true
-                },
-                {
-                    "type": "folder",
-                    "label": "Output path",
-                    "add_quotes": true
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Copy file",
+        "window_name": "Picker sample",
+        "command": "copy %foo% %bar%",
+        "button": "copy",
+        "components": [
+            {
+                "type": "file",
+                "label": "PNG file you want to copy",
+                "extension": "PNG files (*.png)|*.png",
+                "add_quotes": true
+            },
+            {
+                "type": "folder",
+                "label": "Output path",
+                "add_quotes": true
+            }
+        ]
+    }
 }

--- a/examples/get_start/json_embed/gui_definition.json
+++ b/examples/get_start/json_embed/gui_definition.json
@@ -20,7 +20,7 @@
                     "id": "merged_exe",
                     "default": "Tuw.new.exe",
                     "add_quotes": true,
-                    "platforms": ["win"]
+                    "platforms": "win"
                 },
                 {
                     "type": "file",
@@ -45,7 +45,7 @@
                     "id": "merged_exe",
                     "default": "Tuw.new.exe",
                     "add_quotes": true,
-                    "platforms": ["win"]
+                    "platforms": "win"
                 },
                 {
                     "type": "file",
@@ -68,7 +68,7 @@
                     "id": "orig_exe",
                     "default": "Tuw.orig.exe",
                     "add_quotes": true,
-                    "platforms": ["win"]
+                    "platforms": "win"
                 },
                 {
                     "type": "file",

--- a/examples/get_start/minimal/README.md
+++ b/examples/get_start/minimal/README.md
@@ -9,17 +9,15 @@ It has only a button to echo `Hello!`.
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Minimal Sample",
-            "command": "echo Hello!",
-            "components": []
-        }
-    ]
+    "gui": {
+        "label": "Minimal Sample",
+        "command": "echo Hello!",
+        "components": []
+    }
 }
 ```
 
-You can write a definition of your GUI in `"gui": [{}]`.  
+You can write a definition of your GUI in `"gui": {}`.  
 
 -   `label` is the label for your definition. You can type anything you like here.
 -   `command` is the command you want to execute when clicking the execution button.

--- a/examples/get_start/minimal/gui_definition.json
+++ b/examples/get_start/minimal/gui_definition.json
@@ -1,9 +1,7 @@
 {
-    "gui": [
-        {
-            "label": "Minimal Sample",
-            "command": "echo Hello!",
-            "components": []
-        }
-    ]
+    "gui": {
+        "label": "Minimal Sample",
+        "command": "echo Hello!",
+        "components": []
+    }
 }

--- a/examples/get_start/put_component/README.md
+++ b/examples/get_start/put_component/README.md
@@ -6,20 +6,18 @@ You can put a text box in the GUI.
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Text Box Sample",
-            "window_name": "Title here!",
-            "command": "echo %-%",
-            "button": "Hello!",
-            "components": [
-                {
-                    "type": "text",
-                    "label": "Type 'Hello!'"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Text Box Sample",
+        "window_name": "Title here!",
+        "command": "echo %-%",
+        "button": "Hello!",
+        "components": [
+            {
+                "type": "text",
+                "label": "Type 'Hello!'"
+            }
+        ]
+    }
 }
 ```
 
@@ -44,19 +42,17 @@ In the example, the value of the text box will be injected at `%-%`.
 You can also use the [`id`](../../comp_options/id) option to name the components like variables.  
 
 ```json
-"gui": [
-    {
-        "label": "Text Box Sample",
-        "window_name": "Title here!",
-        "command": "echo %foo%, %foo%",
-        "button": "Hello!",
-        "components": [
-            {
-                "type": "text",
-                "label": "Type 'Hello!'",
-                "id": "foo"
-            }
-        ]
-    }
-]
+"gui": {
+    "label": "Text Box Sample",
+    "window_name": "Title here!",
+    "command": "echo %foo%, %foo%",
+    "button": "Hello!",
+    "components": [
+        {
+            "type": "text",
+            "label": "Type 'Hello!'",
+            "id": "foo"
+        }
+    ]
+}
 ```

--- a/examples/get_start/put_component/gui_definition.json
+++ b/examples/get_start/put_component/gui_definition.json
@@ -1,16 +1,14 @@
 {
-    "gui": [
-        {
-            "label": "Minimal Sample",
-            "window_name": "Title here!",
-            "command": "echo %-%",
-            "button": "Hello!",
-            "components": [
-                {
-                    "type": "text",
-                    "label": "Type 'Hello!'"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Minimal Sample",
+        "window_name": "Title here!",
+        "command": "echo %-%",
+        "button": "Hello!",
+        "components": [
+            {
+                "type": "text",
+                "label": "Type 'Hello!'"
+            }
+        ]
+    }
 }

--- a/examples/get_start/title_button/README.md
+++ b/examples/get_start/title_button/README.md
@@ -6,15 +6,13 @@ You can rename the window title and the execution button.
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Minimal Sample",
-            "window_name": "Title here!",
-            "command": "echo Hello!",
-            "button": "Hello!",
-            "components": []
-        }
-    ]
+    "gui": {
+        "label": "Minimal Sample",
+        "window_name": "Title here!",
+        "command": "echo Hello!",
+        "button": "Hello!",
+        "components": []
+    }
 }
 ```
 

--- a/examples/get_start/title_button/gui_definition.json
+++ b/examples/get_start/title_button/gui_definition.json
@@ -1,11 +1,9 @@
 {
-    "gui": [
-        {
-            "label": "Minimal Sample",
-            "window_name": "Title here!",
-            "command": "echo Hello!",
-            "button": "Hello!",
-            "components": []
-        }
-    ]
+    "gui": {
+        "label": "Minimal Sample",
+        "window_name": "Title here!",
+        "command": "echo Hello!",
+        "button": "Hello!",
+        "components": []
+    }
 }

--- a/examples/other_features/alternate_spellings/gui_definition.json
+++ b/examples/other_features/alternate_spellings/gui_definition.json
@@ -1,59 +1,57 @@
 {
-    "gui": [
-        {
-            "label": "Alternate Spellings",
-            "command": "echo folder: %-% & echo combo: %-% & echo check_array: %-% & echo textbox: %-% & echo int: %-%",
-            "title": "Alternate Spellings Sample",
-            "component_array": [
-                {
-                    "type": "static_text",
-                    "label": "Still working with alternate spellings!"
-                },
-                {
-                    "type": "dir",
-                    "label": "Some folder path",
-                    "empty_message": "placeholder!",
-                    "add_quote": true
-                },
-                {
-                    "type": "choice",
-                    "label": "combo box",
-                    "item_array": [
-                        {
-                            "label": "value1"
-                        },
-                        {
-                            "label": "value2"
-                        },
-                        {
-                            "label": "value3"
-                        }
-                    ]
-                },
-                {
-                    "type": "checks",
-                    "label": "options",
-                    "item_array": [
-                        {
-                            "label": "flag1"
-                        },
-                        {
-                            "label": "flag2"
-                        },
-                        {
-                            "label": "flag3"
-                        }
-                    ]
-                },
-                {
-                    "type": "text_box",
-                    "label": "text box"
-                },
-                {
-                    "type": "integer",
-                    "label": "Int picker"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Alternate Spellings",
+        "command": "echo folder: %-% & echo combo: %-% & echo check_array: %-% & echo textbox: %-% & echo int: %-%",
+        "title": "Alternate Spellings Sample",
+        "component_array": [
+            {
+                "type": "static_text",
+                "label": "Still working with alternate spellings!"
+            },
+            {
+                "type": "dir",
+                "label": "Some folder path",
+                "empty_message": "placeholder!",
+                "add_quote": true
+            },
+            {
+                "type": "choice",
+                "label": "combo box",
+                "item_array": [
+                    {
+                        "label": "value1"
+                    },
+                    {
+                        "label": "value2"
+                    },
+                    {
+                        "label": "value3"
+                    }
+                ]
+            },
+            {
+                "type": "checks",
+                "label": "options",
+                "item_array": [
+                    {
+                        "label": "flag1"
+                    },
+                    {
+                        "label": "flag2"
+                    },
+                    {
+                        "label": "flag3"
+                    }
+                ]
+            },
+            {
+                "type": "text_box",
+                "label": "text box"
+            },
+            {
+                "type": "integer",
+                "label": "Int picker"
+            }
+        ]
+    }
 }

--- a/examples/other_features/codepage/README.md
+++ b/examples/other_features/codepage/README.md
@@ -4,14 +4,12 @@ Tuw expects user's default locale for stdout on Windows. If you want to use UTF-
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Use UTF-8 outputs on Windows",
-            "command": "powershell -ExecutionPolicy Bypass -File \"utf.ps1\"",
-            "codepage": "utf8",
-            "components": []
-        }
-    ]
+    "gui": {
+        "label": "Use UTF-8 outputs on Windows",
+        "command": "powershell -ExecutionPolicy Bypass -File \"utf.ps1\"",
+        "codepage": "utf8",
+        "components": []
+    }
 }
 ```
 

--- a/examples/other_features/codepage/gui_definition.json
+++ b/examples/other_features/codepage/gui_definition.json
@@ -1,10 +1,8 @@
 {
-    "gui": [
-        {
-            "label": "Use UTF-8 outputs on Windows",
-            "command": "powershell -ExecutionPolicy Bypass -File \"utf.ps1\"",
-            "codepage": "utf8",
-            "components": []
-        }
-    ]
+    "gui": {
+        "label": "Use UTF-8 outputs on Windows",
+        "command": "powershell -ExecutionPolicy Bypass -File \"utf.ps1\"",
+        "codepage": "utf8",
+        "components": []
+    }
 }

--- a/examples/other_features/cross_platform/README.md
+++ b/examples/other_features/cross_platform/README.md
@@ -44,7 +44,7 @@ Tuw will ignore the component if the current OS does not match the specified pla
             "label": "Windows!",
             "id": "os",
             "default": true,
-            "platforms": [ "win" ]
+            "platforms": "win"
         },
         {
             "type": "check",

--- a/examples/other_features/cross_platform/gui_definition.json
+++ b/examples/other_features/cross_platform/gui_definition.json
@@ -18,7 +18,7 @@
                     "label": "Windows!",
                     "id": "os",
                     "default": true,
-                    "platforms": [ "win" ]
+                    "platforms": "win"
                 },
                 {
                     "type": "check",

--- a/examples/other_features/help/gui_definition.json
+++ b/examples/other_features/help/gui_definition.json
@@ -1,30 +1,28 @@
 {
-    "gui": [
-        {
-            "label": "Sample GUI",
-            "command": "echo file: %-% & echo folder: %-% & echo checkbox: %-%",
-            "components": [
-                {
-                    "type": "static_text",
-                    "label": "This is a sample GUI. Edit 'gui_definition.json' for your scripts."
-                },
-                {
-                    "type": "file",
-                    "label": "Some file path",
-                    "extension": "any files (*)|*",
-                    "placeholder": "Drop a file here!"
-                },
-                {
-                    "type": "folder",
-                    "label": "Some folder path"
-                },
-                {
-                    "type": "check",
-                    "label": "flag"
-                }
-            ]
-        }
-    ],
+    "gui": {
+        "label": "Sample GUI",
+        "command": "echo file: %-% & echo folder: %-% & echo checkbox: %-%",
+        "components": [
+            {
+                "type": "static_text",
+                "label": "This is a sample GUI. Edit 'gui_definition.json' for your scripts."
+            },
+            {
+                "type": "file",
+                "label": "Some file path",
+                "extension": "any files (*)|*",
+                "placeholder": "Drop a file here!"
+            },
+            {
+                "type": "folder",
+                "label": "Some folder path"
+            },
+            {
+                "type": "check",
+                "label": "flag"
+            }
+        ]
+    },
     "help": [
         {
             "type": "url",

--- a/examples/other_features/multiple/README.md
+++ b/examples/other_features/multiple/README.md
@@ -1,6 +1,6 @@
 # Multiple Definitions
 
-You can put multiple definitions in `"gui": []`.  
-These definitions can be selected from the `Menu` in the executable.  
+`"gui"` can be an array of gui definitions.
+Users can select one of the definitions from the `Menu` in the executable.  
 
 ![advanced](https://github.com/matyalatte/tuw/assets/69258547/956be42e-6931-4b71-ae3c-180103a93714)  

--- a/examples/other_features/skip_dialog/README.md
+++ b/examples/other_features/skip_dialog/README.md
@@ -4,12 +4,10 @@ You can disable the success dialog with `"show_success_dialog": false`.
 Tuw will refrain from showing the dialog regardless of how many times you push the execution button.
 
 ```json
-"gui": [
-    {
-        "label": "Skip dialog",
-        "command": "echo No dialogues...",
-        "show_success_dialog": false,
-        "components": []
-    }
-]
+"gui": {
+    "label": "Skip dialog",
+    "command": "echo No dialogues...",
+    "show_success_dialog": false,
+    "components": []
+}
 ```

--- a/examples/other_features/skip_dialog/gui_definition.json
+++ b/examples/other_features/skip_dialog/gui_definition.json
@@ -1,10 +1,8 @@
 {
-    "gui": [
-        {
-            "label": "Skip dialog",
-            "command": "echo No dialogues...",
-            "show_success_dialog": false,
-            "components": []
-        }
-    ]
+    "gui": {
+        "label": "Skip dialog",
+        "command": "echo No dialogues...",
+        "show_success_dialog": false,
+        "components": []
+    }
 }

--- a/examples/other_features/version_check/README.md
+++ b/examples/other_features/version_check/README.md
@@ -11,14 +11,12 @@ There are two options for checking the tool version.
 
 ```json
 {
-    "recommended": "1.1.0",
-    "minimum_required": "1.0.0",
-    "gui": [
-        {
-            "label": "You can't see this GUI.",
-            "command": "echo Hello!",
-            "components": []
-        }
-    ]
+    "recommended": "2.1.0",
+    "minimum_required": "2.0.0",
+    "gui": {
+        "label": "You can't see this GUI.",
+        "command": "echo Hello!",
+        "components": []
+    }
 }
 ```

--- a/examples/other_features/version_check/gui_definition.json
+++ b/examples/other_features/version_check/gui_definition.json
@@ -1,11 +1,9 @@
 {
-    "recommended": "1.1.0",
-    "minimum_required": "1.0.0",
-    "gui": [
-        {
-            "label": "You can't see this GUI.",
-            "command": "echo Hello!",
-            "components": []
-        }
-    ]
+    "recommended": "2.1.0",
+    "minimum_required": "2.0.0",
+    "gui": {
+        "label": "You can't see this GUI.",
+        "command": "echo Hello!",
+        "components": []
+    }
 }

--- a/examples/tips/comments/README.md
+++ b/examples/tips/comments/README.md
@@ -8,14 +8,12 @@ Tuw supports the [JSON with Comments](https://code.visualstudio.com/docs/languag
     /*
      * Multi-line comment
      */
-    "gui": [
-        {
-            "label": "JSON with Comments",
-            "command": "echo Hello!",
-            "components": [],
-            // You can put a trailing comma after the last element.
-            "": "",
-        }
-    ]
+    "gui": {
+        "label": "JSON with Comments",
+        "command": "echo Hello!",
+        "components": [],
+        // You can put a trailing comma after the last element.
+        "": "",
+    }
 }
 ```

--- a/examples/tips/comments/gui_definition.jsonc
+++ b/examples/tips/comments/gui_definition.jsonc
@@ -3,13 +3,11 @@
     /*
      * Multi-line comment
      */
-    "gui": [
-        {
-            "label": "JSON with Comments",
-            "command": "echo Hello!",
-            "components": [],
-            // You can put a trailing comma after the last element.
-            "": "",
-        }
-    ]
+    "gui": {
+        "label": "JSON with Comments",
+        "command": "echo Hello!",
+        "components": [],
+        // You can put a trailing comma after the last element.
+        "": "",
+    }
 }

--- a/examples/tips/unicode/gui_definition.json
+++ b/examples/tips/unicode/gui_definition.json
@@ -1,28 +1,26 @@
 {
-    "gui": [
-        {
-            "label": "Unicode Sample",
-            "command": "echo file: %รหัส% & echo folder: %-% & echo checkbox: %-%",
-            "button": "こんにちは！",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "文件",
-                    "extension": "any files | *",
-                    "default": "ああああ",
-                    "id": "รหัส"
-                },
-                {
-                    "type": "folder",
-                    "label": "폴더",
-                    "default": "いいいい"
-                },
-                {
-                    "type": "check",
-                    "label": "вариант",
-                    "default": true
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Unicode Sample",
+        "command": "echo file: %รหัส% & echo folder: %-% & echo checkbox: %-%",
+        "button": "こんにちは！",
+        "components": [
+            {
+                "type": "file",
+                "label": "文件",
+                "extension": "any files | *",
+                "default": "ああああ",
+                "id": "รหัส"
+            },
+            {
+                "type": "folder",
+                "label": "폴더",
+                "default": "いいいい"
+            },
+            {
+                "type": "check",
+                "label": "вариант",
+                "default": true
+            }
+        ]
+    }
 }

--- a/include/json_utils.h
+++ b/include/json_utils.h
@@ -40,6 +40,6 @@ void CheckVersion(JsonResult& result, rapidjson::Document& definition);
 void CheckDefinition(JsonResult& result, rapidjson::Document& definition);
 void CheckSubDefinition(JsonResult& result, rapidjson::Value& sub_definition,
                         rapidjson::Document::AllocatorType& alloc);
-void CheckHelpURLs(JsonResult& result, const rapidjson::Document& definition);
+void CheckHelpURLs(JsonResult& result, rapidjson::Document& definition);
 
 }  // namespace json_utils

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -7,8 +7,130 @@
     "minimum_required": { "$ref": "#/definitions/types/version" },
     "minimum_required_version": { "$ref": "#/definitions/types/version" },
     "gui": {
-      "type": "array",
-      "items": {
+      "if": { "type": "object" },
+      "then": { "$ref": "#/definitions/types/gui_item" },
+      "else": {
+        "type": "array",
+        "items": { "$ref": "#/definitions/types/gui_item" }
+      }
+    },
+    "help":  {
+      "if": { "type": "object" },
+      "then": { "$ref": "#/definitions/types/help_item" },
+      "else": {
+        "type": "array",
+        "items": { "$ref": "#/definitions/types/help_item" }
+      }
+    }
+  },
+  "required": [ "gui" ],
+  "definitions": {
+    "types": {
+      "version": {
+        "type": "string",
+        "pattern": "^[.0-9]+$",
+        "minLength": 1,
+        "maxLength": 8
+      },
+      "component": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "static_text",
+              "file",
+              "folder",
+              "dir",
+              "choice",
+              "combo",
+              "radio",
+              "check",
+              "check_array",
+              "checks",
+              "text",
+              "text_box",
+              "int",
+              "integer",
+              "float"
+            ]
+          },
+          "label": { "type": "string" },
+          "id": { "type": "string" },
+          "add_quotes": { "type": "boolean" },
+          "optional": { "type": "boolean" },
+          "prefix": { "type": "string" },
+          "suffix": { "type": "string" },
+          "platforms": { "$ref": "#/definitions/types/platform_array" },
+          "platform_array": { "$ref": "#/definitions/types/platform_array" }
+        },
+        "allOf": [
+          { "$ref": "#/definitions/components/file" },
+          { "$ref": "#/definitions/components/folder_or_text" },
+          { "$ref": "#/definitions/components/check" },
+          { "$ref": "#/definitions/components/int" },
+          { "$ref": "#/definitions/components/float" },
+          { "$ref": "#/definitions/components/combo" },
+          { "$ref": "#/definitions/components/check_array" },
+          { "$ref": "#/definitions/components/validator" }
+        ],
+        "required": [ "type", "label" ]
+      },
+      "component_array": {
+        "if": { "type": "object" },
+        "then": { "$ref": "#/definitions/types/component" },
+        "else": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/types/component" }
+        }
+      },
+      "platform": {
+        "type": "string",
+        "enum": [ "win", "mac", "linux" ]
+      },
+      "platform_array": {
+        "if": { "type": "string" },
+        "then": { "$ref": "#/definitions/types/platform" },
+        "else": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/types/platform" }
+        }
+      },
+      "combo_item": {
+        "type": "object",
+        "properties": {
+          "label": { "type": "string" },
+          "value": { "type": "string" }
+        },
+        "required": [ "label" ]
+      },
+      "combo_item_array": {
+        "if": { "type": "object" },
+        "then": { "$ref": "#/definitions/types/combo_item" },
+        "else": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/types/combo_item" }
+        }
+      },
+      "checks_item": {
+        "type": "object",
+        "properties": {
+          "label": { "type": "string" },
+          "value": { "type": "string" },
+          "tooltip": { "type": "string" },
+          "default": { "type": "boolean" }
+        },
+        "required": [ "label" ]
+      },
+      "checks_item_array": {
+        "if": { "type": "object" },
+        "then": { "$ref": "#/definitions/types/checks_item" },
+        "else": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/types/checks_item" }
+        }
+      },
+      "gui_item": {
         "type": "object",
         "properties": {
           "label": { "type": "string" },
@@ -28,8 +150,8 @@
             "type": "string",
             "enum": [ "default", "utf8", "utf-8" ]
           },
-          "components": { "$ref": "#/definitions/types/components" },
-          "component_array": { "$ref": "#/definitions/types/components" }
+          "components": { "$ref": "#/definitions/types/component_array" },
+          "component_array": { "$ref": "#/definitions/types/component_array" }
         },
         "required": [
           "label"
@@ -60,11 +182,8 @@
             }
           }
         ]
-      }
-    },
-    "help": {
-      "type": "array",
-      "items": {
+      },
+      "help_item": {
         "type": "object",
         "properties": {
           "type": {
@@ -102,100 +221,6 @@
             }
           }
         ]
-      }
-    }
-  },
-  "required": [ "gui" ],
-  "definitions": {
-    "types": {
-      "version": {
-        "type": "string",
-        "pattern": "^[.0-9]+$",
-        "minLength": 1,
-        "maxLength": 8
-      },
-      "components": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "static_text",
-                "file",
-                "folder",
-                "dir",
-                "choice",
-                "combo",
-                "radio",
-                "check",
-                "check_array",
-                "checks",
-                "text",
-                "text_box",
-                "int",
-                "integer",
-                "float"
-              ]
-            },
-            "label": { "type": "string" },
-            "id": { "type": "string" },
-            "add_quotes": { "type": "boolean" },
-            "optional": { "type": "boolean" },
-            "prefix": { "type": "string" },
-            "suffix": { "type": "string" },
-            "platforms": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "enum": [ "win", "mac", "linux" ]
-              }
-            },
-            "platform_array": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "enum": [ "win", "mac", "linux" ]
-              }
-            }
-          },
-          "allOf": [
-            { "$ref": "#/definitions/components/file" },
-            { "$ref": "#/definitions/components/folder_or_text" },
-            { "$ref": "#/definitions/components/check" },
-            { "$ref": "#/definitions/components/int" },
-            { "$ref": "#/definitions/components/float" },
-            { "$ref": "#/definitions/components/combo" },
-            { "$ref": "#/definitions/components/check_array" },
-            { "$ref": "#/definitions/components/validator" }
-          ],
-          "required": [ "type", "label" ]
-        }
-      },
-      "combo_items": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "label": { "type": "string" },
-            "value": { "type": "string" }
-          },
-          "required": [ "label" ]
-        }
-      },
-      "checks_items": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "label": { "type": "string" },
-            "value": { "type": "string" },
-            "tooltip": { "type": "string" },
-            "default": { "type": "boolean" }
-          },
-          "required": [ "label" ]
-        }
       }
     },
     "components": {
@@ -291,8 +316,8 @@
           "properties": {
             "default": { "type": "integer" },
             "tooltip": { "type": "string" },
-            "items": { "$ref": "#/definitions/types/combo_items" },
-            "item_array": { "$ref": "#/definitions/types/combo_items" }
+            "items": { "$ref": "#/definitions/types/combo_item_array" },
+            "item_array": { "$ref": "#/definitions/types/combo_item_array" }
           },
           "if": {
             "not": {
@@ -312,8 +337,8 @@
         },
         "then": {
           "properties": {
-            "items": { "$ref": "#/definitions/types/checks_items" },
-            "item_array": { "$ref": "#/definitions/types/checks_items" }
+            "items": { "$ref": "#/definitions/types/checks_item_array" },
+            "item_array": { "$ref": "#/definitions/types/checks_item_array" }
           },
           "if": {
             "not": {


### PR DESCRIPTION
Tuw now allows a value instead of an array of a value in JSON files. You can remove array brackets `[]` and indentations if an array has only one item.

```json
{
    "gui": {
        "label": "You don't need brackets now!",
        "command": "echo %-%",
        "components": {
            "type": "text",
            "label": "Type 'Hello!'",
            "platforms": "win"
        }
    }
}
```