### PR TITLE
Redirect stderr to console window

### DIFF
--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -118,6 +118,9 @@ inline bool operator!=(const char* str1, const tuwString& str2) {
     return str2 != str1;
 }
 
+// Returns only the last line and removes trailing line feeds (\n and \r.)
+tuwString GetLastLine(const tuwString& str);
+
 class tuwWstring {
  private:
     wchar_t* m_str;

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdio>
 #include "env_utils.h"
 
 enum StringError : int {
@@ -156,11 +157,13 @@ uint32_t Fnv1Hash32(const tuwString& str);
 #ifdef _WIN32
 tuwString UTF16toUTF8(const wchar_t* str);
 tuwWstring UTF8toUTF16(const char* str);
-void PrintFmt(const char* fmt, ...);
+void FprintFmt(FILE* out, const char* fmt, ...);
 void EnableCSI();
 #elif defined(__TUW_UNIX__)
 void SetLogEntry(void* log_entry);
-void PrintFmt(const char* fmt, ...);
+void FprintFmt(FILE* out, const char* fmt, ...);
 #else
-#define PrintFmt(...) printf(__VA_ARGS__)
+#define FprintFmt(...) fprintf(__VA_ARGS__)
 #endif
+
+#define PrintFmt(...) FprintFmt(stdout, __VA_ARGS__)

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -6,23 +6,6 @@
 #include "windows.h"
 #endif
 
-inline bool IsNewline(char ch) {
-    return ch == '\n' || ch == '\r';
-}
-
-static tuwString GetLastLine(const tuwString& input) {
-    if (input.empty()) return "";
-    size_t end = input.length();
-
-    // Trim trailing newlines
-    while (end > 0 && IsNewline(input[end - 1])) end--;
-    if (end == 0) return "";
-
-    size_t start = end - 1;
-    while (start > 0 && input[start - 1] != '\n') start--;
-    return input.substr(start, end - start);
-}
-
 enum READ_IO_TYPE : int {
     READ_STDOUT = 0,
     READ_STDERR,
@@ -31,7 +14,7 @@ enum READ_IO_TYPE : int {
 unsigned ReadIO(subprocess_s &process,
                 int read_io_type,
                 char *buf, const unsigned buf_size,
-                tuwString& str, const unsigned str_size) {
+                tuwString& str, const size_t str_size) {
     unsigned read_size = 0;
     if (read_io_type == READ_STDOUT) {
         read_size = subprocess_read_stdout(&process, buf, buf_size);
@@ -69,6 +52,12 @@ void RedirectOutput(FILE* out, const char* buf,
         FprintFmt(out, "%s", buf);
 #endif
     }
+}
+
+inline tuwString TruncateStr(const tuwString& str, size_t size) {
+    if (str.size() > size)
+        return "..." + str.substr(str.size() - size, size);
+    return str;
 }
 
 ExecuteResult Execute(const tuwString& cmd, bool use_utf8_on_windows) {
@@ -112,6 +101,8 @@ ExecuteResult Execute(const tuwString& cmd, bool use_utf8_on_windows) {
         return { -1, "Failed to create a subprocess.\n", ""};
 
     const unsigned BUF_SIZE = 1024;
+    const size_t LAST_LINE_MAX_LEN = BUF_SIZE;
+    const size_t ERR_MSG_MAX_LEN = BUF_SIZE * 2;
     char out_buf[BUF_SIZE + 1];
     char err_buf[BUF_SIZE + 1];
     tuwString last_line;
@@ -129,8 +120,8 @@ ExecuteResult Execute(const tuwString& cmd, bool use_utf8_on_windows) {
     } while (subprocess_alive(&process) || out_read_size || err_read_size);
 
     // Sometimes stdout and stderr still have unread characters
-    out_read_size = ReadIO(process, READ_STDOUT, out_buf, BUF_SIZE, last_line, BUF_SIZE);
-    err_read_size = ReadIO(process, READ_STDERR, err_buf, BUF_SIZE, err_msg, BUF_SIZE * 2);
+    out_read_size = ReadIO(process, READ_STDOUT, out_buf, BUF_SIZE, last_line, LAST_LINE_MAX_LEN);
+    err_read_size = ReadIO(process, READ_STDERR, err_buf, BUF_SIZE, err_msg, ERR_MSG_MAX_LEN);
     RedirectOutput(stdout, out_buf, out_read_size, use_utf8_on_windows);
     RedirectOutput(stderr, err_buf, err_read_size, use_utf8_on_windows);
 
@@ -138,6 +129,8 @@ ExecuteResult Execute(const tuwString& cmd, bool use_utf8_on_windows) {
     DestroyProcess(process, &return_code, err_msg);
 
     last_line = GetLastLine(last_line);
+    last_line = TruncateStr(last_line, LAST_LINE_MAX_LEN);
+    err_msg = TruncateStr(err_msg, ERR_MSG_MAX_LEN);
 
     return { return_code, err_msg, last_line };
 }

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -30,7 +30,7 @@ void tuwString::alloc_cstr(const char *str, size_t size) {
     m_str[size] = '\0';
 }
 
-#define get_strlen(str) (str) ? strlen(str) : 0
+#define get_strlen(str) ((str) ? strlen(str) : 0)
 
 tuwString::tuwString(const char* str) :
         m_str(nullptr), m_size(0) {
@@ -156,7 +156,7 @@ DEFINE_PLUS_FOR_NUM(int, "d")
 DEFINE_PLUS_FOR_NUM(size_t, "zu")
 DEFINE_PLUS_FOR_NUM(uint32_t, PRIu32)
 
-#define null_to_empty(str) (str) ? str : ""
+#define null_to_empty(str) ((str) ? str : "")
 
 bool tuwString::operator==(const char* str) const {
     return strcmp(c_str(), null_to_empty(str)) == 0;
@@ -217,6 +217,26 @@ tuwString operator+(const char* str1, const tuwString& str2) {
     tuwString new_str(str1);
     new_str += str2;
     return new_str;
+}
+
+static inline bool IsNewline(char ch) {
+    return ch == '\n' || ch == '\r';
+}
+
+tuwString GetLastLine(const tuwString& str) {
+    if (str.empty()) return "";
+
+    const char* begin = str.begin();
+    const char* end = str.end() - 1;
+    // Trim trailing line feeds.
+    while (end >= begin && IsNewline(*end)) end--;
+    if (end < begin) return "";
+
+    // Search the next line feed.
+    const char* sub_begin = end;
+    while (sub_begin >= begin && !IsNewline(*sub_begin)) sub_begin--;
+    sub_begin++;
+    return str.substr(static_cast<size_t>(sub_begin - begin), end - sub_begin + 1);
 }
 
 tuwWstring::tuwWstring(const wchar_t* str) :

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -262,7 +262,7 @@ tuwWstring UTF8toUTF16(const char* str) {
     return wstr;
 }
 
-void PrintFmt(const char* fmt, ...) {
+void FprintFmt(FILE* out, const char* fmt, ...) {
     va_list va;
     va_start(va, fmt);
 
@@ -277,7 +277,7 @@ void PrintFmt(const char* fmt, ...) {
     va_end(va);
 
     WCHAR* wfmt = toUTF16(buf);
-    wprintf(L"%ls", wfmt);
+    fwprintf(out, L"%ls", wfmt);
 
     uiprivFree(buf);
     uiprivFree(wfmt);
@@ -633,7 +633,7 @@ void SetLogEntry(void* log_entry) {
     g_logger.SetLogEntry(log_entry);
 }
 
-void PrintFmt(const char* fmt, ...) {
+void FprintFmt(FILE* out, const char* fmt, ...) {
     va_list va;
     va_start(va, fmt);
     va_list va2;
@@ -644,7 +644,7 @@ void PrintFmt(const char* fmt, ...) {
     buf[size] = 0;
     vsnprintf(buf, size + 1, fmt, va);
     g_logger.Log(buf);
-    printf("%s", buf);
+    fprintf(out, "%s", buf);
     delete[] buf;
     va_end(va);
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -7,6 +7,7 @@ test_sources = [
     'json_check_test.cpp',
     'main_frame_test.cpp',
     'string_utils_test.cpp',
+    'validator_test.cpp',
 ]
 
 # build tests

--- a/tests/string_utils_test.cpp
+++ b/tests/string_utils_test.cpp
@@ -306,6 +306,24 @@ TEST(tuwStringTest, IterForNull) {
     EXPECT_EQ(&str.c_str()[0], str.end());
 }
 
+// TestGetLastLine
+TEST(tuwStringTest, GetLastLine) {
+    expect_tuwstr("last", GetLastLine("last"));
+    expect_tuwstr("last", GetLastLine("last\n"));
+    expect_tuwstr("last", GetLastLine("\nlast"));
+    expect_tuwstr("last", GetLastLine("firs\nsecond\nlast\r\n\r\n"));
+}
+
+TEST(tuwStringTest, GetLastLineOneChar) {
+    expect_tuwstr("l", GetLastLine("l"));
+}
+
+TEST(tuwStringTest, GetLastLineNull) {
+    expect_nullstr(GetLastLine(nullptr));
+    expect_nullstr(GetLastLine(""));
+    expect_nullstr(GetLastLine("\n\n\n\n"));
+}
+
 // Test tuwWstring
 void expect_nullwstr(const tuwWstring& str) {
     EXPECT_TRUE(str.empty());
@@ -322,6 +340,8 @@ void expect_tuwwstr(const wchar_t* expected, const tuwWstring& actual) {
 TEST(tuwWstringTest, ConstructWithNull) {
     tuwWstring str(nullptr);
     expect_nullwstr(str);
+    tuwWstring str2("");
+    expect_nullwstr(str2);
 }
 
 TEST(tuwWstringTest, ConstructWithCstr) {

--- a/tests/string_utils_test.cpp
+++ b/tests/string_utils_test.cpp
@@ -340,7 +340,7 @@ void expect_tuwwstr(const wchar_t* expected, const tuwWstring& actual) {
 TEST(tuwWstringTest, ConstructWithNull) {
     tuwWstring str(nullptr);
     expect_nullwstr(str);
-    tuwWstring str2("");
+    tuwWstring str2(L"");
     expect_nullwstr(str2);
 }
 

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -7,6 +7,7 @@
 #include "json_utils.h"
 #include "tuw_constants.h"
 #include "exe_container.h"
+#include "validator.h"
 #include "env_utils.h"
 
 // you need to copy it from examples/all_keys to the json folder

--- a/tests/validator_test.cpp
+++ b/tests/validator_test.cpp
@@ -1,0 +1,141 @@
+// Tests for json embedding
+// Todo: Write more tests
+
+#include "test_utils.h"
+
+Validator GetValidator(const char* config_str) {
+    rapidjson::Document config(rapidjson::kObjectType);
+    config.Parse(config_str);
+    Validator validator;
+    validator.Initialize(config);
+    return validator;
+}
+
+TEST(ValidatorTest, Regex) {
+    const char* config =
+        "{"
+        "    \"regex\": \"^[0-9]*$\""
+        "}";
+    Validator validator = GetValidator(config);
+    EXPECT_TRUE(validator.Validate("1234"));
+    EXPECT_FALSE(validator.Validate("1234abcd"));
+    EXPECT_STREQ("Regex match failed for pattern: ^[0-9]*$",
+                 validator.GetError().c_str());
+}
+
+TEST(ValidatorTest, RegexCompileError) {
+    const char* config =
+        "{"
+        "    \"regex\": \"^[0-9\""
+        "}";
+    Validator validator = GetValidator(config);
+    EXPECT_FALSE(validator.Validate("1234"));
+    EXPECT_STREQ("Failed to parse regex pattern: ^[0-9",
+                 validator.GetError().c_str());
+}
+
+TEST(ValidatorTest, RegexGroupOp) {
+    const char* config =
+        "{"
+        "    \"regex\": \"(a|b)\""
+        "}";
+    Validator validator = GetValidator(config);
+    EXPECT_FALSE(validator.Validate("1234"));
+    EXPECT_STREQ("Regex compile error: () operators are not supported.",
+                 validator.GetError().c_str());
+}
+
+TEST(ValidatorTest, RegexGroupOpEscape) {
+    const char* config =
+        "{"
+        "    \"regex\": \"^\\(a|b\\)\"$"
+        "}";
+    Validator validator = GetValidator(config);
+    EXPECT_TRUE(validator.Validate("(a"));
+    EXPECT_TRUE(validator.Validate("b)"));
+}
+
+TEST(ValidatorTest, RegexCustomError) {
+    const char* config =
+        "{"
+        "    \"regex\": \"^[0-9]*$\","
+        "    \"regex_error\": \"Should be numeric!\""
+        "}";
+    Validator validator = GetValidator(config);
+    EXPECT_FALSE(validator.Validate("abcd"));
+    EXPECT_STREQ("Should be numeric!",
+                 validator.GetError().c_str());
+}
+
+TEST(ValidatorTest, Wildcard) {
+    const char* config =
+        "{"
+        "    \"wildcard\": \"test*foo\""
+        "}";
+    Validator validator = GetValidator(config);
+    EXPECT_TRUE(validator.Validate("testfoo"));
+    EXPECT_TRUE(validator.Validate("testbarfoo"));
+    EXPECT_FALSE(validator.Validate("test"));
+    EXPECT_STREQ("Wildcard match failed for pattern: test*foo",
+                 validator.GetError().c_str());
+}
+
+TEST(ValidatorTest, WildcardCustomError) {
+    const char* config =
+        "{"
+        "    \"wildcard\": \"test*foo\","
+        "    \"wildcard_error\": \"Custom message!\""
+        "}";
+    Validator validator = GetValidator(config);
+    EXPECT_FALSE(validator.Validate("test"));
+    EXPECT_STREQ("Custom message!",
+                 validator.GetError().c_str());
+}
+
+TEST(ValidatorTest, NotEmpty) {
+    const char* config =
+        "{"
+        "    \"not_empty\": true"
+        "}";
+    Validator validator = GetValidator(config);
+    EXPECT_TRUE(validator.Validate("test"));
+    EXPECT_FALSE(validator.Validate(""));
+    EXPECT_STREQ("Empty string is NOT allowed.",
+                 validator.GetError().c_str());
+}
+
+TEST(ValidatorTest, NotEmptyCustomError) {
+    const char* config =
+        "{"
+        "    \"not_empty\": true,"
+        "    \"not_empty_error\": \"Custom message!\""
+        "}";
+    Validator validator = GetValidator(config);
+    EXPECT_FALSE(validator.Validate(""));
+    EXPECT_STREQ("Custom message!",
+                 validator.GetError().c_str());
+}
+
+TEST(ValidatorTest, Exist) {
+    const char* config =
+        "{"
+        "    \"exist\": true"
+        "}";
+    Validator validator = GetValidator(config);
+    EXPECT_TRUE(validator.Validate(JSON_ALL_KEYS));
+    EXPECT_FALSE(validator.Validate(tuwString(JSON_ALL_KEYS) + ".fake.does_not_exist"));
+    EXPECT_STREQ("Path does NOT exist.",
+                 validator.GetError().c_str());
+}
+
+TEST(ValidatorTest, ExistCustomError) {
+    const char* config =
+        "{"
+        "    \"exist\": true,"
+        "    \"exist_error\": \"Custom message!\""
+        "}";
+    Validator validator = GetValidator(config);
+    EXPECT_FALSE(validator.Validate(tuwString(JSON_ALL_KEYS) + ".fake.does_not_exist"));
+    EXPECT_STREQ("Custom message!",
+                 validator.GetError().c_str());
+}


### PR DESCRIPTION
Tuw can show stderr with a message box but the console window ignores it.
![no_redirect](https://github.com/user-attachments/assets/5e0f981d-e5f4-4507-a373-ec03b07f2bdd)

With this PR, tuw redirects stderr into the console window.
![redirect_stderr](https://github.com/user-attachments/assets/7378eb7b-c535-44dd-b24f-a3330e9e5da1)


