### PR TITLE
Allow to define GUI elements in root object.

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,6 @@
+- Array brackets can now be omitted when there is only one element.
+- GUI elements can now be defined in root object.
+
 ver 0.7.2
 - Added "optional" to ignore some options when a text box is empty.
 - Added "prefix" and "suffix" options to append strings to user inputs.

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1,29 +1,33 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "properties": {
-    "recommended": { "$ref": "#/definitions/types/version" },
-    "recommended_version": { "$ref": "#/definitions/types/version" },
-    "minimum_required": { "$ref": "#/definitions/types/version" },
-    "minimum_required_version": { "$ref": "#/definitions/types/version" },
-    "gui": {
-      "if": { "type": "object" },
-      "then": { "$ref": "#/definitions/types/gui_item" },
-      "else": {
-        "type": "array",
-        "items": { "$ref": "#/definitions/types/gui_item" }
-      }
-    },
-    "help":  {
-      "if": { "type": "object" },
-      "then": { "$ref": "#/definitions/types/help_item" },
-      "else": {
-        "type": "array",
-        "items": { "$ref": "#/definitions/types/help_item" }
-      }
+  "if": {
+    "required": [ "gui" ]
+  },
+  "then": {
+    "properties": {
+      "recommended": { "$ref": "#/definitions/types/version" },
+      "recommended_version": { "$ref": "#/definitions/types/version" },
+      "minimum_required": { "$ref": "#/definitions/types/version" },
+      "minimum_required_version": { "$ref": "#/definitions/types/version" },
+      "gui": { "$ref": "#/definitions/types/gui_array" },
+      "help": { "$ref": "#/definitions/types/help_array" }
     }
   },
-  "required": [ "gui" ],
+  "else": {
+    "allOf": [
+      { "$ref": "#/definitions/types/gui_item" },
+      {
+        "properties": {
+          "recommended": { "$ref": "#/definitions/types/version" },
+          "recommended_version": { "$ref": "#/definitions/types/version" },
+          "minimum_required": { "$ref": "#/definitions/types/version" },
+          "minimum_required_version": { "$ref": "#/definitions/types/version" },
+          "help": { "$ref": "#/definitions/types/help_array" }
+        }
+      }
+    ]
+  },
   "definitions": {
     "types": {
       "version": {
@@ -183,6 +187,14 @@
           }
         ]
       },
+      "gui_array": {
+        "if": { "type": "object" },
+        "then": { "$ref": "#/definitions/types/gui_item" },
+        "else": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/types/gui_item" }
+        }
+      },
       "help_item": {
         "type": "object",
         "properties": {
@@ -221,6 +233,14 @@
             }
           }
         ]
+      },
+      "help_array":  {
+        "if": { "type": "object" },
+        "then": { "$ref": "#/definitions/types/help_item" },
+        "else": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/types/help_item" }
+        }
       }
     },
     "components": {

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -229,7 +229,7 @@ namespace json_utils {
 
     // get default definition of gui
     void GetDefaultDefinition(rapidjson::Document& definition) {
-        static const char* def_str = "{\"gui\":{"
+        static const char* def_str = "{"
             "\"label\":\"Default GUI\","
     #ifdef _WIN32
             "\"command\":\"dir\","
@@ -239,7 +239,7 @@ namespace json_utils {
             "\"button\":\"run 'ls'\","
     #endif
             "\"components\":[]"
-            "}}";
+            "}";
         rapidjson::ParseResult ok = definition.Parse(def_str);
         assert(ok);
         JsonResult result = JSON_RESULT_OK;
@@ -685,7 +685,14 @@ namespace json_utils {
     }
 
     void CheckDefinition(JsonResult& result, rapidjson::Document& definition) {
-        CheckJsonArrayType(result, definition, "gui", JsonType::JSON, definition.GetAllocator());
+        rapidjson::Document::AllocatorType& alloc = definition.GetAllocator();
+        if (!definition.HasMember("gui")) {
+            // definition["gui"] = definition
+            rapidjson::Value n(rapidjson::kObjectType);
+            n.CopyFrom(definition, alloc);
+            definition.AddMember("gui", n, alloc);
+        }
+        CheckJsonArrayType(result, definition, "gui", JsonType::JSON, alloc);
         if (!result.ok) return;
         if (definition["gui"].Size() == 0) {
             result.ok = false;
@@ -694,7 +701,7 @@ namespace json_utils {
 
         for (rapidjson::Value& sub_d : definition["gui"].GetArray()) {
             if (!result.ok) return;
-            CheckSubDefinition(result, sub_d, definition.GetAllocator());
+            CheckSubDefinition(result, sub_d, alloc);
         }
     }
 

--- a/tests/json/relaxed.jsonc
+++ b/tests/json/relaxed.jsonc
@@ -3,8 +3,12 @@
     /*
      * Multi-line comments
      */
-    "ary": [
-        "",
-        "trailing_comma",
-    ]
+    "label": "test",
+    "command": "echo hello",
+    "components": [],
+    "help": {
+        "label": "test",
+        "type": "url",
+        "url": "example.com",
+    },
 }

--- a/tests/json_check_test.cpp
+++ b/tests/json_check_test.cpp
@@ -71,6 +71,14 @@ TEST(JsonCheckTest, checkGUISuccess4) {
     EXPECT_TRUE(result.ok);
 }
 
+TEST(JsonCheckTest, checkGUISuccessRelaxed) {
+    rapidjson::Document test_json;
+    json_utils::JsonResult result = json_utils::LoadJson(JSON_RELAXED, test_json);
+    EXPECT_TRUE(result.ok);
+    json_utils::CheckDefinition(result, test_json);
+    EXPECT_TRUE(result.ok);
+}
+
 void CheckGUIError(rapidjson::Document& test_json, const char* expected) {
     json_utils::JsonResult result = JSON_RESULT_OK;
     json_utils::CheckDefinition(result, test_json);
@@ -82,7 +90,7 @@ TEST(JsonCheckTest, checkGUIFail) {
     rapidjson::Document test_json;
     GetTestJson(test_json);
     test_json.RemoveMember("gui");
-    CheckGUIError(test_json, "['gui'] not found.");
+    CheckGUIError(test_json, "['components'] not found.");
 }
 
 TEST(JsonCheckTest, checkGUIFail2) {
@@ -133,6 +141,14 @@ TEST(JsonCheckTest, checkGUIFail7) {
         " echo file: __comp2__ & echo folder: __comp3__ & echo combo: __comp4__"
         " & echo radio: __comp5__ & echo check: __comp6__ & echo check_array: __comp7__"
         " & echo textbox: __comp8__ & echo int: __comp9__ & echo float: __comp???__");
+}
+
+TEST(JsonCheckTest, checkGUIFailRelaxed) {
+    rapidjson::Document test_json;
+    json_utils::JsonResult result = json_utils::LoadJson(JSON_RELAXED, test_json);
+    EXPECT_TRUE(result.ok);
+    test_json.AddMember("exit_success", "a", test_json.GetAllocator());
+    CheckGUIError(test_json, "['exit_success'] should be an int.");
 }
 
 TEST(JsonCheckTest, checkHelpSuccess) {


### PR DESCRIPTION
You can move gui elements (e.g. `"command"`) into the root object.

```json
{
    "minimum_required": "0.8.0",
    "label": "test",
    "command": "echo hello",
    "components": [],
    "help": {
        "label": "test",
        "type": "url",
        "url": "example.com"
    }
}
```