### PR TITLE
Make GUI labels optional

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -46,7 +46,6 @@ jobs:
 
             - Linux builds only support distributions using glibc.
               [Build the executable](https://github.com/matyalatte/${{ env.TOOL_NAME }}/blob/main/docs/Building.md) by yourself if you want to use it on unsupported distros.
-            - `Tuw-*-Windows-x64-ucrt.zip` is much smaller than the standard version, but it only works on Windows10 or later.
             - Tuw supports more unix-like systems (BSD, Haiku, illumos, etc.)
               [Building Workflow for Other Platforms - matyalatte/tuw](https://github.com/matyalatte/${{ env.TOOL_NAME }}/blob/main/docs/Build-on-Other.md)
           draft: true
@@ -71,7 +70,7 @@ jobs:
             exe_ext: .exe
             zip_ext: zip
             arch: UCRT
-            arch_suffix: -x64-ucrt
+            arch_suffix: 10-x64
           - os: ubuntu-20.04
             exe_ext: ""
             zip_ext: tar.bz2

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,9 +39,10 @@ All you need is a JSON file and a tiny executable.
 
 You can download executables from [the release page](https://github.com/matyalatte/tuw/releases)
 
--   `Tuw*-Windows*.zip` is for Windows (7 or later.)  
--   `Tuw*-macOS*.tar.bz2` is for macOS (10.9 or later.)  
--   `Tuw*-Linux*.tar.bz2` is for Linux (with GTK3.14, GLIBC2.15, and GLIBCXX3.4.21, or later versions of the libraries.)  
+-   `Tuw-*-Windows-*.zip` is for Windows (7 or later.)  
+-   `Tuw-*-Windows10-*.zip` requires Windows 10 or later, but it's much smaller than the standard version.  
+-   `Tuw-*-macOS.tar.bz2` is for macOS (10.9 or later.)  
+-   `Tuw-*-Linux-*.tar.bz2` is for Linux (with GTK3.14, GLIBC2.15, and GLIBCXX3.4.21, or later versions of the libraries.)  
 
 ## Examples
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,8 +20,8 @@ Tuw provides a very simple GUI for your scripts.
 All you need is a JSON file and a tiny executable.  
 **No need for compilers, browsers, or huge executables!**  
 
-![sample](https://github.com/matyalatte/tuw/assets/69258547/9b3c8487-010e-497b-b66c-95af84906dd0)
-<img src=https://user-images.githubusercontent.com/69258547/192090797-f5e5b52d-59aa-4942-a361-2c8b5c7bd746.png width=387></img>  
+![sample](https://github.com/user-attachments/assets/17894d27-64fc-45c7-89bf-7f55d505508f)
+<img src=https://github.com/user-attachments/assets/249b954f-e66e-46a8-8451-ad39e700d564 width=397></img>  
 
 ## Features
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,7 @@ For VSCode, you can add the schema path to `settings.json` (`File > Preferences 
 ```json
 "json.schemas": [
     {
-        "fileMatch": [ "gui_definition.json" ],
+        "fileMatch": [ "gui_definition.json", "gui_definition.jsonc" ],
         "url": "https://raw.githubusercontent.com/matyalatte/tuw/main/schema/schema.json"
     }
 ]

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,6 @@
+- Array brackets can now be omitted when there is only one element.
+- GUI elements can now be defined in root object.
+
 ver 0.7.2
 - Added "optional" to ignore some options when a text box is empty.
 - Added "prefix" and "suffix" options to append strings to user inputs.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,5 +1,6 @@
 - Array brackets can now be omitted when there is only one element.
 - GUI elements can now be defined in root object.
+- GUI labels became optional.
 
 ver 0.7.2
 - Added "optional" to ignore some options when a text box is empty.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,6 +1,7 @@
 - Array brackets can now be omitted when there is only one element.
 - GUI elements can now be defined in root object.
 - GUI labels became optional.
+- "window_name" can now be default values of GUI labels.
 
 ver 0.7.2
 - Added "optional" to ignore some options when a text box is empty.

--- a/examples/all_keys/gui_definition.json
+++ b/examples/all_keys/gui_definition.json
@@ -3,7 +3,7 @@
     "minimum_required": "0.7.1",
     "gui": [
         {
-            "label": "Components Minimal",
+            "window_name": "Components Minimal",
             "command": "echo file: %-% & echo folder: %-% & echo combo: %-% & echo radio: %-% & echo check: %-% & echo check_array: %-% & echo textbox: %-% & echo int: %-% & echo float: %-%",
             "components": [
                 {
@@ -82,7 +82,7 @@
             ]
         },
         {
-            "label": "Components Optional",
+            "window_name": "Components Optional",
             "command": "echo file: %file% & echo folder: %folder% & echo combo: %combo% & echo radio: %radio% & echo check: %check% & echo check_array: %options% & echo textbox: %text% & echo int: %integer% & echo float: %double%",
             "components": [
                 {
@@ -248,8 +248,8 @@
             ]
         },
         {
-            "label": "GUI Optional",
-            "window_name": "Window Title Here",
+            "window_name": "GUI Optional",
+            "label": "GUI Optional (this string is for a menu item)",
             "command_win": "echo home: %__HOME__% & echo cwd: %__CWD__% & echo percent: %% & echo sample message!",
             "command_linux": "echo home: %__HOME__%; echo cwd: %__CWD__%; echo percent: %%; echo sample message!",
             "command_mac": "echo home: %__HOME__%; echo cwd: %__CWD__%; echo percent: %%; echo sample message!",

--- a/examples/comp_options/affix/README.md
+++ b/examples/comp_options/affix/README.md
@@ -6,19 +6,17 @@
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Affix example",
-            "command": "echo %-%",
-            "components": [
-                {
-                    "type": "text",
-                    "label": "Text box",
-                    "prefix": "-pre=",
-                    "suffix": " -suf"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Affix example",
+        "command": "echo %-%",
+        "components": [
+            {
+                "type": "text",
+                "label": "Text box",
+                "prefix": "-pre=",
+                "suffix": " -suf"
+            }
+        ]
+    }
 }
 ```

--- a/examples/comp_options/affix/README.md
+++ b/examples/comp_options/affix/README.md
@@ -7,7 +7,6 @@
 ```json
 {
     "gui": {
-        "label": "Affix example",
         "command": "echo %-%",
         "components": [
             {

--- a/examples/comp_options/affix/gui_definition.json
+++ b/examples/comp_options/affix/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Affix example",
         "command": "echo %-%",
         "components": [
             {

--- a/examples/comp_options/affix/gui_definition.json
+++ b/examples/comp_options/affix/gui_definition.json
@@ -1,16 +1,14 @@
 {
-    "gui": [
-        {
-            "label": "Affix example",
-            "command": "echo %-%",
-            "components": [
-                {
-                    "type": "text",
-                    "label": "Text box",
-                    "prefix": "-pre=",
-                    "suffix": " -suf"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Affix example",
+        "command": "echo %-%",
+        "components": [
+            {
+                "type": "text",
+                "label": "Text box",
+                "prefix": "-pre=",
+                "suffix": " -suf"
+            }
+        ]
+    }
 }

--- a/examples/comp_options/button/README.md
+++ b/examples/comp_options/button/README.md
@@ -7,24 +7,22 @@ It allows you to rename the button associated with the picker component.
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Button",
-            "window_name": "Button sample",
-            "command": "echo %-% %-%",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "Some file",
-                    "button": "..."
-                },
-                {
-                    "type": "folder",
-                    "label": "Some folder",
-                    "button": "Open"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Button",
+        "window_name": "Button sample",
+        "command": "echo %-% %-%",
+        "components": [
+            {
+                "type": "file",
+                "label": "Some file",
+                "button": "..."
+            },
+            {
+                "type": "folder",
+                "label": "Some folder",
+                "button": "Open"
+            }
+        ]
+    }
 }
 ```

--- a/examples/comp_options/button/README.md
+++ b/examples/comp_options/button/README.md
@@ -8,7 +8,6 @@ It allows you to rename the button associated with the picker component.
 ```json
 {
     "gui": {
-        "label": "Button",
         "window_name": "Button sample",
         "command": "echo %-% %-%",
         "components": [

--- a/examples/comp_options/button/gui_definition.json
+++ b/examples/comp_options/button/gui_definition.json
@@ -1,21 +1,19 @@
 {
-    "gui": [
-        {
-            "label": "Button",
-            "window_name": "Button sample",
-            "command": "echo %-% %-%",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "Some file",
-                    "button": "..."
-                },
-                {
-                    "type": "folder",
-                    "label": "Some folder",
-                    "button": "Open"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Button",
+        "window_name": "Button sample",
+        "command": "echo %-% %-%",
+        "components": [
+            {
+                "type": "file",
+                "label": "Some file",
+                "button": "..."
+            },
+            {
+                "type": "folder",
+                "label": "Some folder",
+                "button": "Open"
+            }
+        ]
+    }
 }

--- a/examples/comp_options/button/gui_definition.json
+++ b/examples/comp_options/button/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Button",
         "window_name": "Button sample",
         "command": "echo %-% %-%",
         "components": [

--- a/examples/comp_options/default/gui_definition.json
+++ b/examples/comp_options/default/gui_definition.json
@@ -1,34 +1,32 @@
 {
-    "gui": [
-        {
-            "label": "Sample GUI",
-            "command": "echo file: %-% & echo options: %-%",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "Some file path",
-                    "extension": "any files (*)|*",
-                    "default": "./foo/bar"
-                },
-                {
-                    "type": "check_array",
-                    "label": "options",
-                    "items": [
-                        {
-                            "label": "falg1",
-                            "default": true
-                        },
-                        {
-                            "label": "falg2",
-                            "default": false
-                        },
-                        {
-                            "label": "falg3",
-                            "default": true
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Sample GUI",
+        "command": "echo file: %-% & echo options: %-%",
+        "components": [
+            {
+                "type": "file",
+                "label": "Some file path",
+                "extension": "any files (*)|*",
+                "default": "./foo/bar"
+            },
+            {
+                "type": "check_array",
+                "label": "options",
+                "items": [
+                    {
+                        "label": "falg1",
+                        "default": true
+                    },
+                    {
+                        "label": "falg2",
+                        "default": false
+                    },
+                    {
+                        "label": "falg3",
+                        "default": true
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/examples/comp_options/default/gui_definition.json
+++ b/examples/comp_options/default/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Sample GUI",
         "command": "echo file: %-% & echo options: %-%",
         "components": [
             {

--- a/examples/comp_options/id/README.md
+++ b/examples/comp_options/id/README.md
@@ -5,7 +5,6 @@ You can use the defined ids as variable names in commands.
 
 ```json
 {
-    "label": "IDs",
     "command": "echo x: %x% & echo y: %y% & echo x: %x%",
     "button": "Echo!",
     "components": [
@@ -29,7 +28,6 @@ When you put an undefined id in `%*%`, it'll use one of the components that have
 
 ```json
 {
-    "label": "Undefined IDs",
     "command": "echo x: %-% & echo y: %y% & echo z: %foo%",
     "button": "Echo!",
     "components": [
@@ -61,7 +59,6 @@ There are some predefined ids.
 
 ```json
 {
-    "label": "Reserved IDs",
     "command": "echo percent: %% & echo cwd: %__CWD__% & echo home: %__HOME__%",
     "button": "Echo!",
     "components": []

--- a/examples/comp_options/optional/README.md
+++ b/examples/comp_options/optional/README.md
@@ -7,7 +7,6 @@
 ```json
 {
     "gui": {
-        "label": "Optional component",
         "command": "echo %-%",
         "components": [
             {

--- a/examples/comp_options/optional/README.md
+++ b/examples/comp_options/optional/README.md
@@ -6,23 +6,21 @@
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Optional component",
-            "command": "echo %-%",
-            "components": [
-                {
-                    "type": "text",
-                    "label": "Text box",
-                    "optional": true,
-                    "prefix": "-pre=",
-                    "suffix": " -suf",
-                    "validator": {
-                        "regex": ".+"
-                    }
+    "gui": {
+        "label": "Optional component",
+        "command": "echo %-%",
+        "components": [
+            {
+                "type": "text",
+                "label": "Text box",
+                "optional": true,
+                "prefix": "-pre=",
+                "suffix": " -suf",
+                "validator": {
+                    "regex": ".+"
                 }
-            ]
-        }
-    ]
+            }
+        ]
+    }
 }
 ```

--- a/examples/comp_options/optional/gui_definition.json
+++ b/examples/comp_options/optional/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Optional component",
         "command": "echo %-%",
         "components": [
             {

--- a/examples/comp_options/optional/gui_definition.json
+++ b/examples/comp_options/optional/gui_definition.json
@@ -1,20 +1,18 @@
 {
-    "gui": [
-        {
-            "label": "Optional component",
-            "command": "echo %-%",
-            "components": [
-                {
-                    "type": "text",
-                    "label": "Text box",
-                    "optional": true,
-                    "prefix": "-pre=",
-                    "suffix": " -suf",
-                    "validator": {
-                        "regex": ".+"
-                    }
+    "gui": {
+        "label": "Optional component",
+        "command": "echo %-%",
+        "components": [
+            {
+                "type": "text",
+                "label": "Text box",
+                "optional": true,
+                "prefix": "-pre=",
+                "suffix": " -suf",
+                "validator": {
+                    "regex": ".+"
                 }
-            ]
-        }
-    ]
+            }
+        ]
+    }
 }

--- a/examples/comp_options/placeholder/README.md
+++ b/examples/comp_options/placeholder/README.md
@@ -7,29 +7,27 @@ It displays a message when the text box is empty.
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Placeholder",
-            "window_name": "Placeholder sample",
-            "command": "echo %-% %-% %-%",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "Some file",
-                    "placeholder": "Drop a file here!"
-                },
-                {
-                    "type": "folder",
-                    "label": "Some folder",
-                    "placeholder": "Drop a folder here!"
-                },
-                {
-                    "type": "text",
-                    "label": "Some text",
-                    "placeholder": "Type here!"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Placeholder",
+        "window_name": "Placeholder sample",
+        "command": "echo %-% %-% %-%",
+        "components": [
+            {
+                "type": "file",
+                "label": "Some file",
+                "placeholder": "Drop a file here!"
+            },
+            {
+                "type": "folder",
+                "label": "Some folder",
+                "placeholder": "Drop a folder here!"
+            },
+            {
+                "type": "text",
+                "label": "Some text",
+                "placeholder": "Type here!"
+            }
+        ]
+    }
 }
 ```

--- a/examples/comp_options/placeholder/README.md
+++ b/examples/comp_options/placeholder/README.md
@@ -8,7 +8,6 @@ It displays a message when the text box is empty.
 ```json
 {
     "gui": {
-        "label": "Placeholder",
         "window_name": "Placeholder sample",
         "command": "echo %-% %-% %-%",
         "components": [

--- a/examples/comp_options/placeholder/gui_definition.json
+++ b/examples/comp_options/placeholder/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Placeholder",
         "window_name": "Placeholder sample",
         "command": "echo %-% %-% %-%",
         "components": [

--- a/examples/comp_options/placeholder/gui_definition.json
+++ b/examples/comp_options/placeholder/gui_definition.json
@@ -1,26 +1,24 @@
 {
-    "gui": [
-        {
-            "label": "Placeholder",
-            "window_name": "Placeholder sample",
-            "command": "echo %-% %-% %-%",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "Some file",
-                    "placeholder": "Drop a file here!"
-                },
-                {
-                    "type": "folder",
-                    "label": "Some folder",
-                    "placeholder": "Drop a folder here!"
-                },
-                {
-                    "type": "text",
-                    "label": "Some text",
-                    "placeholder": "Type here!"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Placeholder",
+        "window_name": "Placeholder sample",
+        "command": "echo %-% %-% %-%",
+        "components": [
+            {
+                "type": "file",
+                "label": "Some file",
+                "placeholder": "Drop a file here!"
+            },
+            {
+                "type": "folder",
+                "label": "Some folder",
+                "placeholder": "Drop a folder here!"
+            },
+            {
+                "type": "text",
+                "label": "Some text",
+                "placeholder": "Type here!"
+            }
+        ]
+    }
 }

--- a/examples/comp_options/tooltip/gui_definition.json
+++ b/examples/comp_options/tooltip/gui_definition.json
@@ -1,43 +1,41 @@
 {
-    "gui": [
-        {
-            "label": "Sample GUI",
-            "command": "echo file: %-% & echo folder: %-% & echo options: %-%",
-            "components": [
-                {
-                    "type": "static_text",
-                    "label": "Move the mouse cursor to components to see tooltip messages!"
-                },
-                {
-                    "type": "file",
-                    "label": "Some file path",
-                    "extension": "any files (*)|*",
-                    "tooltip": "tooltip for file path!"
-                },
-                {
-                    "type": "folder",
-                    "label": "Some folder path",
-                    "tooltip": "tooltip for folder path!"
-                },
-                {
-                    "type": "check_array",
-                    "label": "options",
-                    "items": [
-                        {
-                            "label": "falg1",
-                            "tooltip": "tooltip for flag1!"
-                        },
-                        {
-                            "label": "falg2",
-                            "tooltip": "flag2!"
-                        },
-                        {
-                            "label": "falg3",
-                            "tooltip": "flag3..."
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Sample GUI",
+        "command": "echo file: %-% & echo folder: %-% & echo options: %-%",
+        "components": [
+            {
+                "type": "static_text",
+                "label": "Move the mouse cursor to components to see tooltip messages!"
+            },
+            {
+                "type": "file",
+                "label": "Some file path",
+                "extension": "any files (*)|*",
+                "tooltip": "tooltip for file path!"
+            },
+            {
+                "type": "folder",
+                "label": "Some folder path",
+                "tooltip": "tooltip for folder path!"
+            },
+            {
+                "type": "check_array",
+                "label": "options",
+                "items": [
+                    {
+                        "label": "falg1",
+                        "tooltip": "tooltip for flag1!"
+                    },
+                    {
+                        "label": "falg2",
+                        "tooltip": "flag2!"
+                    },
+                    {
+                        "label": "falg3",
+                        "tooltip": "flag3..."
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/examples/comp_options/tooltip/gui_definition.json
+++ b/examples/comp_options/tooltip/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Sample GUI",
         "command": "echo file: %-% & echo folder: %-% & echo options: %-%",
         "components": [
             {

--- a/examples/components/check_boxes/gui_definition.json
+++ b/examples/components/check_boxes/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Check Boxes",
         "command": "echo checkbox: %-% & echo options:%-%",
         "button": "Echo!",
         "components": [

--- a/examples/components/check_boxes/gui_definition.json
+++ b/examples/components/check_boxes/gui_definition.json
@@ -1,34 +1,32 @@
 {
-    "gui": [
-        {
-            "label": "Check Boxes",
-            "command": "echo checkbox: %-% & echo options:%-%",
-            "button": "Echo!",
-            "components": [
-                {
-                    "type": "check",
-                    "label": "checkbox",
-                    "value": "checked!"
-                },
-                {
-                    "type": "check_array",
-                    "label": "options",
-                    "items": [
-                        {
-                            "label": "flag1",
-                            "value": " -f1"
-                        },
-                        {
-                            "label": "flag2",
-                            "value": " -f2"
-                        },
-                        {
-                            "label": "flag3",
-                            "value": " -f3"
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Check Boxes",
+        "command": "echo checkbox: %-% & echo options:%-%",
+        "button": "Echo!",
+        "components": [
+            {
+                "type": "check",
+                "label": "checkbox",
+                "value": "checked!"
+            },
+            {
+                "type": "check_array",
+                "label": "options",
+                "items": [
+                    {
+                        "label": "flag1",
+                        "value": " -f1"
+                    },
+                    {
+                        "label": "flag2",
+                        "value": " -f2"
+                    },
+                    {
+                        "label": "flag3",
+                        "value": " -f3"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/examples/components/choices/gui_definition.json
+++ b/examples/components/choices/gui_definition.json
@@ -1,45 +1,43 @@
 {
-    "gui": [
-        {
-            "label": "Component Sample",
-            "command": "echo combo: %a% & echo radio: %b%",
-            "button": "Echo!",
-            "components": [
-                {
-                    "type": "combo",
-                    "label": "Combo box",
-                    "items": [
-                        {
-                            "label": "one",
-                            "value": "1"
-                        },
-                        {
-                            "label": "two",
-                            "value": "2"
-                        },
-                        {
-                            "label": "3"
-                        }
-                    ]
-                },
-                {
-                    "type": "radio",
-                    "label": "Radio buttons",
-                    "items": [
-                        {
-                            "label": "one",
-                            "value": "1"
-                        },
-                        {
-                            "label": "two",
-                            "value": "2"
-                        },
-                        {
-                            "label": "3"
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Component Sample",
+        "command": "echo combo: %a% & echo radio: %b%",
+        "button": "Echo!",
+        "components": [
+            {
+                "type": "combo",
+                "label": "Combo box",
+                "items": [
+                    {
+                        "label": "one",
+                        "value": "1"
+                    },
+                    {
+                        "label": "two",
+                        "value": "2"
+                    },
+                    {
+                        "label": "3"
+                    }
+                ]
+            },
+            {
+                "type": "radio",
+                "label": "Radio buttons",
+                "items": [
+                    {
+                        "label": "one",
+                        "value": "1"
+                    },
+                    {
+                        "label": "two",
+                        "value": "2"
+                    },
+                    {
+                        "label": "3"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/examples/components/choices/gui_definition.json
+++ b/examples/components/choices/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Component Sample",
         "command": "echo combo: %a% & echo radio: %b%",
         "button": "Echo!",
         "components": [

--- a/examples/components/num_pickers/gui_definition.json
+++ b/examples/components/num_pickers/gui_definition.json
@@ -1,27 +1,25 @@
 {
-    "gui": [
-        {
-            "label": "Select numbers",
-            "window_name": "Picker sample",
-            "command": "echo int: %-% & echo float: %-%",
-            "components": [
-                {
-                    "type": "int",
-                    "label": "Integer",
-                    "min": 0,
-                    "max": 100,
-                    "inc": 10,
-                    "wrap": true
-                },
-                {
-                    "type": "float",
-                    "label": "Floating-point number",
-                    "min": 0,
-                    "max": 1,
-                    "inc": 0.01,
-                    "digits": 2
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Select numbers",
+        "window_name": "Picker sample",
+        "command": "echo int: %-% & echo float: %-%",
+        "components": [
+            {
+                "type": "int",
+                "label": "Integer",
+                "min": 0,
+                "max": 100,
+                "inc": 10,
+                "wrap": true
+            },
+            {
+                "type": "float",
+                "label": "Floating-point number",
+                "min": 0,
+                "max": 1,
+                "inc": 0.01,
+                "digits": 2
+            }
+        ]
+    }
 }

--- a/examples/components/num_pickers/gui_definition.json
+++ b/examples/components/num_pickers/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Select numbers",
         "window_name": "Picker sample",
         "command": "echo int: %-% & echo float: %-%",
         "components": [

--- a/examples/components/other_components/gui_definition.json
+++ b/examples/components/other_components/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Component Sample",
         "command": "echo textbox: %c%",
         "button": "Echo!",
         "components": [

--- a/examples/components/other_components/gui_definition.json
+++ b/examples/components/other_components/gui_definition.json
@@ -1,19 +1,17 @@
 {
-    "gui": [
-        {
-            "label": "Component Sample",
-            "command": "echo textbox: %c%",
-            "button": "Echo!",
-            "components": [
-                {
-                    "type": "static_text",
-                    "label": "This is a sample GUI. Edit 'gui_definition.json' for your scripts."
-                },
-                {
-                    "type": "text",
-                    "label": "Some text"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Component Sample",
+        "command": "echo textbox: %c%",
+        "button": "Echo!",
+        "components": [
+            {
+                "type": "static_text",
+                "label": "This is a sample GUI. Edit 'gui_definition.json' for your scripts."
+            },
+            {
+                "type": "text",
+                "label": "Some text"
+            }
+        ]
+    }
 }

--- a/examples/components/path_pickers/README.md
+++ b/examples/components/path_pickers/README.md
@@ -7,27 +7,25 @@ Of course, you can drop files on the pickers to specify the paths.
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Copy file",
-            "window_name": "Picker sample",
-            "command": "copy %foo% %bar%",
-            "button": "copy",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "PNG file you want to copy",
-                    "extension": "PNG files (*.png)|*.png",
-                    "add_quotes": true
-                },
-                {
-                    "type": "folder",
-                    "label": "Output path",
-                    "add_quotes": true
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Copy file",
+        "window_name": "Picker sample",
+        "command": "copy %foo% %bar%",
+        "button": "copy",
+        "components": [
+            {
+                "type": "file",
+                "label": "PNG file you want to copy",
+                "extension": "PNG files (*.png)|*.png",
+                "add_quotes": true
+            },
+            {
+                "type": "folder",
+                "label": "Output path",
+                "add_quotes": true
+            }
+        ]
+    }
 }
 ```
 

--- a/examples/components/path_pickers/README.md
+++ b/examples/components/path_pickers/README.md
@@ -8,7 +8,6 @@ Of course, you can drop files on the pickers to specify the paths.
 ```json
 {
     "gui": {
-        "label": "Copy file",
         "window_name": "Picker sample",
         "command": "copy %foo% %bar%",
         "button": "copy",

--- a/examples/components/path_pickers/gui_definition.json
+++ b/examples/components/path_pickers/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Copy file",
         "window_name": "Picker sample",
         "command": "copy %foo% %bar%",
         "button": "copy",

--- a/examples/components/path_pickers/gui_definition.json
+++ b/examples/components/path_pickers/gui_definition.json
@@ -1,23 +1,21 @@
 {
-    "gui": [
-        {
-            "label": "Copy file",
-            "window_name": "Picker sample",
-            "command": "copy %foo% %bar%",
-            "button": "copy",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "PNG file you want to copy",
-                    "extension": "PNG files (*.png)|*.png",
-                    "add_quotes": true
-                },
-                {
-                    "type": "folder",
-                    "label": "Output path",
-                    "add_quotes": true
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Copy file",
+        "window_name": "Picker sample",
+        "command": "copy %foo% %bar%",
+        "button": "copy",
+        "components": [
+            {
+                "type": "file",
+                "label": "PNG file you want to copy",
+                "extension": "PNG files (*.png)|*.png",
+                "add_quotes": true
+            },
+            {
+                "type": "folder",
+                "label": "Output path",
+                "add_quotes": true
+            }
+        ]
+    }
 }

--- a/examples/get_start/json_embed/gui_definition.json
+++ b/examples/get_start/json_embed/gui_definition.json
@@ -20,7 +20,7 @@
                     "id": "merged_exe",
                     "default": "Tuw.new.exe",
                     "add_quotes": true,
-                    "platforms": ["win"]
+                    "platforms": "win"
                 },
                 {
                     "type": "file",
@@ -45,7 +45,7 @@
                     "id": "merged_exe",
                     "default": "Tuw.new.exe",
                     "add_quotes": true,
-                    "platforms": ["win"]
+                    "platforms": "win"
                 },
                 {
                     "type": "file",
@@ -68,7 +68,7 @@
                     "id": "orig_exe",
                     "default": "Tuw.orig.exe",
                     "add_quotes": true,
-                    "platforms": ["win"]
+                    "platforms": "win"
                 },
                 {
                     "type": "file",

--- a/examples/get_start/minimal/README.md
+++ b/examples/get_start/minimal/README.md
@@ -9,17 +9,15 @@ It has only a button to echo `Hello!`.
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Minimal Sample",
-            "command": "echo Hello!",
-            "components": []
-        }
-    ]
+    "gui": {
+        "label": "Minimal Sample",
+        "command": "echo Hello!",
+        "components": []
+    }
 }
 ```
 
-You can write a definition of your GUI in `"gui": [{}]`.  
+You can write a definition of your GUI in `"gui": {}`.  
 
 -   `label` is the label for your definition. You can type anything you like here.
 -   `command` is the command you want to execute when clicking the execution button.

--- a/examples/get_start/minimal/README.md
+++ b/examples/get_start/minimal/README.md
@@ -10,7 +10,6 @@ It has only a button to echo `Hello!`.
 ```json
 {
     "gui": {
-        "label": "Minimal Sample",
         "command": "echo Hello!",
         "components": []
     }
@@ -19,6 +18,5 @@ It has only a button to echo `Hello!`.
 
 You can write a definition of your GUI in `"gui": {}`.  
 
--   `label` is the label for your definition. You can type anything you like here.
 -   `command` is the command you want to execute when clicking the execution button.
 -   `components` is an array of GUI components (e.g., file pickers). `[]` means no components.

--- a/examples/get_start/minimal/gui_definition.json
+++ b/examples/get_start/minimal/gui_definition.json
@@ -1,9 +1,7 @@
 {
-    "gui": [
-        {
-            "label": "Minimal Sample",
-            "command": "echo Hello!",
-            "components": []
-        }
-    ]
+    "gui": {
+        "label": "Minimal Sample",
+        "command": "echo Hello!",
+        "components": []
+    }
 }

--- a/examples/get_start/minimal/gui_definition.json
+++ b/examples/get_start/minimal/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Minimal Sample",
         "command": "echo Hello!",
         "components": []
     }

--- a/examples/get_start/put_component/README.md
+++ b/examples/get_start/put_component/README.md
@@ -6,20 +6,18 @@ You can put a text box in the GUI.
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Text Box Sample",
-            "window_name": "Title here!",
-            "command": "echo %-%",
-            "button": "Hello!",
-            "components": [
-                {
-                    "type": "text",
-                    "label": "Type 'Hello!'"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Text Box Sample",
+        "window_name": "Title here!",
+        "command": "echo %-%",
+        "button": "Hello!",
+        "components": [
+            {
+                "type": "text",
+                "label": "Type 'Hello!'"
+            }
+        ]
+    }
 }
 ```
 
@@ -44,19 +42,17 @@ In the example, the value of the text box will be injected at `%-%`.
 You can also use the [`id`](../../comp_options/id) option to name the components like variables.  
 
 ```json
-"gui": [
-    {
-        "label": "Text Box Sample",
-        "window_name": "Title here!",
-        "command": "echo %foo%, %foo%",
-        "button": "Hello!",
-        "components": [
-            {
-                "type": "text",
-                "label": "Type 'Hello!'",
-                "id": "foo"
-            }
-        ]
-    }
-]
+"gui": {
+    "label": "Text Box Sample",
+    "window_name": "Title here!",
+    "command": "echo %foo%, %foo%",
+    "button": "Hello!",
+    "components": [
+        {
+            "type": "text",
+            "label": "Type 'Hello!'",
+            "id": "foo"
+        }
+    ]
+}
 ```

--- a/examples/get_start/put_component/README.md
+++ b/examples/get_start/put_component/README.md
@@ -7,7 +7,6 @@ You can put a text box in the GUI.
 ```json
 {
     "gui": {
-        "label": "Text Box Sample",
         "window_name": "Title here!",
         "command": "echo %-%",
         "button": "Hello!",

--- a/examples/get_start/put_component/gui_definition.json
+++ b/examples/get_start/put_component/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Minimal Sample",
         "window_name": "Title here!",
         "command": "echo %-%",
         "button": "Hello!",

--- a/examples/get_start/put_component/gui_definition.json
+++ b/examples/get_start/put_component/gui_definition.json
@@ -1,16 +1,14 @@
 {
-    "gui": [
-        {
-            "label": "Minimal Sample",
-            "window_name": "Title here!",
-            "command": "echo %-%",
-            "button": "Hello!",
-            "components": [
-                {
-                    "type": "text",
-                    "label": "Type 'Hello!'"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Minimal Sample",
+        "window_name": "Title here!",
+        "command": "echo %-%",
+        "button": "Hello!",
+        "components": [
+            {
+                "type": "text",
+                "label": "Type 'Hello!'"
+            }
+        ]
+    }
 }

--- a/examples/get_start/title_button/README.md
+++ b/examples/get_start/title_button/README.md
@@ -7,7 +7,6 @@ You can rename the window title and the execution button.
 ```json
 {
     "gui": {
-        "label": "Minimal Sample",
         "window_name": "Title here!",
         "command": "echo Hello!",
         "button": "Hello!",

--- a/examples/get_start/title_button/README.md
+++ b/examples/get_start/title_button/README.md
@@ -6,15 +6,13 @@ You can rename the window title and the execution button.
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Minimal Sample",
-            "window_name": "Title here!",
-            "command": "echo Hello!",
-            "button": "Hello!",
-            "components": []
-        }
-    ]
+    "gui": {
+        "label": "Minimal Sample",
+        "window_name": "Title here!",
+        "command": "echo Hello!",
+        "button": "Hello!",
+        "components": []
+    }
 }
 ```
 

--- a/examples/get_start/title_button/gui_definition.json
+++ b/examples/get_start/title_button/gui_definition.json
@@ -1,11 +1,9 @@
 {
-    "gui": [
-        {
-            "label": "Minimal Sample",
-            "window_name": "Title here!",
-            "command": "echo Hello!",
-            "button": "Hello!",
-            "components": []
-        }
-    ]
+    "gui": {
+        "label": "Minimal Sample",
+        "window_name": "Title here!",
+        "command": "echo Hello!",
+        "button": "Hello!",
+        "components": []
+    }
 }

--- a/examples/get_start/title_button/gui_definition.json
+++ b/examples/get_start/title_button/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Minimal Sample",
         "window_name": "Title here!",
         "command": "echo Hello!",
         "button": "Hello!",

--- a/examples/other_features/alternate_spellings/gui_definition.json
+++ b/examples/other_features/alternate_spellings/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Alternate Spellings",
         "command": "echo folder: %-% & echo combo: %-% & echo check_array: %-% & echo textbox: %-% & echo int: %-%",
         "title": "Alternate Spellings Sample",
         "component_array": [

--- a/examples/other_features/alternate_spellings/gui_definition.json
+++ b/examples/other_features/alternate_spellings/gui_definition.json
@@ -1,59 +1,57 @@
 {
-    "gui": [
-        {
-            "label": "Alternate Spellings",
-            "command": "echo folder: %-% & echo combo: %-% & echo check_array: %-% & echo textbox: %-% & echo int: %-%",
-            "title": "Alternate Spellings Sample",
-            "component_array": [
-                {
-                    "type": "static_text",
-                    "label": "Still working with alternate spellings!"
-                },
-                {
-                    "type": "dir",
-                    "label": "Some folder path",
-                    "empty_message": "placeholder!",
-                    "add_quote": true
-                },
-                {
-                    "type": "choice",
-                    "label": "combo box",
-                    "item_array": [
-                        {
-                            "label": "value1"
-                        },
-                        {
-                            "label": "value2"
-                        },
-                        {
-                            "label": "value3"
-                        }
-                    ]
-                },
-                {
-                    "type": "checks",
-                    "label": "options",
-                    "item_array": [
-                        {
-                            "label": "flag1"
-                        },
-                        {
-                            "label": "flag2"
-                        },
-                        {
-                            "label": "flag3"
-                        }
-                    ]
-                },
-                {
-                    "type": "text_box",
-                    "label": "text box"
-                },
-                {
-                    "type": "integer",
-                    "label": "Int picker"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Alternate Spellings",
+        "command": "echo folder: %-% & echo combo: %-% & echo check_array: %-% & echo textbox: %-% & echo int: %-%",
+        "title": "Alternate Spellings Sample",
+        "component_array": [
+            {
+                "type": "static_text",
+                "label": "Still working with alternate spellings!"
+            },
+            {
+                "type": "dir",
+                "label": "Some folder path",
+                "empty_message": "placeholder!",
+                "add_quote": true
+            },
+            {
+                "type": "choice",
+                "label": "combo box",
+                "item_array": [
+                    {
+                        "label": "value1"
+                    },
+                    {
+                        "label": "value2"
+                    },
+                    {
+                        "label": "value3"
+                    }
+                ]
+            },
+            {
+                "type": "checks",
+                "label": "options",
+                "item_array": [
+                    {
+                        "label": "flag1"
+                    },
+                    {
+                        "label": "flag2"
+                    },
+                    {
+                        "label": "flag3"
+                    }
+                ]
+            },
+            {
+                "type": "text_box",
+                "label": "text box"
+            },
+            {
+                "type": "integer",
+                "label": "Int picker"
+            }
+        ]
+    }
 }

--- a/examples/other_features/codepage/README.md
+++ b/examples/other_features/codepage/README.md
@@ -4,14 +4,12 @@ Tuw expects user's default locale for stdout on Windows. If you want to use UTF-
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Use UTF-8 outputs on Windows",
-            "command": "powershell -ExecutionPolicy Bypass -File \"utf.ps1\"",
-            "codepage": "utf8",
-            "components": []
-        }
-    ]
+    "gui": {
+        "label": "Use UTF-8 outputs on Windows",
+        "command": "powershell -ExecutionPolicy Bypass -File \"utf.ps1\"",
+        "codepage": "utf8",
+        "components": []
+    }
 }
 ```
 

--- a/examples/other_features/codepage/README.md
+++ b/examples/other_features/codepage/README.md
@@ -5,7 +5,7 @@ Tuw expects user's default locale for stdout on Windows. If you want to use UTF-
 ```json
 {
     "gui": {
-        "label": "Use UTF-8 outputs on Windows",
+        "window_name": "Use UTF-8 outputs on Windows",
         "command": "powershell -ExecutionPolicy Bypass -File \"utf.ps1\"",
         "codepage": "utf8",
         "components": []

--- a/examples/other_features/codepage/gui_definition.json
+++ b/examples/other_features/codepage/gui_definition.json
@@ -1,6 +1,6 @@
 {
     "gui": {
-        "label": "Use UTF-8 outputs on Windows",
+        "window_name": "Use UTF-8 outputs on Windows",
         "command": "powershell -ExecutionPolicy Bypass -File \"utf.ps1\"",
         "codepage": "utf8",
         "components": []

--- a/examples/other_features/codepage/gui_definition.json
+++ b/examples/other_features/codepage/gui_definition.json
@@ -1,10 +1,8 @@
 {
-    "gui": [
-        {
-            "label": "Use UTF-8 outputs on Windows",
-            "command": "powershell -ExecutionPolicy Bypass -File \"utf.ps1\"",
-            "codepage": "utf8",
-            "components": []
-        }
-    ]
+    "gui": {
+        "label": "Use UTF-8 outputs on Windows",
+        "command": "powershell -ExecutionPolicy Bypass -File \"utf.ps1\"",
+        "codepage": "utf8",
+        "components": []
+    }
 }

--- a/examples/other_features/cross_platform/README.md
+++ b/examples/other_features/cross_platform/README.md
@@ -14,7 +14,6 @@ Tuw will use the platform-specific command instead of the default `command` valu
 
 ```json
 {
-    "label": "Platform Specific Commands",
     "command_win": "echo Windows!",
     "command_mac": "echo macOS!",
     "command_linux": "echo Linux!",
@@ -35,7 +34,6 @@ Tuw will ignore the component if the current OS does not match the specified pla
 
 ```json
 {
-    "label": "Platform Specific Components",
     "command": "echo %os%",
     "show_last_line": true,
     "components": [

--- a/examples/other_features/cross_platform/README.md
+++ b/examples/other_features/cross_platform/README.md
@@ -44,7 +44,7 @@ Tuw will ignore the component if the current OS does not match the specified pla
             "label": "Windows!",
             "id": "os",
             "default": true,
-            "platforms": [ "win" ]
+            "platforms": "win"
         },
         {
             "type": "check",

--- a/examples/other_features/cross_platform/gui_definition.json
+++ b/examples/other_features/cross_platform/gui_definition.json
@@ -18,7 +18,7 @@
                     "label": "Windows!",
                     "id": "os",
                     "default": true,
-                    "platforms": [ "win" ]
+                    "platforms": "win"
                 },
                 {
                     "type": "check",

--- a/examples/other_features/error/README.md
+++ b/examples/other_features/error/README.md
@@ -8,13 +8,8 @@ When the executed command outputs something to `stderr`, Tuw will display an err
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Error Sample",
-            "command": "notcommand",
-            "components": []
-        }
-    ]
+    "command": "notcommand",
+    "components": []
 }
 ```
 
@@ -26,7 +21,6 @@ You can also customize the success code using the `exit_success` option.
 
 ```json
 {
-    "label": "check_exit_code Sample",
     "command": "echo exit code is zero.",
     "check_exit_code": true,
     "exit_success": 10,
@@ -44,7 +38,6 @@ When `check_exit_code` is enabled, it can also show the last line in the error d
 
 ```json
 {
-    "label": "show_last_line Sample",
     "command": "echo Fake Error!",
     "show_last_line": true,
     "components": []

--- a/examples/other_features/help/gui_definition.json
+++ b/examples/other_features/help/gui_definition.json
@@ -1,30 +1,28 @@
 {
-    "gui": [
-        {
-            "label": "Sample GUI",
-            "command": "echo file: %-% & echo folder: %-% & echo checkbox: %-%",
-            "components": [
-                {
-                    "type": "static_text",
-                    "label": "This is a sample GUI. Edit 'gui_definition.json' for your scripts."
-                },
-                {
-                    "type": "file",
-                    "label": "Some file path",
-                    "extension": "any files (*)|*",
-                    "placeholder": "Drop a file here!"
-                },
-                {
-                    "type": "folder",
-                    "label": "Some folder path"
-                },
-                {
-                    "type": "check",
-                    "label": "flag"
-                }
-            ]
-        }
-    ],
+    "gui": {
+        "label": "Sample GUI",
+        "command": "echo file: %-% & echo folder: %-% & echo checkbox: %-%",
+        "components": [
+            {
+                "type": "static_text",
+                "label": "This is a sample GUI. Edit 'gui_definition.json' for your scripts."
+            },
+            {
+                "type": "file",
+                "label": "Some file path",
+                "extension": "any files (*)|*",
+                "placeholder": "Drop a file here!"
+            },
+            {
+                "type": "folder",
+                "label": "Some folder path"
+            },
+            {
+                "type": "check",
+                "label": "flag"
+            }
+        ]
+    },
     "help": [
         {
             "type": "url",

--- a/examples/other_features/help/gui_definition.json
+++ b/examples/other_features/help/gui_definition.json
@@ -1,6 +1,6 @@
 {
     "gui": {
-        "label": "Sample GUI",
+        "window_name": "Sample GUI",
         "command": "echo file: %-% & echo folder: %-% & echo checkbox: %-%",
         "components": [
             {

--- a/examples/other_features/multiple/README.md
+++ b/examples/other_features/multiple/README.md
@@ -2,7 +2,8 @@
 
 `"gui"` can be an array of gui definitions.
 Users can select one of these definitions from the `Menu` in the executable.
-You can also use `"label"` to modify strings that are displayed in the menu bar.  
+You can also use `"label"` to modify strings that are displayed in the menu bar.
+When `"label"` is not defined, `"window_name"` will be used as the GUI label.  
 
 ![advanced](https://github.com/matyalatte/tuw/assets/69258547/956be42e-6931-4b71-ae3c-180103a93714)  
 
@@ -21,7 +22,7 @@ You can also use `"label"` to modify strings that are displayed in the menu bar.
             ]
         },
         {
-            "label": "Sample GUI2",
+            "window_name": "Sample GUI2",
             "command": "echo text_box: %-%",
             "button": "Echo!",
             "components": [

--- a/examples/other_features/multiple/README.md
+++ b/examples/other_features/multiple/README.md
@@ -1,6 +1,36 @@
 # Multiple Definitions
 
 `"gui"` can be an array of gui definitions.
-Users can select one of the definitions from the `Menu` in the executable.  
+Users can select one of these definitions from the `Menu` in the executable.
+You can also use `"label"` to modify strings that are displayed in the menu bar.  
 
 ![advanced](https://github.com/matyalatte/tuw/assets/69258547/956be42e-6931-4b71-ae3c-180103a93714)  
+
+```json
+{
+    "gui": [
+        {
+            "label": "Sample GUI",
+            "command": "echo file: %-%",
+            "button": "Echo!",
+            "components": [
+                {
+                    "type": "file",
+                    "label": "Some file path"
+                }
+            ]
+        },
+        {
+            "label": "Sample GUI2",
+            "command": "echo text_box: %-%",
+            "button": "Echo!",
+            "components": [
+                {
+                    "type": "text",
+                    "label": "Some text"
+                }
+            ]
+        }
+    ]
+}
+```

--- a/examples/other_features/multiple/README.md
+++ b/examples/other_features/multiple/README.md
@@ -1,6 +1,6 @@
 # Multiple Definitions
 
-You can put multiple definitions in `"gui": []`.  
-These definitions can be selected from the `Menu` in the executable.  
+`"gui"` can be an array of gui definitions.
+Users can select one of the definitions from the `Menu` in the executable.  
 
 ![advanced](https://github.com/matyalatte/tuw/assets/69258547/956be42e-6931-4b71-ae3c-180103a93714)  

--- a/examples/other_features/multiple/gui_definition.json
+++ b/examples/other_features/multiple/gui_definition.json
@@ -12,7 +12,7 @@
             ]
         },
         {
-            "label": "Sample GUI2",
+            "window_name": "Sample GUI2",
             "command": "echo text_box: %-%",
             "button": "Echo!",
             "components": [

--- a/examples/other_features/multiple/gui_definition.json
+++ b/examples/other_features/multiple/gui_definition.json
@@ -2,64 +2,23 @@
     "gui": [
         {
             "label": "Sample GUI",
-            "command": "echo file: %-% & echo folder: %-% & echo checkbox: %-%",
+            "command": "echo file: %-%",
             "button": "Echo!",
             "components": [
                 {
-                    "type": "static_text",
-                    "label": "This is a sample GUI. Edit 'gui_definition.json' for your scripts."
-                },
-                {
                     "type": "file",
-                    "label": "Some file path",
-                    "extension": "any files (*)|*",
-                    "placeholder": "Drop a file here!"
-                },
-                {
-                    "type": "folder",
-                    "label": "Some folder path"
-                },
-                {
-                    "type": "check",
-                    "label": "checkbox",
-                    "value": "true",
-                    "default": true
+                    "label": "Some file path"
                 }
             ]
         },
         {
             "label": "Sample GUI2",
-            "command": "echo text_box: %-% & echo options:%-%",
+            "command": "echo text_box: %-%",
             "button": "Echo!",
             "components": [
                 {
-                    "type": "static_text",
-                    "label": "This is a sample GUI. Edit 'gui_definition.json' for your scripts."
-                },
-                {
                     "type": "text",
                     "label": "Some text"
-                },
-                {
-                    "type": "check_array",
-                    "label": "options",
-                    "items": [
-                        {
-                            "label": "option1",
-                            "value": "--opt1",
-                            "default": true
-                        },
-                        {
-                            "label": "option2",
-                            "value": "--opt2",
-                            "default": false
-                        },
-                        {
-                            "label": "option3",
-                            "value": "--opt3",
-                            "default": false
-                        }
-                    ]
                 }
             ]
         }

--- a/examples/other_features/skip_dialog/README.md
+++ b/examples/other_features/skip_dialog/README.md
@@ -4,12 +4,10 @@ You can disable the success dialog with `"show_success_dialog": false`.
 Tuw will refrain from showing the dialog regardless of how many times you push the execution button.
 
 ```json
-"gui": [
-    {
-        "label": "Skip dialog",
-        "command": "echo No dialogues...",
-        "show_success_dialog": false,
-        "components": []
-    }
-]
+"gui": {
+    "label": "Skip dialog",
+    "command": "echo No dialogues...",
+    "show_success_dialog": false,
+    "components": []
+}
 ```

--- a/examples/other_features/skip_dialog/README.md
+++ b/examples/other_features/skip_dialog/README.md
@@ -5,7 +5,7 @@ Tuw will refrain from showing the dialog regardless of how many times you push t
 
 ```json
 "gui": {
-    "label": "Skip dialog",
+    "window_name": "Skip dialog",
     "command": "echo No dialogues...",
     "show_success_dialog": false,
     "components": []

--- a/examples/other_features/skip_dialog/gui_definition.json
+++ b/examples/other_features/skip_dialog/gui_definition.json
@@ -1,10 +1,8 @@
 {
-    "gui": [
-        {
-            "label": "Skip dialog",
-            "command": "echo No dialogues...",
-            "show_success_dialog": false,
-            "components": []
-        }
-    ]
+    "gui": {
+        "label": "Skip dialog",
+        "command": "echo No dialogues...",
+        "show_success_dialog": false,
+        "components": []
+    }
 }

--- a/examples/other_features/skip_dialog/gui_definition.json
+++ b/examples/other_features/skip_dialog/gui_definition.json
@@ -1,6 +1,6 @@
 {
     "gui": {
-        "label": "Skip dialog",
+        "window_name": "Skip dialog",
         "command": "echo No dialogues...",
         "show_success_dialog": false,
         "components": []

--- a/examples/other_features/version_check/README.md
+++ b/examples/other_features/version_check/README.md
@@ -14,7 +14,7 @@ There are two options for checking the tool version.
     "recommended": "2.1.0",
     "minimum_required": "2.0.0",
     "gui": {
-        "label": "You can't see this GUI.",
+        "window_name": "You can't see this GUI.",
         "command": "echo Hello!",
         "components": []
     }

--- a/examples/other_features/version_check/README.md
+++ b/examples/other_features/version_check/README.md
@@ -11,14 +11,12 @@ There are two options for checking the tool version.
 
 ```json
 {
-    "recommended": "1.1.0",
-    "minimum_required": "1.0.0",
-    "gui": [
-        {
-            "label": "You can't see this GUI.",
-            "command": "echo Hello!",
-            "components": []
-        }
-    ]
+    "recommended": "2.1.0",
+    "minimum_required": "2.0.0",
+    "gui": {
+        "label": "You can't see this GUI.",
+        "command": "echo Hello!",
+        "components": []
+    }
 }
 ```

--- a/examples/other_features/version_check/gui_definition.json
+++ b/examples/other_features/version_check/gui_definition.json
@@ -2,7 +2,7 @@
     "recommended": "2.1.0",
     "minimum_required": "2.0.0",
     "gui": {
-        "label": "You can't see this GUI.",
+        "window_name": "You can't see this GUI.",
         "command": "echo Hello!",
         "components": []
     }

--- a/examples/other_features/version_check/gui_definition.json
+++ b/examples/other_features/version_check/gui_definition.json
@@ -1,11 +1,9 @@
 {
-    "recommended": "1.1.0",
-    "minimum_required": "1.0.0",
-    "gui": [
-        {
-            "label": "You can't see this GUI.",
-            "command": "echo Hello!",
-            "components": []
-        }
-    ]
+    "recommended": "2.1.0",
+    "minimum_required": "2.0.0",
+    "gui": {
+        "label": "You can't see this GUI.",
+        "command": "echo Hello!",
+        "components": []
+    }
 }

--- a/examples/tips/comments/README.md
+++ b/examples/tips/comments/README.md
@@ -9,7 +9,7 @@ Tuw supports the [JSON with Comments](https://code.visualstudio.com/docs/languag
      * Multi-line comment
      */
     "gui": {
-        "label": "JSON with Comments",
+        "window_name": "JSON with Comments",
         "command": "echo Hello!",
         "components": [],
         // You can put a trailing comma after the last element.

--- a/examples/tips/comments/README.md
+++ b/examples/tips/comments/README.md
@@ -8,14 +8,12 @@ Tuw supports the [JSON with Comments](https://code.visualstudio.com/docs/languag
     /*
      * Multi-line comment
      */
-    "gui": [
-        {
-            "label": "JSON with Comments",
-            "command": "echo Hello!",
-            "components": [],
-            // You can put a trailing comma after the last element.
-            "": "",
-        }
-    ]
+    "gui": {
+        "label": "JSON with Comments",
+        "command": "echo Hello!",
+        "components": [],
+        // You can put a trailing comma after the last element.
+        "": "",
+    }
 }
 ```

--- a/examples/tips/comments/gui_definition.jsonc
+++ b/examples/tips/comments/gui_definition.jsonc
@@ -4,7 +4,7 @@
      * Multi-line comment
      */
     "gui": {
-        "label": "JSON with Comments",
+        "window_name": "JSON with Comments",
         "command": "echo Hello!",
         "components": [],
         // You can put a trailing comma after the last element.

--- a/examples/tips/comments/gui_definition.jsonc
+++ b/examples/tips/comments/gui_definition.jsonc
@@ -3,13 +3,11 @@
     /*
      * Multi-line comment
      */
-    "gui": [
-        {
-            "label": "JSON with Comments",
-            "command": "echo Hello!",
-            "components": [],
-            // You can put a trailing comma after the last element.
-            "": "",
-        }
-    ]
+    "gui": {
+        "label": "JSON with Comments",
+        "command": "echo Hello!",
+        "components": [],
+        // You can put a trailing comma after the last element.
+        "": "",
+    }
 }

--- a/examples/tips/multi_lines/README.md
+++ b/examples/tips/multi_lines/README.md
@@ -10,9 +10,9 @@ But you can see some examples for it.
 On windows, you can join the commands with ` && `.  
 And some commands like `for` loop require parentheses `()`.
 
-```json
+```jsonc
 {
-    "label": "Search json in a folder (Windows)",
+    // Search json in a folder (Windows)
     "command": "@echo off && (for %%f in (\"%dir%\\*.json\") do (echo %%f)) && echo Done!",
     "button": "Echo!",
     "components": [
@@ -28,9 +28,9 @@ And some commands like `for` loop require parentheses `()`.
 
 On non-Windows platforms, you can join the commands with `;`.
 
-```json
+```jsonc
 {
-    "label": "Search json in a folder (Unix/Linux)",
+    // Search json in a folder (Unix/Linux)
     "command": "for f in %dir%/*.json; do echo \"${f}\"; done; echo Done!",
     "button": "Echo!",
     "components": [

--- a/examples/tips/unicode/README.md
+++ b/examples/tips/unicode/README.md
@@ -6,7 +6,7 @@ Tuw supports UTF-8 strings.
 
 ```json
 {
-    "label": "Unicode Sample",
+    "window_name": "Unicode Sample",
     "command": "echo file: %รหัส% & echo folder: %-% & echo checkbox: %-%",
     "button": "こんにちは！",
     "components": [

--- a/examples/tips/unicode/gui_definition.json
+++ b/examples/tips/unicode/gui_definition.json
@@ -1,28 +1,26 @@
 {
-    "gui": [
-        {
-            "label": "Unicode Sample",
-            "command": "echo file: %รหัส% & echo folder: %-% & echo checkbox: %-%",
-            "button": "こんにちは！",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "文件",
-                    "extension": "any files | *",
-                    "default": "ああああ",
-                    "id": "รหัส"
-                },
-                {
-                    "type": "folder",
-                    "label": "폴더",
-                    "default": "いいいい"
-                },
-                {
-                    "type": "check",
-                    "label": "вариант",
-                    "default": true
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Unicode Sample",
+        "command": "echo file: %รหัส% & echo folder: %-% & echo checkbox: %-%",
+        "button": "こんにちは！",
+        "components": [
+            {
+                "type": "file",
+                "label": "文件",
+                "extension": "any files | *",
+                "default": "ああああ",
+                "id": "รหัส"
+            },
+            {
+                "type": "folder",
+                "label": "폴더",
+                "default": "いいいい"
+            },
+            {
+                "type": "check",
+                "label": "вариант",
+                "default": true
+            }
+        ]
+    }
 }

--- a/examples/tips/unicode/gui_definition.json
+++ b/examples/tips/unicode/gui_definition.json
@@ -1,6 +1,6 @@
 {
     "gui": {
-        "label": "Unicode Sample",
+        "window_name": "Unicode Sample",
         "command": "echo file: %รหัส% & echo folder: %-% & echo checkbox: %-%",
         "button": "こんにちは！",
         "components": [

--- a/include/json_utils.h
+++ b/include/json_utils.h
@@ -40,6 +40,6 @@ void CheckVersion(JsonResult& result, rapidjson::Document& definition);
 void CheckDefinition(JsonResult& result, rapidjson::Document& definition);
 void CheckSubDefinition(JsonResult& result, rapidjson::Value& sub_definition,
                         rapidjson::Document::AllocatorType& alloc);
-void CheckHelpURLs(JsonResult& result, const rapidjson::Document& definition);
+void CheckHelpURLs(JsonResult& result, rapidjson::Document& definition);
 
 }  // namespace json_utils

--- a/include/json_utils.h
+++ b/include/json_utils.h
@@ -39,6 +39,7 @@ void GetDefaultDefinition(rapidjson::Document& definition);
 void CheckVersion(JsonResult& result, rapidjson::Document& definition);
 void CheckDefinition(JsonResult& result, rapidjson::Document& definition);
 void CheckSubDefinition(JsonResult& result, rapidjson::Value& sub_definition,
+                        int index,
                         rapidjson::Document::AllocatorType& alloc);
 void CheckHelpURLs(JsonResult& result, rapidjson::Document& definition);
 

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1,29 +1,33 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "properties": {
-    "recommended": { "$ref": "#/definitions/types/version" },
-    "recommended_version": { "$ref": "#/definitions/types/version" },
-    "minimum_required": { "$ref": "#/definitions/types/version" },
-    "minimum_required_version": { "$ref": "#/definitions/types/version" },
-    "gui": {
-      "if": { "type": "object" },
-      "then": { "$ref": "#/definitions/types/gui_item" },
-      "else": {
-        "type": "array",
-        "items": { "$ref": "#/definitions/types/gui_item" }
-      }
-    },
-    "help":  {
-      "if": { "type": "object" },
-      "then": { "$ref": "#/definitions/types/help_item" },
-      "else": {
-        "type": "array",
-        "items": { "$ref": "#/definitions/types/help_item" }
-      }
+  "if": {
+    "required": [ "gui" ]
+  },
+  "then": {
+    "properties": {
+      "recommended": { "$ref": "#/definitions/types/version" },
+      "recommended_version": { "$ref": "#/definitions/types/version" },
+      "minimum_required": { "$ref": "#/definitions/types/version" },
+      "minimum_required_version": { "$ref": "#/definitions/types/version" },
+      "gui": { "$ref": "#/definitions/types/gui_array" },
+      "help": { "$ref": "#/definitions/types/help_array" }
     }
   },
-  "required": [ "gui" ],
+  "else": {
+    "allOf": [
+      { "$ref": "#/definitions/types/gui_item" },
+      {
+        "properties": {
+          "recommended": { "$ref": "#/definitions/types/version" },
+          "recommended_version": { "$ref": "#/definitions/types/version" },
+          "minimum_required": { "$ref": "#/definitions/types/version" },
+          "minimum_required_version": { "$ref": "#/definitions/types/version" },
+          "help": { "$ref": "#/definitions/types/help_array" }
+        }
+      }
+    ]
+  },
   "definitions": {
     "types": {
       "version": {
@@ -183,6 +187,14 @@
           }
         ]
       },
+      "gui_array": {
+        "if": { "type": "object" },
+        "then": { "$ref": "#/definitions/types/gui_item" },
+        "else": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/types/gui_item" }
+        }
+      },
       "help_item": {
         "type": "object",
         "properties": {
@@ -221,6 +233,14 @@
             }
           }
         ]
+      },
+      "help_array":  {
+        "if": { "type": "object" },
+        "then": { "$ref": "#/definitions/types/help_item" },
+        "else": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/types/help_item" }
+        }
       }
     },
     "components": {

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -7,8 +7,130 @@
     "minimum_required": { "$ref": "#/definitions/types/version" },
     "minimum_required_version": { "$ref": "#/definitions/types/version" },
     "gui": {
-      "type": "array",
-      "items": {
+      "if": { "type": "object" },
+      "then": { "$ref": "#/definitions/types/gui_item" },
+      "else": {
+        "type": "array",
+        "items": { "$ref": "#/definitions/types/gui_item" }
+      }
+    },
+    "help":  {
+      "if": { "type": "object" },
+      "then": { "$ref": "#/definitions/types/help_item" },
+      "else": {
+        "type": "array",
+        "items": { "$ref": "#/definitions/types/help_item" }
+      }
+    }
+  },
+  "required": [ "gui" ],
+  "definitions": {
+    "types": {
+      "version": {
+        "type": "string",
+        "pattern": "^[.0-9]+$",
+        "minLength": 1,
+        "maxLength": 8
+      },
+      "component": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "static_text",
+              "file",
+              "folder",
+              "dir",
+              "choice",
+              "combo",
+              "radio",
+              "check",
+              "check_array",
+              "checks",
+              "text",
+              "text_box",
+              "int",
+              "integer",
+              "float"
+            ]
+          },
+          "label": { "type": "string" },
+          "id": { "type": "string" },
+          "add_quotes": { "type": "boolean" },
+          "optional": { "type": "boolean" },
+          "prefix": { "type": "string" },
+          "suffix": { "type": "string" },
+          "platforms": { "$ref": "#/definitions/types/platform_array" },
+          "platform_array": { "$ref": "#/definitions/types/platform_array" }
+        },
+        "allOf": [
+          { "$ref": "#/definitions/components/file" },
+          { "$ref": "#/definitions/components/folder_or_text" },
+          { "$ref": "#/definitions/components/check" },
+          { "$ref": "#/definitions/components/int" },
+          { "$ref": "#/definitions/components/float" },
+          { "$ref": "#/definitions/components/combo" },
+          { "$ref": "#/definitions/components/check_array" },
+          { "$ref": "#/definitions/components/validator" }
+        ],
+        "required": [ "type", "label" ]
+      },
+      "component_array": {
+        "if": { "type": "object" },
+        "then": { "$ref": "#/definitions/types/component" },
+        "else": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/types/component" }
+        }
+      },
+      "platform": {
+        "type": "string",
+        "enum": [ "win", "mac", "linux" ]
+      },
+      "platform_array": {
+        "if": { "type": "string" },
+        "then": { "$ref": "#/definitions/types/platform" },
+        "else": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/types/platform" }
+        }
+      },
+      "combo_item": {
+        "type": "object",
+        "properties": {
+          "label": { "type": "string" },
+          "value": { "type": "string" }
+        },
+        "required": [ "label" ]
+      },
+      "combo_item_array": {
+        "if": { "type": "object" },
+        "then": { "$ref": "#/definitions/types/combo_item" },
+        "else": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/types/combo_item" }
+        }
+      },
+      "checks_item": {
+        "type": "object",
+        "properties": {
+          "label": { "type": "string" },
+          "value": { "type": "string" },
+          "tooltip": { "type": "string" },
+          "default": { "type": "boolean" }
+        },
+        "required": [ "label" ]
+      },
+      "checks_item_array": {
+        "if": { "type": "object" },
+        "then": { "$ref": "#/definitions/types/checks_item" },
+        "else": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/types/checks_item" }
+        }
+      },
+      "gui_item": {
         "type": "object",
         "properties": {
           "label": { "type": "string" },
@@ -28,8 +150,8 @@
             "type": "string",
             "enum": [ "default", "utf8", "utf-8" ]
           },
-          "components": { "$ref": "#/definitions/types/components" },
-          "component_array": { "$ref": "#/definitions/types/components" }
+          "components": { "$ref": "#/definitions/types/component_array" },
+          "component_array": { "$ref": "#/definitions/types/component_array" }
         },
         "required": [
           "label"
@@ -60,11 +182,8 @@
             }
           }
         ]
-      }
-    },
-    "help": {
-      "type": "array",
-      "items": {
+      },
+      "help_item": {
         "type": "object",
         "properties": {
           "type": {
@@ -102,100 +221,6 @@
             }
           }
         ]
-      }
-    }
-  },
-  "required": [ "gui" ],
-  "definitions": {
-    "types": {
-      "version": {
-        "type": "string",
-        "pattern": "^[.0-9]+$",
-        "minLength": 1,
-        "maxLength": 8
-      },
-      "components": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "static_text",
-                "file",
-                "folder",
-                "dir",
-                "choice",
-                "combo",
-                "radio",
-                "check",
-                "check_array",
-                "checks",
-                "text",
-                "text_box",
-                "int",
-                "integer",
-                "float"
-              ]
-            },
-            "label": { "type": "string" },
-            "id": { "type": "string" },
-            "add_quotes": { "type": "boolean" },
-            "optional": { "type": "boolean" },
-            "prefix": { "type": "string" },
-            "suffix": { "type": "string" },
-            "platforms": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "enum": [ "win", "mac", "linux" ]
-              }
-            },
-            "platform_array": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "enum": [ "win", "mac", "linux" ]
-              }
-            }
-          },
-          "allOf": [
-            { "$ref": "#/definitions/components/file" },
-            { "$ref": "#/definitions/components/folder_or_text" },
-            { "$ref": "#/definitions/components/check" },
-            { "$ref": "#/definitions/components/int" },
-            { "$ref": "#/definitions/components/float" },
-            { "$ref": "#/definitions/components/combo" },
-            { "$ref": "#/definitions/components/check_array" },
-            { "$ref": "#/definitions/components/validator" }
-          ],
-          "required": [ "type", "label" ]
-        }
-      },
-      "combo_items": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "label": { "type": "string" },
-            "value": { "type": "string" }
-          },
-          "required": [ "label" ]
-        }
-      },
-      "checks_items": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "label": { "type": "string" },
-            "value": { "type": "string" },
-            "tooltip": { "type": "string" },
-            "default": { "type": "boolean" }
-          },
-          "required": [ "label" ]
-        }
       }
     },
     "components": {
@@ -291,8 +316,8 @@
           "properties": {
             "default": { "type": "integer" },
             "tooltip": { "type": "string" },
-            "items": { "$ref": "#/definitions/types/combo_items" },
-            "item_array": { "$ref": "#/definitions/types/combo_items" }
+            "items": { "$ref": "#/definitions/types/combo_item_array" },
+            "item_array": { "$ref": "#/definitions/types/combo_item_array" }
           },
           "if": {
             "not": {
@@ -312,8 +337,8 @@
         },
         "then": {
           "properties": {
-            "items": { "$ref": "#/definitions/types/checks_items" },
-            "item_array": { "$ref": "#/definitions/types/checks_items" }
+            "items": { "$ref": "#/definitions/types/checks_item_array" },
+            "item_array": { "$ref": "#/definitions/types/checks_item_array" }
           },
           "if": {
             "not": {

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -157,9 +157,6 @@
           "components": { "$ref": "#/definitions/types/component_array" },
           "component_array": { "$ref": "#/definitions/types/component_array" }
         },
-        "required": [
-          "label"
-        ],
         "allOf": [
           {
             "if": {

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -229,7 +229,7 @@ namespace json_utils {
 
     // get default definition of gui
     void GetDefaultDefinition(rapidjson::Document& definition) {
-        static const char* def_str = "{\"gui\":{"
+        static const char* def_str = "{"
             "\"label\":\"Default GUI\","
     #ifdef _WIN32
             "\"command\":\"dir\","
@@ -239,7 +239,7 @@ namespace json_utils {
             "\"button\":\"run 'ls'\","
     #endif
             "\"components\":[]"
-            "}}";
+            "}";
         rapidjson::ParseResult ok = definition.Parse(def_str);
         assert(ok);
         JsonResult result = JSON_RESULT_OK;
@@ -685,7 +685,14 @@ namespace json_utils {
     }
 
     void CheckDefinition(JsonResult& result, rapidjson::Document& definition) {
-        CheckJsonArrayType(result, definition, "gui", JsonType::JSON, definition.GetAllocator());
+        rapidjson::Document::AllocatorType& alloc = definition.GetAllocator();
+        if (!definition.HasMember("gui")) {
+            // definition["gui"] = definition
+            rapidjson::Value n(rapidjson::kObjectType);
+            n.CopyFrom(definition, alloc);
+            definition.AddMember("gui", n, alloc);
+        }
+        CheckJsonArrayType(result, definition, "gui", JsonType::JSON, alloc);
         if (!result.ok) return;
         if (definition["gui"].Size() == 0) {
             result.ok = false;
@@ -694,7 +701,7 @@ namespace json_utils {
 
         for (rapidjson::Value& sub_d : definition["gui"].GetArray()) {
             if (!result.ok) return;
-            CheckSubDefinition(result, sub_d, definition.GetAllocator());
+            CheckSubDefinition(result, sub_d, alloc);
         }
     }
 

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -447,17 +447,19 @@ namespace json_utils {
     void CheckSubDefinition(JsonResult& result, rapidjson::Value& sub_definition,
                             int index,
                             rapidjson::Document::AllocatorType& alloc) {
-        if (!sub_definition.HasMember("label")) {
-            std::string default_label = ConcatCStrings("GUI ", index);
-            rapidjson::Value n(rapidjson::kStringType);
-            n.SetString(default_label.c_str(), alloc);
-            sub_definition.AddMember("label", n, alloc);
-        }
-        CheckJsonType(result, sub_definition, "label", JsonType::STRING, "", OPTIONAL);
-        CheckJsonType(result, sub_definition, "button", JsonType::STRING, "", OPTIONAL);
         CorrectKey(sub_definition, "window_title", "window_name", alloc);
         CorrectKey(sub_definition, "title", "window_name", alloc);
         CheckJsonType(result, sub_definition, "window_name", JsonType::STRING, "", OPTIONAL);
+
+        if (!sub_definition.HasMember("label")) {
+            std::string default_label = ConcatCStrings("GUI ", index);
+            const char* label = GetString(sub_definition, "window_name", default_label.c_str());
+            rapidjson::Value n(label, alloc);
+            sub_definition.AddMember("label", n, alloc);
+        }
+        CheckJsonType(result, sub_definition, "label", JsonType::STRING);
+
+        CheckJsonType(result, sub_definition, "button", JsonType::STRING, "", OPTIONAL);
 
         CheckJsonType(result, sub_definition, "check_exit_code", JsonType::BOOLEAN, "", OPTIONAL);
         CheckJsonType(result, sub_definition, "exit_success", JsonType::INTEGER, "", OPTIONAL);

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -230,7 +230,6 @@ namespace json_utils {
     // get default definition of gui
     void GetDefaultDefinition(rapidjson::Document& definition) {
         static const char* def_str = "{"
-            "\"label\":\"Default GUI\","
     #ifdef _WIN32
             "\"command\":\"dir\","
             "\"button\":\"run 'dir'\","
@@ -446,9 +445,15 @@ namespace json_utils {
 
     // validate one of definitions (["gui"][i]) and store parsed info
     void CheckSubDefinition(JsonResult& result, rapidjson::Value& sub_definition,
+                            int index,
                             rapidjson::Document::AllocatorType& alloc) {
-        // check is_string
-        CheckJsonType(result, sub_definition, "label", JsonType::STRING);
+        if (!sub_definition.HasMember("label")) {
+            std::string default_label = ConcatCStrings("GUI ", index);
+            rapidjson::Value n(rapidjson::kStringType);
+            n.SetString(default_label.c_str(), alloc);
+            sub_definition.AddMember("label", n, alloc);
+        }
+        CheckJsonType(result, sub_definition, "label", JsonType::STRING, "", OPTIONAL);
         CheckJsonType(result, sub_definition, "button", JsonType::STRING, "", OPTIONAL);
         CorrectKey(sub_definition, "window_title", "window_name", alloc);
         CorrectKey(sub_definition, "title", "window_name", alloc);
@@ -699,9 +704,11 @@ namespace json_utils {
             result.msg = "The size of [\"gui\"] should NOT be zero.";
         }
 
+        int i = 0;
         for (rapidjson::Value& sub_d : definition["gui"].GetArray()) {
             if (!result.ok) return;
-            CheckSubDefinition(result, sub_d, alloc);
+            CheckSubDefinition(result, sub_d, i, alloc);
+            i++;
         }
     }
 

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -313,8 +313,10 @@ static void OnClicked(uiButton *sender, void *data) {
 void MainFrame::UpdatePanel(unsigned definition_id) {
     m_definition_id = definition_id;
     rapidjson::Value& sub_definition = m_definition["gui"][m_definition_id];
-    const char* label = sub_definition["label"].GetString();
-    PrintFmt("[UpdatePanel] Label: %s\n", label);
+    if (m_definition["gui"].Size() > 1) {
+        const char* label = sub_definition["label"].GetString();
+        PrintFmt("[UpdatePanel] Label: %s\n", label);
+    }
     const char* cmd_str = sub_definition["command_str"].GetString();
     PrintFmt("[UpdatePanel] Command: %s\n", cmd_str);
     const char* window_name = json_utils::GetString(sub_definition,

--- a/tests/json/relaxed.jsonc
+++ b/tests/json/relaxed.jsonc
@@ -3,7 +3,6 @@
     /*
      * Multi-line comments
      */
-    "label": "test",
     "command": "echo hello",
     "components": [],
     "help": {

--- a/tests/json/relaxed.jsonc
+++ b/tests/json/relaxed.jsonc
@@ -3,8 +3,12 @@
     /*
      * Multi-line comments
      */
-    "ary": [
-        "",
-        "trailing_comma",
-    ]
+    "label": "test",
+    "command": "echo hello",
+    "components": [],
+    "help": {
+        "label": "test",
+        "type": "url",
+        "url": "example.com",
+    },
 }

--- a/tests/json_check_test.cpp
+++ b/tests/json_check_test.cpp
@@ -71,6 +71,14 @@ TEST(JsonCheckTest, checkGUISuccess4) {
     EXPECT_TRUE(result.ok);
 }
 
+TEST(JsonCheckTest, checkGUISuccessRelaxed) {
+    rapidjson::Document test_json;
+    json_utils::JsonResult result = json_utils::LoadJson(JSON_RELAXED, test_json);
+    EXPECT_TRUE(result.ok);
+    json_utils::CheckDefinition(result, test_json);
+    EXPECT_TRUE(result.ok);
+}
+
 void CheckGUIError(rapidjson::Document& test_json, const char* expected) {
     json_utils::JsonResult result = JSON_RESULT_OK;
     json_utils::CheckDefinition(result, test_json);
@@ -82,7 +90,7 @@ TEST(JsonCheckTest, checkGUIFail) {
     rapidjson::Document test_json;
     GetTestJson(test_json);
     test_json.RemoveMember("gui");
-    CheckGUIError(test_json, "['gui'] not found.");
+    CheckGUIError(test_json, "['components'] not found.");
 }
 
 TEST(JsonCheckTest, checkGUIFail2) {
@@ -133,6 +141,14 @@ TEST(JsonCheckTest, checkGUIFail7) {
         " echo file: __comp2__ & echo folder: __comp3__ & echo combo: __comp4__"
         " & echo radio: __comp5__ & echo check: __comp6__ & echo check_array: __comp7__"
         " & echo textbox: __comp8__ & echo int: __comp9__ & echo float: __comp???__");
+}
+
+TEST(JsonCheckTest, checkGUIFailRelaxed) {
+    rapidjson::Document test_json;
+    json_utils::JsonResult result = json_utils::LoadJson(JSON_RELAXED, test_json);
+    EXPECT_TRUE(result.ok);
+    test_json.AddMember("exit_success", "a", test_json.GetAllocator());
+    CheckGUIError(test_json, "['exit_success'] should be an int.");
 }
 
 TEST(JsonCheckTest, checkHelpSuccess) {


### PR DESCRIPTION
I made GUI labels optional because they were used only when the `"gui"` array had multiple definitions. You don't need to define `"label"` for each command now.

```json
{
    "gui": {
        "command": "echo Hello!",
        "components": []
    }
}
```


Also, you can now use `"window_name"` as the default value of `"label"`.

```jsonc
{
    "gui": [
        {
            // The value of "label" also become "Sample GUI 1"
            "window_name": "Sample GUI 1",
            "command": "echo hello",
            "components": []
        },
        {
            "window_name": "Sample GUI 2",
            // Of course, you can define a custom value for "label"
            "label": "Menu Item 2",
            "command": "echo text_box: %-%",
            "components": [
                {
                    "type": "text",
                    "label": "Some text"
                }
            ]
        }
    ]
}
```
