### PR TITLE
v0.8.0 release

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -41,13 +41,6 @@ jobs:
 
             - First Change
             - Second Change
-
-            ## Notes
-
-            - Linux builds only support distributions using glibc.
-              [Build the executable](https://github.com/matyalatte/${{ env.TOOL_NAME }}/blob/main/docs/Building.md) by yourself if you want to use it on unsupported distros.
-            - Tuw supports more unix-like systems (BSD, Haiku, illumos, etc.)
-              [Building Workflow for Other Platforms - matyalatte/tuw](https://github.com/matyalatte/${{ env.TOOL_NAME }}/blob/main/docs/Build-on-Other.md)
           draft: true
           prerelease: false
 

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -46,7 +46,6 @@ jobs:
 
             - Linux builds only support distributions using glibc.
               [Build the executable](https://github.com/matyalatte/${{ env.TOOL_NAME }}/blob/main/docs/Building.md) by yourself if you want to use it on unsupported distros.
-            - `Tuw-*-Windows-x64-ucrt.zip` is much smaller than the standard version, but it only works on Windows10 or later.
             - Tuw supports more unix-like systems (BSD, Haiku, illumos, etc.)
               [Building Workflow for Other Platforms - matyalatte/tuw](https://github.com/matyalatte/${{ env.TOOL_NAME }}/blob/main/docs/Build-on-Other.md)
           draft: true
@@ -71,7 +70,7 @@ jobs:
             exe_ext: .exe
             zip_ext: zip
             arch: UCRT
-            arch_suffix: -x64-ucrt
+            arch_suffix: 10-x64
           - os: ubuntu-20.04
             exe_ext: ""
             zip_ext: tar.bz2

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,9 +39,10 @@ All you need is a JSON file and a tiny executable.
 
 You can download executables from [the release page](https://github.com/matyalatte/tuw/releases)
 
--   `Tuw*-Windows*.zip` is for Windows (7 or later.)  
--   `Tuw*-macOS*.tar.bz2` is for macOS (10.9 or later.)  
--   `Tuw*-Linux*.tar.bz2` is for Linux (with GTK3.14, GLIBC2.15, and GLIBCXX3.4.21, or later versions of the libraries.)  
+-   `Tuw-*-Windows-*.zip` is for Windows (7 or later.)  
+-   `Tuw-*-Windows10-*.zip` requires Windows 10 or later, but it's much smaller than the standard version.  
+-   `Tuw-*-macOS.tar.bz2` is for macOS (10.9 or later.)  
+-   `Tuw-*-Linux-*.tar.bz2` is for Linux (with GTK3.14, GLIBC2.15, and GLIBCXX3.4.21, or later versions of the libraries.)  
 
 ## Examples
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,8 +20,8 @@ Tuw provides a very simple GUI for your scripts.
 All you need is a JSON file and a tiny executable.  
 **No need for compilers, browsers, or huge executables!**  
 
-![sample](https://github.com/matyalatte/tuw/assets/69258547/9b3c8487-010e-497b-b66c-95af84906dd0)
-<img src=https://user-images.githubusercontent.com/69258547/192090797-f5e5b52d-59aa-4942-a361-2c8b5c7bd746.png width=387></img>  
+![sample](https://github.com/user-attachments/assets/17894d27-64fc-45c7-89bf-7f55d505508f)
+<img src=https://github.com/user-attachments/assets/249b954f-e66e-46a8-8451-ad39e700d564 width=397></img>  
 
 ## Features
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,8 +20,8 @@ Tuw provides a very simple GUI for your scripts.
 All you need is a JSON file and a tiny executable.  
 **No need for compilers, browsers, or huge executables!**  
 
-![sample](https://github.com/user-attachments/assets/17894d27-64fc-45c7-89bf-7f55d505508f)
-<img src=https://github.com/user-attachments/assets/249b954f-e66e-46a8-8451-ad39e700d564 width=397></img>  
+![sample](https://github.com/user-attachments/assets/6426fc08-821f-49f5-af74-965273d45d4a)
+<img src=https://github.com/user-attachments/assets/d770ea1d-cead-405c-a48c-48fe9ba3a4cf width=398></img>  
 
 ## Features
 
@@ -44,9 +44,12 @@ You can download executables from [the release page](https://github.com/matyalat
 -   `Tuw-*-macOS.tar.bz2` is for macOS (10.9 or later.)  
 -   `Tuw-*-Linux-*.tar.bz2` is for Linux (with GTK3.14, GLIBC2.15, and GLIBCXX3.4.21, or later versions of the libraries.)  
 
+> [!Note]
+> Tuw also supports [Linux distributions using musl](https://github.com/matyalatte/tuw/blob/main/docs/Build-on-Linux.md) and [other Unix-like systems (BSD, Haiku, illumos, etc.)](https://github.com/matyalatte/Tuw/blob/main/docs/Build-on-Other.md). While there is no release package available for these systems, you can build Tuw from the source code.
+
 ## Examples
 
-There are some [JSON files](../examples/README.md) to learn how to define GUIs.  
+There are many [JSON files](../examples/README.md) to learn how to define GUIs.  
 
 ## JSON Schema
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,7 @@ For VSCode, you can add the schema path to `settings.json` (`File > Preferences 
 ```json
 "json.schemas": [
     {
-        "fileMatch": [ "gui_definition.json" ],
+        "fileMatch": [ "gui_definition.json", "gui_definition.jsonc" ],
         "url": "https://raw.githubusercontent.com/matyalatte/tuw/main/schema/schema.json"
     }
 ]

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,7 +1,10 @@
+ver 0.8.0
 - Array brackets can now be omitted when there is only one element.
 - GUI elements can now be defined in root object.
 - GUI labels became optional.
 - "window_name" can now be default values of GUI labels.
+- Tuw now redirects stderr into the console window.
+- Replaced std::string with a custom string class to reduce the binary size.
 
 ver 0.7.2
 - Added "optional" to ignore some options when a text box is empty.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,6 @@
+- Array brackets can now be omitted when there is only one element.
+- GUI elements can now be defined in root object.
+
 ver 0.7.2
 - Added "optional" to ignore some options when a text box is empty.
 - Added "prefix" and "suffix" options to append strings to user inputs.

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,5 +1,7 @@
 - Array brackets can now be omitted when there is only one element.
 - GUI elements can now be defined in root object.
+- GUI labels became optional.
+- "window_name" can now be default values of GUI labels.
 
 ver 0.7.2
 - Added "optional" to ignore some options when a text box is empty.

--- a/examples/all_keys/gui_definition.json
+++ b/examples/all_keys/gui_definition.json
@@ -1,6 +1,6 @@
 {
-    "recommended": "0.7.2",
-    "minimum_required": "0.7.1",
+    "recommended": "0.8.0",
+    "minimum_required": "0.8.0",
     "gui": [
         {
             "window_name": "Components Minimal",

--- a/examples/all_keys/gui_definition.json
+++ b/examples/all_keys/gui_definition.json
@@ -3,7 +3,7 @@
     "minimum_required": "0.7.1",
     "gui": [
         {
-            "label": "Components Minimal",
+            "window_name": "Components Minimal",
             "command": "echo file: %-% & echo folder: %-% & echo combo: %-% & echo radio: %-% & echo check: %-% & echo check_array: %-% & echo textbox: %-% & echo int: %-% & echo float: %-%",
             "components": [
                 {
@@ -82,7 +82,7 @@
             ]
         },
         {
-            "label": "Components Optional",
+            "window_name": "Components Optional",
             "command": "echo file: %file% & echo folder: %folder% & echo combo: %combo% & echo radio: %radio% & echo check: %check% & echo check_array: %options% & echo textbox: %text% & echo int: %integer% & echo float: %double%",
             "components": [
                 {
@@ -248,8 +248,8 @@
             ]
         },
         {
-            "label": "GUI Optional",
-            "window_name": "Window Title Here",
+            "window_name": "GUI Optional",
+            "label": "GUI Optional (this string is for a menu item)",
             "command_win": "echo home: %__HOME__% & echo cwd: %__CWD__% & echo percent: %% & echo sample message!",
             "command_linux": "echo home: %__HOME__%; echo cwd: %__CWD__%; echo percent: %%; echo sample message!",
             "command_mac": "echo home: %__HOME__%; echo cwd: %__CWD__%; echo percent: %%; echo sample message!",

--- a/examples/comp_options/affix/README.md
+++ b/examples/comp_options/affix/README.md
@@ -6,19 +6,17 @@
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Affix example",
-            "command": "echo %-%",
-            "components": [
-                {
-                    "type": "text",
-                    "label": "Text box",
-                    "prefix": "-pre=",
-                    "suffix": " -suf"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Affix example",
+        "command": "echo %-%",
+        "components": [
+            {
+                "type": "text",
+                "label": "Text box",
+                "prefix": "-pre=",
+                "suffix": " -suf"
+            }
+        ]
+    }
 }
 ```

--- a/examples/comp_options/affix/README.md
+++ b/examples/comp_options/affix/README.md
@@ -7,7 +7,6 @@
 ```json
 {
     "gui": {
-        "label": "Affix example",
         "command": "echo %-%",
         "components": [
             {

--- a/examples/comp_options/affix/gui_definition.json
+++ b/examples/comp_options/affix/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Affix example",
         "command": "echo %-%",
         "components": [
             {

--- a/examples/comp_options/affix/gui_definition.json
+++ b/examples/comp_options/affix/gui_definition.json
@@ -1,16 +1,14 @@
 {
-    "gui": [
-        {
-            "label": "Affix example",
-            "command": "echo %-%",
-            "components": [
-                {
-                    "type": "text",
-                    "label": "Text box",
-                    "prefix": "-pre=",
-                    "suffix": " -suf"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Affix example",
+        "command": "echo %-%",
+        "components": [
+            {
+                "type": "text",
+                "label": "Text box",
+                "prefix": "-pre=",
+                "suffix": " -suf"
+            }
+        ]
+    }
 }

--- a/examples/comp_options/button/README.md
+++ b/examples/comp_options/button/README.md
@@ -7,24 +7,22 @@ It allows you to rename the button associated with the picker component.
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Button",
-            "window_name": "Button sample",
-            "command": "echo %-% %-%",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "Some file",
-                    "button": "..."
-                },
-                {
-                    "type": "folder",
-                    "label": "Some folder",
-                    "button": "Open"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Button",
+        "window_name": "Button sample",
+        "command": "echo %-% %-%",
+        "components": [
+            {
+                "type": "file",
+                "label": "Some file",
+                "button": "..."
+            },
+            {
+                "type": "folder",
+                "label": "Some folder",
+                "button": "Open"
+            }
+        ]
+    }
 }
 ```

--- a/examples/comp_options/button/README.md
+++ b/examples/comp_options/button/README.md
@@ -8,7 +8,6 @@ It allows you to rename the button associated with the picker component.
 ```json
 {
     "gui": {
-        "label": "Button",
         "window_name": "Button sample",
         "command": "echo %-% %-%",
         "components": [

--- a/examples/comp_options/button/gui_definition.json
+++ b/examples/comp_options/button/gui_definition.json
@@ -1,21 +1,19 @@
 {
-    "gui": [
-        {
-            "label": "Button",
-            "window_name": "Button sample",
-            "command": "echo %-% %-%",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "Some file",
-                    "button": "..."
-                },
-                {
-                    "type": "folder",
-                    "label": "Some folder",
-                    "button": "Open"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Button",
+        "window_name": "Button sample",
+        "command": "echo %-% %-%",
+        "components": [
+            {
+                "type": "file",
+                "label": "Some file",
+                "button": "..."
+            },
+            {
+                "type": "folder",
+                "label": "Some folder",
+                "button": "Open"
+            }
+        ]
+    }
 }

--- a/examples/comp_options/button/gui_definition.json
+++ b/examples/comp_options/button/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Button",
         "window_name": "Button sample",
         "command": "echo %-% %-%",
         "components": [

--- a/examples/comp_options/default/gui_definition.json
+++ b/examples/comp_options/default/gui_definition.json
@@ -1,34 +1,32 @@
 {
-    "gui": [
-        {
-            "label": "Sample GUI",
-            "command": "echo file: %-% & echo options: %-%",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "Some file path",
-                    "extension": "any files (*)|*",
-                    "default": "./foo/bar"
-                },
-                {
-                    "type": "check_array",
-                    "label": "options",
-                    "items": [
-                        {
-                            "label": "falg1",
-                            "default": true
-                        },
-                        {
-                            "label": "falg2",
-                            "default": false
-                        },
-                        {
-                            "label": "falg3",
-                            "default": true
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Sample GUI",
+        "command": "echo file: %-% & echo options: %-%",
+        "components": [
+            {
+                "type": "file",
+                "label": "Some file path",
+                "extension": "any files (*)|*",
+                "default": "./foo/bar"
+            },
+            {
+                "type": "check_array",
+                "label": "options",
+                "items": [
+                    {
+                        "label": "falg1",
+                        "default": true
+                    },
+                    {
+                        "label": "falg2",
+                        "default": false
+                    },
+                    {
+                        "label": "falg3",
+                        "default": true
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/examples/comp_options/default/gui_definition.json
+++ b/examples/comp_options/default/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Sample GUI",
         "command": "echo file: %-% & echo options: %-%",
         "components": [
             {

--- a/examples/comp_options/id/README.md
+++ b/examples/comp_options/id/README.md
@@ -5,7 +5,6 @@ You can use the defined ids as variable names in commands.
 
 ```json
 {
-    "label": "IDs",
     "command": "echo x: %x% & echo y: %y% & echo x: %x%",
     "button": "Echo!",
     "components": [
@@ -29,7 +28,6 @@ When you put an undefined id in `%*%`, it'll use one of the components that have
 
 ```json
 {
-    "label": "Undefined IDs",
     "command": "echo x: %-% & echo y: %y% & echo z: %foo%",
     "button": "Echo!",
     "components": [
@@ -61,7 +59,6 @@ There are some predefined ids.
 
 ```json
 {
-    "label": "Reserved IDs",
     "command": "echo percent: %% & echo cwd: %__CWD__% & echo home: %__HOME__%",
     "button": "Echo!",
     "components": []

--- a/examples/comp_options/optional/README.md
+++ b/examples/comp_options/optional/README.md
@@ -7,7 +7,6 @@
 ```json
 {
     "gui": {
-        "label": "Optional component",
         "command": "echo %-%",
         "components": [
             {

--- a/examples/comp_options/optional/README.md
+++ b/examples/comp_options/optional/README.md
@@ -6,23 +6,21 @@
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Optional component",
-            "command": "echo %-%",
-            "components": [
-                {
-                    "type": "text",
-                    "label": "Text box",
-                    "optional": true,
-                    "prefix": "-pre=",
-                    "suffix": " -suf",
-                    "validator": {
-                        "regex": ".+"
-                    }
+    "gui": {
+        "label": "Optional component",
+        "command": "echo %-%",
+        "components": [
+            {
+                "type": "text",
+                "label": "Text box",
+                "optional": true,
+                "prefix": "-pre=",
+                "suffix": " -suf",
+                "validator": {
+                    "regex": ".+"
                 }
-            ]
-        }
-    ]
+            }
+        ]
+    }
 }
 ```

--- a/examples/comp_options/optional/gui_definition.json
+++ b/examples/comp_options/optional/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Optional component",
         "command": "echo %-%",
         "components": [
             {

--- a/examples/comp_options/optional/gui_definition.json
+++ b/examples/comp_options/optional/gui_definition.json
@@ -1,20 +1,18 @@
 {
-    "gui": [
-        {
-            "label": "Optional component",
-            "command": "echo %-%",
-            "components": [
-                {
-                    "type": "text",
-                    "label": "Text box",
-                    "optional": true,
-                    "prefix": "-pre=",
-                    "suffix": " -suf",
-                    "validator": {
-                        "regex": ".+"
-                    }
+    "gui": {
+        "label": "Optional component",
+        "command": "echo %-%",
+        "components": [
+            {
+                "type": "text",
+                "label": "Text box",
+                "optional": true,
+                "prefix": "-pre=",
+                "suffix": " -suf",
+                "validator": {
+                    "regex": ".+"
                 }
-            ]
-        }
-    ]
+            }
+        ]
+    }
 }

--- a/examples/comp_options/placeholder/README.md
+++ b/examples/comp_options/placeholder/README.md
@@ -7,29 +7,27 @@ It displays a message when the text box is empty.
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Placeholder",
-            "window_name": "Placeholder sample",
-            "command": "echo %-% %-% %-%",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "Some file",
-                    "placeholder": "Drop a file here!"
-                },
-                {
-                    "type": "folder",
-                    "label": "Some folder",
-                    "placeholder": "Drop a folder here!"
-                },
-                {
-                    "type": "text",
-                    "label": "Some text",
-                    "placeholder": "Type here!"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Placeholder",
+        "window_name": "Placeholder sample",
+        "command": "echo %-% %-% %-%",
+        "components": [
+            {
+                "type": "file",
+                "label": "Some file",
+                "placeholder": "Drop a file here!"
+            },
+            {
+                "type": "folder",
+                "label": "Some folder",
+                "placeholder": "Drop a folder here!"
+            },
+            {
+                "type": "text",
+                "label": "Some text",
+                "placeholder": "Type here!"
+            }
+        ]
+    }
 }
 ```

--- a/examples/comp_options/placeholder/README.md
+++ b/examples/comp_options/placeholder/README.md
@@ -8,7 +8,6 @@ It displays a message when the text box is empty.
 ```json
 {
     "gui": {
-        "label": "Placeholder",
         "window_name": "Placeholder sample",
         "command": "echo %-% %-% %-%",
         "components": [

--- a/examples/comp_options/placeholder/gui_definition.json
+++ b/examples/comp_options/placeholder/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Placeholder",
         "window_name": "Placeholder sample",
         "command": "echo %-% %-% %-%",
         "components": [

--- a/examples/comp_options/placeholder/gui_definition.json
+++ b/examples/comp_options/placeholder/gui_definition.json
@@ -1,26 +1,24 @@
 {
-    "gui": [
-        {
-            "label": "Placeholder",
-            "window_name": "Placeholder sample",
-            "command": "echo %-% %-% %-%",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "Some file",
-                    "placeholder": "Drop a file here!"
-                },
-                {
-                    "type": "folder",
-                    "label": "Some folder",
-                    "placeholder": "Drop a folder here!"
-                },
-                {
-                    "type": "text",
-                    "label": "Some text",
-                    "placeholder": "Type here!"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Placeholder",
+        "window_name": "Placeholder sample",
+        "command": "echo %-% %-% %-%",
+        "components": [
+            {
+                "type": "file",
+                "label": "Some file",
+                "placeholder": "Drop a file here!"
+            },
+            {
+                "type": "folder",
+                "label": "Some folder",
+                "placeholder": "Drop a folder here!"
+            },
+            {
+                "type": "text",
+                "label": "Some text",
+                "placeholder": "Type here!"
+            }
+        ]
+    }
 }

--- a/examples/comp_options/tooltip/gui_definition.json
+++ b/examples/comp_options/tooltip/gui_definition.json
@@ -1,43 +1,41 @@
 {
-    "gui": [
-        {
-            "label": "Sample GUI",
-            "command": "echo file: %-% & echo folder: %-% & echo options: %-%",
-            "components": [
-                {
-                    "type": "static_text",
-                    "label": "Move the mouse cursor to components to see tooltip messages!"
-                },
-                {
-                    "type": "file",
-                    "label": "Some file path",
-                    "extension": "any files (*)|*",
-                    "tooltip": "tooltip for file path!"
-                },
-                {
-                    "type": "folder",
-                    "label": "Some folder path",
-                    "tooltip": "tooltip for folder path!"
-                },
-                {
-                    "type": "check_array",
-                    "label": "options",
-                    "items": [
-                        {
-                            "label": "falg1",
-                            "tooltip": "tooltip for flag1!"
-                        },
-                        {
-                            "label": "falg2",
-                            "tooltip": "flag2!"
-                        },
-                        {
-                            "label": "falg3",
-                            "tooltip": "flag3..."
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Sample GUI",
+        "command": "echo file: %-% & echo folder: %-% & echo options: %-%",
+        "components": [
+            {
+                "type": "static_text",
+                "label": "Move the mouse cursor to components to see tooltip messages!"
+            },
+            {
+                "type": "file",
+                "label": "Some file path",
+                "extension": "any files (*)|*",
+                "tooltip": "tooltip for file path!"
+            },
+            {
+                "type": "folder",
+                "label": "Some folder path",
+                "tooltip": "tooltip for folder path!"
+            },
+            {
+                "type": "check_array",
+                "label": "options",
+                "items": [
+                    {
+                        "label": "falg1",
+                        "tooltip": "tooltip for flag1!"
+                    },
+                    {
+                        "label": "falg2",
+                        "tooltip": "flag2!"
+                    },
+                    {
+                        "label": "falg3",
+                        "tooltip": "flag3..."
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/examples/comp_options/tooltip/gui_definition.json
+++ b/examples/comp_options/tooltip/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Sample GUI",
         "command": "echo file: %-% & echo folder: %-% & echo options: %-%",
         "components": [
             {

--- a/examples/components/check_boxes/gui_definition.json
+++ b/examples/components/check_boxes/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Check Boxes",
         "command": "echo checkbox: %-% & echo options:%-%",
         "button": "Echo!",
         "components": [

--- a/examples/components/check_boxes/gui_definition.json
+++ b/examples/components/check_boxes/gui_definition.json
@@ -1,34 +1,32 @@
 {
-    "gui": [
-        {
-            "label": "Check Boxes",
-            "command": "echo checkbox: %-% & echo options:%-%",
-            "button": "Echo!",
-            "components": [
-                {
-                    "type": "check",
-                    "label": "checkbox",
-                    "value": "checked!"
-                },
-                {
-                    "type": "check_array",
-                    "label": "options",
-                    "items": [
-                        {
-                            "label": "flag1",
-                            "value": " -f1"
-                        },
-                        {
-                            "label": "flag2",
-                            "value": " -f2"
-                        },
-                        {
-                            "label": "flag3",
-                            "value": " -f3"
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Check Boxes",
+        "command": "echo checkbox: %-% & echo options:%-%",
+        "button": "Echo!",
+        "components": [
+            {
+                "type": "check",
+                "label": "checkbox",
+                "value": "checked!"
+            },
+            {
+                "type": "check_array",
+                "label": "options",
+                "items": [
+                    {
+                        "label": "flag1",
+                        "value": " -f1"
+                    },
+                    {
+                        "label": "flag2",
+                        "value": " -f2"
+                    },
+                    {
+                        "label": "flag3",
+                        "value": " -f3"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/examples/components/choices/gui_definition.json
+++ b/examples/components/choices/gui_definition.json
@@ -1,45 +1,43 @@
 {
-    "gui": [
-        {
-            "label": "Component Sample",
-            "command": "echo combo: %a% & echo radio: %b%",
-            "button": "Echo!",
-            "components": [
-                {
-                    "type": "combo",
-                    "label": "Combo box",
-                    "items": [
-                        {
-                            "label": "one",
-                            "value": "1"
-                        },
-                        {
-                            "label": "two",
-                            "value": "2"
-                        },
-                        {
-                            "label": "3"
-                        }
-                    ]
-                },
-                {
-                    "type": "radio",
-                    "label": "Radio buttons",
-                    "items": [
-                        {
-                            "label": "one",
-                            "value": "1"
-                        },
-                        {
-                            "label": "two",
-                            "value": "2"
-                        },
-                        {
-                            "label": "3"
-                        }
-                    ]
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Component Sample",
+        "command": "echo combo: %a% & echo radio: %b%",
+        "button": "Echo!",
+        "components": [
+            {
+                "type": "combo",
+                "label": "Combo box",
+                "items": [
+                    {
+                        "label": "one",
+                        "value": "1"
+                    },
+                    {
+                        "label": "two",
+                        "value": "2"
+                    },
+                    {
+                        "label": "3"
+                    }
+                ]
+            },
+            {
+                "type": "radio",
+                "label": "Radio buttons",
+                "items": [
+                    {
+                        "label": "one",
+                        "value": "1"
+                    },
+                    {
+                        "label": "two",
+                        "value": "2"
+                    },
+                    {
+                        "label": "3"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/examples/components/choices/gui_definition.json
+++ b/examples/components/choices/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Component Sample",
         "command": "echo combo: %a% & echo radio: %b%",
         "button": "Echo!",
         "components": [

--- a/examples/components/num_pickers/gui_definition.json
+++ b/examples/components/num_pickers/gui_definition.json
@@ -1,27 +1,25 @@
 {
-    "gui": [
-        {
-            "label": "Select numbers",
-            "window_name": "Picker sample",
-            "command": "echo int: %-% & echo float: %-%",
-            "components": [
-                {
-                    "type": "int",
-                    "label": "Integer",
-                    "min": 0,
-                    "max": 100,
-                    "inc": 10,
-                    "wrap": true
-                },
-                {
-                    "type": "float",
-                    "label": "Floating-point number",
-                    "min": 0,
-                    "max": 1,
-                    "inc": 0.01,
-                    "digits": 2
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Select numbers",
+        "window_name": "Picker sample",
+        "command": "echo int: %-% & echo float: %-%",
+        "components": [
+            {
+                "type": "int",
+                "label": "Integer",
+                "min": 0,
+                "max": 100,
+                "inc": 10,
+                "wrap": true
+            },
+            {
+                "type": "float",
+                "label": "Floating-point number",
+                "min": 0,
+                "max": 1,
+                "inc": 0.01,
+                "digits": 2
+            }
+        ]
+    }
 }

--- a/examples/components/num_pickers/gui_definition.json
+++ b/examples/components/num_pickers/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Select numbers",
         "window_name": "Picker sample",
         "command": "echo int: %-% & echo float: %-%",
         "components": [

--- a/examples/components/other_components/gui_definition.json
+++ b/examples/components/other_components/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Component Sample",
         "command": "echo textbox: %c%",
         "button": "Echo!",
         "components": [

--- a/examples/components/other_components/gui_definition.json
+++ b/examples/components/other_components/gui_definition.json
@@ -1,19 +1,17 @@
 {
-    "gui": [
-        {
-            "label": "Component Sample",
-            "command": "echo textbox: %c%",
-            "button": "Echo!",
-            "components": [
-                {
-                    "type": "static_text",
-                    "label": "This is a sample GUI. Edit 'gui_definition.json' for your scripts."
-                },
-                {
-                    "type": "text",
-                    "label": "Some text"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Component Sample",
+        "command": "echo textbox: %c%",
+        "button": "Echo!",
+        "components": [
+            {
+                "type": "static_text",
+                "label": "This is a sample GUI. Edit 'gui_definition.json' for your scripts."
+            },
+            {
+                "type": "text",
+                "label": "Some text"
+            }
+        ]
+    }
 }

--- a/examples/components/path_pickers/README.md
+++ b/examples/components/path_pickers/README.md
@@ -7,27 +7,25 @@ Of course, you can drop files on the pickers to specify the paths.
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Copy file",
-            "window_name": "Picker sample",
-            "command": "copy %foo% %bar%",
-            "button": "copy",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "PNG file you want to copy",
-                    "extension": "PNG files (*.png)|*.png",
-                    "add_quotes": true
-                },
-                {
-                    "type": "folder",
-                    "label": "Output path",
-                    "add_quotes": true
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Copy file",
+        "window_name": "Picker sample",
+        "command": "copy %foo% %bar%",
+        "button": "copy",
+        "components": [
+            {
+                "type": "file",
+                "label": "PNG file you want to copy",
+                "extension": "PNG files (*.png)|*.png",
+                "add_quotes": true
+            },
+            {
+                "type": "folder",
+                "label": "Output path",
+                "add_quotes": true
+            }
+        ]
+    }
 }
 ```
 

--- a/examples/components/path_pickers/README.md
+++ b/examples/components/path_pickers/README.md
@@ -8,7 +8,6 @@ Of course, you can drop files on the pickers to specify the paths.
 ```json
 {
     "gui": {
-        "label": "Copy file",
         "window_name": "Picker sample",
         "command": "copy %foo% %bar%",
         "button": "copy",

--- a/examples/components/path_pickers/gui_definition.json
+++ b/examples/components/path_pickers/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Copy file",
         "window_name": "Picker sample",
         "command": "copy %foo% %bar%",
         "button": "copy",

--- a/examples/components/path_pickers/gui_definition.json
+++ b/examples/components/path_pickers/gui_definition.json
@@ -1,23 +1,21 @@
 {
-    "gui": [
-        {
-            "label": "Copy file",
-            "window_name": "Picker sample",
-            "command": "copy %foo% %bar%",
-            "button": "copy",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "PNG file you want to copy",
-                    "extension": "PNG files (*.png)|*.png",
-                    "add_quotes": true
-                },
-                {
-                    "type": "folder",
-                    "label": "Output path",
-                    "add_quotes": true
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Copy file",
+        "window_name": "Picker sample",
+        "command": "copy %foo% %bar%",
+        "button": "copy",
+        "components": [
+            {
+                "type": "file",
+                "label": "PNG file you want to copy",
+                "extension": "PNG files (*.png)|*.png",
+                "add_quotes": true
+            },
+            {
+                "type": "folder",
+                "label": "Output path",
+                "add_quotes": true
+            }
+        ]
+    }
 }

--- a/examples/get_start/json_embed/gui_definition.json
+++ b/examples/get_start/json_embed/gui_definition.json
@@ -20,7 +20,7 @@
                     "id": "merged_exe",
                     "default": "Tuw.new.exe",
                     "add_quotes": true,
-                    "platforms": ["win"]
+                    "platforms": "win"
                 },
                 {
                     "type": "file",
@@ -45,7 +45,7 @@
                     "id": "merged_exe",
                     "default": "Tuw.new.exe",
                     "add_quotes": true,
-                    "platforms": ["win"]
+                    "platforms": "win"
                 },
                 {
                     "type": "file",
@@ -68,7 +68,7 @@
                     "id": "orig_exe",
                     "default": "Tuw.orig.exe",
                     "add_quotes": true,
-                    "platforms": ["win"]
+                    "platforms": "win"
                 },
                 {
                     "type": "file",

--- a/examples/get_start/minimal/README.md
+++ b/examples/get_start/minimal/README.md
@@ -9,17 +9,15 @@ It has only a button to echo `Hello!`.
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Minimal Sample",
-            "command": "echo Hello!",
-            "components": []
-        }
-    ]
+    "gui": {
+        "label": "Minimal Sample",
+        "command": "echo Hello!",
+        "components": []
+    }
 }
 ```
 
-You can write a definition of your GUI in `"gui": [{}]`.  
+You can write a definition of your GUI in `"gui": {}`.  
 
 -   `label` is the label for your definition. You can type anything you like here.
 -   `command` is the command you want to execute when clicking the execution button.

--- a/examples/get_start/minimal/README.md
+++ b/examples/get_start/minimal/README.md
@@ -10,7 +10,6 @@ It has only a button to echo `Hello!`.
 ```json
 {
     "gui": {
-        "label": "Minimal Sample",
         "command": "echo Hello!",
         "components": []
     }
@@ -19,6 +18,5 @@ It has only a button to echo `Hello!`.
 
 You can write a definition of your GUI in `"gui": {}`.  
 
--   `label` is the label for your definition. You can type anything you like here.
 -   `command` is the command you want to execute when clicking the execution button.
 -   `components` is an array of GUI components (e.g., file pickers). `[]` means no components.

--- a/examples/get_start/minimal/gui_definition.json
+++ b/examples/get_start/minimal/gui_definition.json
@@ -1,9 +1,7 @@
 {
-    "gui": [
-        {
-            "label": "Minimal Sample",
-            "command": "echo Hello!",
-            "components": []
-        }
-    ]
+    "gui": {
+        "label": "Minimal Sample",
+        "command": "echo Hello!",
+        "components": []
+    }
 }

--- a/examples/get_start/minimal/gui_definition.json
+++ b/examples/get_start/minimal/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Minimal Sample",
         "command": "echo Hello!",
         "components": []
     }

--- a/examples/get_start/put_component/README.md
+++ b/examples/get_start/put_component/README.md
@@ -6,20 +6,18 @@ You can put a text box in the GUI.
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Text Box Sample",
-            "window_name": "Title here!",
-            "command": "echo %-%",
-            "button": "Hello!",
-            "components": [
-                {
-                    "type": "text",
-                    "label": "Type 'Hello!'"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Text Box Sample",
+        "window_name": "Title here!",
+        "command": "echo %-%",
+        "button": "Hello!",
+        "components": [
+            {
+                "type": "text",
+                "label": "Type 'Hello!'"
+            }
+        ]
+    }
 }
 ```
 
@@ -44,19 +42,17 @@ In the example, the value of the text box will be injected at `%-%`.
 You can also use the [`id`](../../comp_options/id) option to name the components like variables.  
 
 ```json
-"gui": [
-    {
-        "label": "Text Box Sample",
-        "window_name": "Title here!",
-        "command": "echo %foo%, %foo%",
-        "button": "Hello!",
-        "components": [
-            {
-                "type": "text",
-                "label": "Type 'Hello!'",
-                "id": "foo"
-            }
-        ]
-    }
-]
+"gui": {
+    "label": "Text Box Sample",
+    "window_name": "Title here!",
+    "command": "echo %foo%, %foo%",
+    "button": "Hello!",
+    "components": [
+        {
+            "type": "text",
+            "label": "Type 'Hello!'",
+            "id": "foo"
+        }
+    ]
+}
 ```

--- a/examples/get_start/put_component/README.md
+++ b/examples/get_start/put_component/README.md
@@ -7,7 +7,6 @@ You can put a text box in the GUI.
 ```json
 {
     "gui": {
-        "label": "Text Box Sample",
         "window_name": "Title here!",
         "command": "echo %-%",
         "button": "Hello!",

--- a/examples/get_start/put_component/gui_definition.json
+++ b/examples/get_start/put_component/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Minimal Sample",
         "window_name": "Title here!",
         "command": "echo %-%",
         "button": "Hello!",

--- a/examples/get_start/put_component/gui_definition.json
+++ b/examples/get_start/put_component/gui_definition.json
@@ -1,16 +1,14 @@
 {
-    "gui": [
-        {
-            "label": "Minimal Sample",
-            "window_name": "Title here!",
-            "command": "echo %-%",
-            "button": "Hello!",
-            "components": [
-                {
-                    "type": "text",
-                    "label": "Type 'Hello!'"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Minimal Sample",
+        "window_name": "Title here!",
+        "command": "echo %-%",
+        "button": "Hello!",
+        "components": [
+            {
+                "type": "text",
+                "label": "Type 'Hello!'"
+            }
+        ]
+    }
 }

--- a/examples/get_start/title_button/README.md
+++ b/examples/get_start/title_button/README.md
@@ -7,7 +7,6 @@ You can rename the window title and the execution button.
 ```json
 {
     "gui": {
-        "label": "Minimal Sample",
         "window_name": "Title here!",
         "command": "echo Hello!",
         "button": "Hello!",

--- a/examples/get_start/title_button/README.md
+++ b/examples/get_start/title_button/README.md
@@ -6,15 +6,13 @@ You can rename the window title and the execution button.
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Minimal Sample",
-            "window_name": "Title here!",
-            "command": "echo Hello!",
-            "button": "Hello!",
-            "components": []
-        }
-    ]
+    "gui": {
+        "label": "Minimal Sample",
+        "window_name": "Title here!",
+        "command": "echo Hello!",
+        "button": "Hello!",
+        "components": []
+    }
 }
 ```
 

--- a/examples/get_start/title_button/gui_definition.json
+++ b/examples/get_start/title_button/gui_definition.json
@@ -1,11 +1,9 @@
 {
-    "gui": [
-        {
-            "label": "Minimal Sample",
-            "window_name": "Title here!",
-            "command": "echo Hello!",
-            "button": "Hello!",
-            "components": []
-        }
-    ]
+    "gui": {
+        "label": "Minimal Sample",
+        "window_name": "Title here!",
+        "command": "echo Hello!",
+        "button": "Hello!",
+        "components": []
+    }
 }

--- a/examples/get_start/title_button/gui_definition.json
+++ b/examples/get_start/title_button/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Minimal Sample",
         "window_name": "Title here!",
         "command": "echo Hello!",
         "button": "Hello!",

--- a/examples/other_features/alternate_spellings/gui_definition.json
+++ b/examples/other_features/alternate_spellings/gui_definition.json
@@ -1,6 +1,5 @@
 {
     "gui": {
-        "label": "Alternate Spellings",
         "command": "echo folder: %-% & echo combo: %-% & echo check_array: %-% & echo textbox: %-% & echo int: %-%",
         "title": "Alternate Spellings Sample",
         "component_array": [

--- a/examples/other_features/alternate_spellings/gui_definition.json
+++ b/examples/other_features/alternate_spellings/gui_definition.json
@@ -1,59 +1,57 @@
 {
-    "gui": [
-        {
-            "label": "Alternate Spellings",
-            "command": "echo folder: %-% & echo combo: %-% & echo check_array: %-% & echo textbox: %-% & echo int: %-%",
-            "title": "Alternate Spellings Sample",
-            "component_array": [
-                {
-                    "type": "static_text",
-                    "label": "Still working with alternate spellings!"
-                },
-                {
-                    "type": "dir",
-                    "label": "Some folder path",
-                    "empty_message": "placeholder!",
-                    "add_quote": true
-                },
-                {
-                    "type": "choice",
-                    "label": "combo box",
-                    "item_array": [
-                        {
-                            "label": "value1"
-                        },
-                        {
-                            "label": "value2"
-                        },
-                        {
-                            "label": "value3"
-                        }
-                    ]
-                },
-                {
-                    "type": "checks",
-                    "label": "options",
-                    "item_array": [
-                        {
-                            "label": "flag1"
-                        },
-                        {
-                            "label": "flag2"
-                        },
-                        {
-                            "label": "flag3"
-                        }
-                    ]
-                },
-                {
-                    "type": "text_box",
-                    "label": "text box"
-                },
-                {
-                    "type": "integer",
-                    "label": "Int picker"
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Alternate Spellings",
+        "command": "echo folder: %-% & echo combo: %-% & echo check_array: %-% & echo textbox: %-% & echo int: %-%",
+        "title": "Alternate Spellings Sample",
+        "component_array": [
+            {
+                "type": "static_text",
+                "label": "Still working with alternate spellings!"
+            },
+            {
+                "type": "dir",
+                "label": "Some folder path",
+                "empty_message": "placeholder!",
+                "add_quote": true
+            },
+            {
+                "type": "choice",
+                "label": "combo box",
+                "item_array": [
+                    {
+                        "label": "value1"
+                    },
+                    {
+                        "label": "value2"
+                    },
+                    {
+                        "label": "value3"
+                    }
+                ]
+            },
+            {
+                "type": "checks",
+                "label": "options",
+                "item_array": [
+                    {
+                        "label": "flag1"
+                    },
+                    {
+                        "label": "flag2"
+                    },
+                    {
+                        "label": "flag3"
+                    }
+                ]
+            },
+            {
+                "type": "text_box",
+                "label": "text box"
+            },
+            {
+                "type": "integer",
+                "label": "Int picker"
+            }
+        ]
+    }
 }

--- a/examples/other_features/codepage/README.md
+++ b/examples/other_features/codepage/README.md
@@ -4,14 +4,12 @@ Tuw expects user's default locale for stdout on Windows. If you want to use UTF-
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Use UTF-8 outputs on Windows",
-            "command": "powershell -ExecutionPolicy Bypass -File \"utf.ps1\"",
-            "codepage": "utf8",
-            "components": []
-        }
-    ]
+    "gui": {
+        "label": "Use UTF-8 outputs on Windows",
+        "command": "powershell -ExecutionPolicy Bypass -File \"utf.ps1\"",
+        "codepage": "utf8",
+        "components": []
+    }
 }
 ```
 

--- a/examples/other_features/codepage/README.md
+++ b/examples/other_features/codepage/README.md
@@ -5,7 +5,7 @@ Tuw expects user's default locale for stdout on Windows. If you want to use UTF-
 ```json
 {
     "gui": {
-        "label": "Use UTF-8 outputs on Windows",
+        "window_name": "Use UTF-8 outputs on Windows",
         "command": "powershell -ExecutionPolicy Bypass -File \"utf.ps1\"",
         "codepage": "utf8",
         "components": []

--- a/examples/other_features/codepage/gui_definition.json
+++ b/examples/other_features/codepage/gui_definition.json
@@ -1,6 +1,6 @@
 {
     "gui": {
-        "label": "Use UTF-8 outputs on Windows",
+        "window_name": "Use UTF-8 outputs on Windows",
         "command": "powershell -ExecutionPolicy Bypass -File \"utf.ps1\"",
         "codepage": "utf8",
         "components": []

--- a/examples/other_features/codepage/gui_definition.json
+++ b/examples/other_features/codepage/gui_definition.json
@@ -1,10 +1,8 @@
 {
-    "gui": [
-        {
-            "label": "Use UTF-8 outputs on Windows",
-            "command": "powershell -ExecutionPolicy Bypass -File \"utf.ps1\"",
-            "codepage": "utf8",
-            "components": []
-        }
-    ]
+    "gui": {
+        "label": "Use UTF-8 outputs on Windows",
+        "command": "powershell -ExecutionPolicy Bypass -File \"utf.ps1\"",
+        "codepage": "utf8",
+        "components": []
+    }
 }

--- a/examples/other_features/cross_platform/README.md
+++ b/examples/other_features/cross_platform/README.md
@@ -14,7 +14,6 @@ Tuw will use the platform-specific command instead of the default `command` valu
 
 ```json
 {
-    "label": "Platform Specific Commands",
     "command_win": "echo Windows!",
     "command_mac": "echo macOS!",
     "command_linux": "echo Linux!",
@@ -35,7 +34,6 @@ Tuw will ignore the component if the current OS does not match the specified pla
 
 ```json
 {
-    "label": "Platform Specific Components",
     "command": "echo %os%",
     "show_last_line": true,
     "components": [

--- a/examples/other_features/cross_platform/README.md
+++ b/examples/other_features/cross_platform/README.md
@@ -44,7 +44,7 @@ Tuw will ignore the component if the current OS does not match the specified pla
             "label": "Windows!",
             "id": "os",
             "default": true,
-            "platforms": [ "win" ]
+            "platforms": "win"
         },
         {
             "type": "check",

--- a/examples/other_features/cross_platform/gui_definition.json
+++ b/examples/other_features/cross_platform/gui_definition.json
@@ -18,7 +18,7 @@
                     "label": "Windows!",
                     "id": "os",
                     "default": true,
-                    "platforms": [ "win" ]
+                    "platforms": "win"
                 },
                 {
                     "type": "check",

--- a/examples/other_features/error/README.md
+++ b/examples/other_features/error/README.md
@@ -8,13 +8,8 @@ When the executed command outputs something to `stderr`, Tuw will display an err
 
 ```json
 {
-    "gui": [
-        {
-            "label": "Error Sample",
-            "command": "notcommand",
-            "components": []
-        }
-    ]
+    "command": "notcommand",
+    "components": []
 }
 ```
 
@@ -26,7 +21,6 @@ You can also customize the success code using the `exit_success` option.
 
 ```json
 {
-    "label": "check_exit_code Sample",
     "command": "echo exit code is zero.",
     "check_exit_code": true,
     "exit_success": 10,
@@ -44,7 +38,6 @@ When `check_exit_code` is enabled, it can also show the last line in the error d
 
 ```json
 {
-    "label": "show_last_line Sample",
     "command": "echo Fake Error!",
     "show_last_line": true,
     "components": []

--- a/examples/other_features/help/gui_definition.json
+++ b/examples/other_features/help/gui_definition.json
@@ -1,30 +1,28 @@
 {
-    "gui": [
-        {
-            "label": "Sample GUI",
-            "command": "echo file: %-% & echo folder: %-% & echo checkbox: %-%",
-            "components": [
-                {
-                    "type": "static_text",
-                    "label": "This is a sample GUI. Edit 'gui_definition.json' for your scripts."
-                },
-                {
-                    "type": "file",
-                    "label": "Some file path",
-                    "extension": "any files (*)|*",
-                    "placeholder": "Drop a file here!"
-                },
-                {
-                    "type": "folder",
-                    "label": "Some folder path"
-                },
-                {
-                    "type": "check",
-                    "label": "flag"
-                }
-            ]
-        }
-    ],
+    "gui": {
+        "label": "Sample GUI",
+        "command": "echo file: %-% & echo folder: %-% & echo checkbox: %-%",
+        "components": [
+            {
+                "type": "static_text",
+                "label": "This is a sample GUI. Edit 'gui_definition.json' for your scripts."
+            },
+            {
+                "type": "file",
+                "label": "Some file path",
+                "extension": "any files (*)|*",
+                "placeholder": "Drop a file here!"
+            },
+            {
+                "type": "folder",
+                "label": "Some folder path"
+            },
+            {
+                "type": "check",
+                "label": "flag"
+            }
+        ]
+    },
     "help": [
         {
             "type": "url",

--- a/examples/other_features/help/gui_definition.json
+++ b/examples/other_features/help/gui_definition.json
@@ -1,6 +1,6 @@
 {
     "gui": {
-        "label": "Sample GUI",
+        "window_name": "Sample GUI",
         "command": "echo file: %-% & echo folder: %-% & echo checkbox: %-%",
         "components": [
             {

--- a/examples/other_features/multiple/README.md
+++ b/examples/other_features/multiple/README.md
@@ -1,6 +1,37 @@
 # Multiple Definitions
 
 `"gui"` can be an array of gui definitions.
-Users can select one of the definitions from the `Menu` in the executable.  
+Users can select one of these definitions from the `Menu` in the executable.
+You can also use `"label"` to modify strings that are displayed in the menu bar.
+When `"label"` is not defined, `"window_name"` will be used as the GUI label.  
 
 ![advanced](https://github.com/matyalatte/tuw/assets/69258547/956be42e-6931-4b71-ae3c-180103a93714)  
+
+```json
+{
+    "gui": [
+        {
+            "label": "Sample GUI",
+            "command": "echo file: %-%",
+            "button": "Echo!",
+            "components": [
+                {
+                    "type": "file",
+                    "label": "Some file path"
+                }
+            ]
+        },
+        {
+            "window_name": "Sample GUI2",
+            "command": "echo text_box: %-%",
+            "button": "Echo!",
+            "components": [
+                {
+                    "type": "text",
+                    "label": "Some text"
+                }
+            ]
+        }
+    ]
+}
+```

--- a/examples/other_features/multiple/README.md
+++ b/examples/other_features/multiple/README.md
@@ -1,6 +1,6 @@
 # Multiple Definitions
 
-You can put multiple definitions in `"gui": []`.  
-These definitions can be selected from the `Menu` in the executable.  
+`"gui"` can be an array of gui definitions.
+Users can select one of the definitions from the `Menu` in the executable.  
 
 ![advanced](https://github.com/matyalatte/tuw/assets/69258547/956be42e-6931-4b71-ae3c-180103a93714)  

--- a/examples/other_features/multiple/gui_definition.json
+++ b/examples/other_features/multiple/gui_definition.json
@@ -2,64 +2,23 @@
     "gui": [
         {
             "label": "Sample GUI",
-            "command": "echo file: %-% & echo folder: %-% & echo checkbox: %-%",
+            "command": "echo file: %-%",
             "button": "Echo!",
             "components": [
                 {
-                    "type": "static_text",
-                    "label": "This is a sample GUI. Edit 'gui_definition.json' for your scripts."
-                },
-                {
                     "type": "file",
-                    "label": "Some file path",
-                    "extension": "any files (*)|*",
-                    "placeholder": "Drop a file here!"
-                },
-                {
-                    "type": "folder",
-                    "label": "Some folder path"
-                },
-                {
-                    "type": "check",
-                    "label": "checkbox",
-                    "value": "true",
-                    "default": true
+                    "label": "Some file path"
                 }
             ]
         },
         {
-            "label": "Sample GUI2",
-            "command": "echo text_box: %-% & echo options:%-%",
+            "window_name": "Sample GUI2",
+            "command": "echo text_box: %-%",
             "button": "Echo!",
             "components": [
                 {
-                    "type": "static_text",
-                    "label": "This is a sample GUI. Edit 'gui_definition.json' for your scripts."
-                },
-                {
                     "type": "text",
                     "label": "Some text"
-                },
-                {
-                    "type": "check_array",
-                    "label": "options",
-                    "items": [
-                        {
-                            "label": "option1",
-                            "value": "--opt1",
-                            "default": true
-                        },
-                        {
-                            "label": "option2",
-                            "value": "--opt2",
-                            "default": false
-                        },
-                        {
-                            "label": "option3",
-                            "value": "--opt3",
-                            "default": false
-                        }
-                    ]
                 }
             ]
         }

--- a/examples/other_features/skip_dialog/README.md
+++ b/examples/other_features/skip_dialog/README.md
@@ -4,12 +4,10 @@ You can disable the success dialog with `"show_success_dialog": false`.
 Tuw will refrain from showing the dialog regardless of how many times you push the execution button.
 
 ```json
-"gui": [
-    {
-        "label": "Skip dialog",
-        "command": "echo No dialogues...",
-        "show_success_dialog": false,
-        "components": []
-    }
-]
+"gui": {
+    "label": "Skip dialog",
+    "command": "echo No dialogues...",
+    "show_success_dialog": false,
+    "components": []
+}
 ```

--- a/examples/other_features/skip_dialog/README.md
+++ b/examples/other_features/skip_dialog/README.md
@@ -5,7 +5,7 @@ Tuw will refrain from showing the dialog regardless of how many times you push t
 
 ```json
 "gui": {
-    "label": "Skip dialog",
+    "window_name": "Skip dialog",
     "command": "echo No dialogues...",
     "show_success_dialog": false,
     "components": []

--- a/examples/other_features/skip_dialog/gui_definition.json
+++ b/examples/other_features/skip_dialog/gui_definition.json
@@ -1,10 +1,8 @@
 {
-    "gui": [
-        {
-            "label": "Skip dialog",
-            "command": "echo No dialogues...",
-            "show_success_dialog": false,
-            "components": []
-        }
-    ]
+    "gui": {
+        "label": "Skip dialog",
+        "command": "echo No dialogues...",
+        "show_success_dialog": false,
+        "components": []
+    }
 }

--- a/examples/other_features/skip_dialog/gui_definition.json
+++ b/examples/other_features/skip_dialog/gui_definition.json
@@ -1,6 +1,6 @@
 {
     "gui": {
-        "label": "Skip dialog",
+        "window_name": "Skip dialog",
         "command": "echo No dialogues...",
         "show_success_dialog": false,
         "components": []

--- a/examples/other_features/version_check/README.md
+++ b/examples/other_features/version_check/README.md
@@ -14,7 +14,7 @@ There are two options for checking the tool version.
     "recommended": "2.1.0",
     "minimum_required": "2.0.0",
     "gui": {
-        "label": "You can't see this GUI.",
+        "window_name": "You can't see this GUI.",
         "command": "echo Hello!",
         "components": []
     }

--- a/examples/other_features/version_check/README.md
+++ b/examples/other_features/version_check/README.md
@@ -11,14 +11,12 @@ There are two options for checking the tool version.
 
 ```json
 {
-    "recommended": "1.1.0",
-    "minimum_required": "1.0.0",
-    "gui": [
-        {
-            "label": "You can't see this GUI.",
-            "command": "echo Hello!",
-            "components": []
-        }
-    ]
+    "recommended": "2.1.0",
+    "minimum_required": "2.0.0",
+    "gui": {
+        "label": "You can't see this GUI.",
+        "command": "echo Hello!",
+        "components": []
+    }
 }
 ```

--- a/examples/other_features/version_check/gui_definition.json
+++ b/examples/other_features/version_check/gui_definition.json
@@ -2,7 +2,7 @@
     "recommended": "2.1.0",
     "minimum_required": "2.0.0",
     "gui": {
-        "label": "You can't see this GUI.",
+        "window_name": "You can't see this GUI.",
         "command": "echo Hello!",
         "components": []
     }

--- a/examples/other_features/version_check/gui_definition.json
+++ b/examples/other_features/version_check/gui_definition.json
@@ -1,11 +1,9 @@
 {
-    "recommended": "1.1.0",
-    "minimum_required": "1.0.0",
-    "gui": [
-        {
-            "label": "You can't see this GUI.",
-            "command": "echo Hello!",
-            "components": []
-        }
-    ]
+    "recommended": "2.1.0",
+    "minimum_required": "2.0.0",
+    "gui": {
+        "label": "You can't see this GUI.",
+        "command": "echo Hello!",
+        "components": []
+    }
 }

--- a/examples/tips/comments/README.md
+++ b/examples/tips/comments/README.md
@@ -9,7 +9,7 @@ Tuw supports the [JSON with Comments](https://code.visualstudio.com/docs/languag
      * Multi-line comment
      */
     "gui": {
-        "label": "JSON with Comments",
+        "window_name": "JSON with Comments",
         "command": "echo Hello!",
         "components": [],
         // You can put a trailing comma after the last element.

--- a/examples/tips/comments/README.md
+++ b/examples/tips/comments/README.md
@@ -8,14 +8,12 @@ Tuw supports the [JSON with Comments](https://code.visualstudio.com/docs/languag
     /*
      * Multi-line comment
      */
-    "gui": [
-        {
-            "label": "JSON with Comments",
-            "command": "echo Hello!",
-            "components": [],
-            // You can put a trailing comma after the last element.
-            "": "",
-        }
-    ]
+    "gui": {
+        "label": "JSON with Comments",
+        "command": "echo Hello!",
+        "components": [],
+        // You can put a trailing comma after the last element.
+        "": "",
+    }
 }
 ```

--- a/examples/tips/comments/gui_definition.jsonc
+++ b/examples/tips/comments/gui_definition.jsonc
@@ -4,7 +4,7 @@
      * Multi-line comment
      */
     "gui": {
-        "label": "JSON with Comments",
+        "window_name": "JSON with Comments",
         "command": "echo Hello!",
         "components": [],
         // You can put a trailing comma after the last element.

--- a/examples/tips/comments/gui_definition.jsonc
+++ b/examples/tips/comments/gui_definition.jsonc
@@ -3,13 +3,11 @@
     /*
      * Multi-line comment
      */
-    "gui": [
-        {
-            "label": "JSON with Comments",
-            "command": "echo Hello!",
-            "components": [],
-            // You can put a trailing comma after the last element.
-            "": "",
-        }
-    ]
+    "gui": {
+        "label": "JSON with Comments",
+        "command": "echo Hello!",
+        "components": [],
+        // You can put a trailing comma after the last element.
+        "": "",
+    }
 }

--- a/examples/tips/multi_lines/README.md
+++ b/examples/tips/multi_lines/README.md
@@ -10,9 +10,9 @@ But you can see some examples for it.
 On windows, you can join the commands with ` && `.  
 And some commands like `for` loop require parentheses `()`.
 
-```json
+```jsonc
 {
-    "label": "Search json in a folder (Windows)",
+    // Search json in a folder (Windows)
     "command": "@echo off && (for %%f in (\"%dir%\\*.json\") do (echo %%f)) && echo Done!",
     "button": "Echo!",
     "components": [
@@ -28,9 +28,9 @@ And some commands like `for` loop require parentheses `()`.
 
 On non-Windows platforms, you can join the commands with `;`.
 
-```json
+```jsonc
 {
-    "label": "Search json in a folder (Unix/Linux)",
+    // Search json in a folder (Unix/Linux)
     "command": "for f in %dir%/*.json; do echo \"${f}\"; done; echo Done!",
     "button": "Echo!",
     "components": [

--- a/examples/tips/unicode/README.md
+++ b/examples/tips/unicode/README.md
@@ -6,7 +6,7 @@ Tuw supports UTF-8 strings.
 
 ```json
 {
-    "label": "Unicode Sample",
+    "window_name": "Unicode Sample",
     "command": "echo file: %รหัส% & echo folder: %-% & echo checkbox: %-%",
     "button": "こんにちは！",
     "components": [

--- a/examples/tips/unicode/gui_definition.json
+++ b/examples/tips/unicode/gui_definition.json
@@ -1,28 +1,26 @@
 {
-    "gui": [
-        {
-            "label": "Unicode Sample",
-            "command": "echo file: %รหัส% & echo folder: %-% & echo checkbox: %-%",
-            "button": "こんにちは！",
-            "components": [
-                {
-                    "type": "file",
-                    "label": "文件",
-                    "extension": "any files | *",
-                    "default": "ああああ",
-                    "id": "รหัส"
-                },
-                {
-                    "type": "folder",
-                    "label": "폴더",
-                    "default": "いいいい"
-                },
-                {
-                    "type": "check",
-                    "label": "вариант",
-                    "default": true
-                }
-            ]
-        }
-    ]
+    "gui": {
+        "label": "Unicode Sample",
+        "command": "echo file: %รหัส% & echo folder: %-% & echo checkbox: %-%",
+        "button": "こんにちは！",
+        "components": [
+            {
+                "type": "file",
+                "label": "文件",
+                "extension": "any files | *",
+                "default": "ああああ",
+                "id": "รหัส"
+            },
+            {
+                "type": "folder",
+                "label": "폴더",
+                "default": "いいいい"
+            },
+            {
+                "type": "check",
+                "label": "вариант",
+                "default": true
+            }
+        ]
+    }
 }

--- a/examples/tips/unicode/gui_definition.json
+++ b/examples/tips/unicode/gui_definition.json
@@ -1,6 +1,6 @@
 {
     "gui": {
-        "label": "Unicode Sample",
+        "window_name": "Unicode Sample",
         "command": "echo file: %รหัส% & echo folder: %-% & echo checkbox: %-%",
         "button": "こんにちは！",
         "components": [

--- a/include/component.h
+++ b/include/component.h
@@ -1,8 +1,8 @@
 #pragma once
-#include <string>
 #include <vector>
 #include "rapidjson/document.h"
 #include "ui.h"
+#include "string_utils.h"
 #include "validator.h"
 
 #define UNUSED(x) (void)(x)
@@ -11,15 +11,15 @@
 class Component {
  protected:
     void* m_widget;
-    std::string m_label;
-    std::string m_id;
+    tuwString m_label;
+    tuwString m_id;
     bool m_has_string;
     bool m_is_wide;
     Validator m_validator;
     uiLabel* m_error_widget;
     bool m_optional;
-    std::string m_prefix;
-    std::string m_suffix;
+    tuwString m_prefix;
+    tuwString m_suffix;
 
  private:
     bool m_add_quotes;
@@ -27,9 +27,9 @@ class Component {
  public:
     explicit Component(const rapidjson::Value& j);
     virtual ~Component();
-    virtual std::string GetRawString() { return "";}
-    std::string GetString();
-    const std::string& GetID() const { return m_id; }
+    virtual tuwString GetRawString() { return "";}
+    tuwString GetString();
+    const tuwString& GetID() const { return m_id; }
 
     virtual void SetConfig(const rapidjson::Value& config) { UNUSED(config); }
     virtual void GetConfig(rapidjson::Document& config) { UNUSED(config); }
@@ -38,7 +38,7 @@ class Component {
     bool IsWide() const { return m_is_wide; }
 
     bool Validate(bool* redraw_flag);
-    const std::string& GetValidationError() const;
+    const tuwString& GetValidationError() const;
     void PutErrorWidget(uiBox* box);
 
     static Component* PutComponent(uiBox* box, const rapidjson::Value& j);
@@ -47,10 +47,10 @@ class Component {
 // containers for Combo and CheckArray
 class MultipleValuesContainer {
  protected:
-    std::vector<std::string> m_values;
+    std::vector<tuwString> m_values;
 
  public:
-    void SetValues(std::vector<std::string> values){
+    void SetValues(std::vector<tuwString> values){
         m_values = values;
     }
 };
@@ -74,9 +74,9 @@ class StringComponentBase : public Component {
 
 class FilePicker : public StringComponentBase {
  private:
-    std::string m_ext;
+    tuwString m_ext;
  public:
-    std::string GetRawString() override;
+    tuwString GetRawString() override;
     FilePicker(uiBox* box, const rapidjson::Value& j);
     void SetConfig(const rapidjson::Value& config) override;
     void OpenFile();
@@ -84,7 +84,7 @@ class FilePicker : public StringComponentBase {
 
 class DirPicker : public StringComponentBase {
  public:
-    std::string GetRawString() override;
+    tuwString GetRawString() override;
     DirPicker(uiBox* box, const rapidjson::Value& j);
     void SetConfig(const rapidjson::Value& config) override;
     void OpenFolder();
@@ -92,7 +92,7 @@ class DirPicker : public StringComponentBase {
 
 class ComboBox : public StringComponentBase, MultipleValuesContainer {
  public:
-    std::string GetRawString() override;
+    tuwString GetRawString() override;
     ComboBox(uiBox* box, const rapidjson::Value& j);
     void GetConfig(rapidjson::Document& config) override;
     void SetConfig(const rapidjson::Value& config) override;
@@ -100,7 +100,7 @@ class ComboBox : public StringComponentBase, MultipleValuesContainer {
 
 class RadioButtons : public StringComponentBase, MultipleValuesContainer {
  public:
-    std::string GetRawString() override;
+    tuwString GetRawString() override;
     RadioButtons(uiBox* box, const rapidjson::Value& j);
     void GetConfig(rapidjson::Document& config) override;
     void SetConfig(const rapidjson::Value& config) override;
@@ -108,9 +108,9 @@ class RadioButtons : public StringComponentBase, MultipleValuesContainer {
 
 class CheckBox : public Component {
  private:
-    std::string m_value;
+    tuwString m_value;
  public:
-    std::string GetRawString() override;
+    tuwString GetRawString() override;
     CheckBox(uiBox* box, const rapidjson::Value& j);
     void GetConfig(rapidjson::Document& config) override;
     void SetConfig(const rapidjson::Value& config) override;
@@ -118,7 +118,7 @@ class CheckBox : public Component {
 
 class CheckArray : public StringComponentBase, MultipleValuesContainer {
  public:
-    std::string GetRawString() override;
+    tuwString GetRawString() override;
     CheckArray(uiBox* box, const rapidjson::Value& j);
     void GetConfig(rapidjson::Document& config) override;
     void SetConfig(const rapidjson::Value& config) override;
@@ -126,7 +126,7 @@ class CheckArray : public StringComponentBase, MultipleValuesContainer {
 
 class TextBox : public StringComponentBase {
  public:
-    std::string GetRawString() override;
+    tuwString GetRawString() override;
     TextBox(uiBox* box, const rapidjson::Value& j);
     void SetConfig(const rapidjson::Value& config) override;
 };
@@ -134,7 +134,7 @@ class TextBox : public StringComponentBase {
 class IntPicker : public StringComponentBase {
  public:
     IntPicker(uiBox* box, const rapidjson::Value& j);
-    std::string GetRawString() override;
+    tuwString GetRawString() override;
     void GetConfig(rapidjson::Document& config) override;
     void SetConfig(const rapidjson::Value& config) override;
 };
@@ -143,7 +143,7 @@ class IntPicker : public StringComponentBase {
 class FloatPicker : public StringComponentBase {
  public:
     FloatPicker(uiBox* box, const rapidjson::Value& j);
-    std::string GetRawString() override;
+    tuwString GetRawString() override;
     void GetConfig(rapidjson::Document& config) override;
     void SetConfig(const rapidjson::Value& config) override;
 };

--- a/include/exe_container.h
+++ b/include/exe_container.h
@@ -1,11 +1,11 @@
 #pragma once
-#include <string>
 #include "rapidjson/document.h"
 #include "json_utils.h"
+#include "string_utils.h"
 
 class ExeContainer {
  private:
-    std::string m_exe_path;
+    tuwString m_exe_path;
     uint32_t m_exe_size;
     rapidjson::Document m_json;
 
@@ -15,8 +15,8 @@ class ExeContainer {
                     m_json() {
         m_json.SetObject();
     }
-    json_utils::JsonResult Read(const std::string& exe_path);
-    json_utils::JsonResult Write(const std::string& exe_path);
+    json_utils::JsonResult Read(const tuwString& exe_path);
+    json_utils::JsonResult Write(const tuwString& exe_path);
     bool HasJson() { return m_json.IsObject() && !m_json.ObjectEmpty(); }
     void GetJson(rapidjson::Document& json) { json.CopyFrom(m_json, json.GetAllocator()); }
     void SetJson(rapidjson::Document& json) { m_json.CopyFrom(json, m_json.GetAllocator()); }

--- a/include/exec.h
+++ b/include/exec.h
@@ -1,13 +1,13 @@
 #pragma once
-#include <string>
+#include "string_utils.h"
 
 struct ExecuteResult {
     int exit_code;
-    std::string err_msg;
-    std::string last_line;
+    tuwString err_msg;
+    tuwString last_line;
 };
 
 // When use_utf8_on_windows is true,
 // Tuw converts output strings from UTF-8 to UTF-16 on Windows.
-ExecuteResult Execute(const std::string& cmd, bool use_utf8_on_windows = false);
-ExecuteResult LaunchDefaultApp(const std::string& url);
+ExecuteResult Execute(const tuwString& cmd, bool use_utf8_on_windows = false);
+ExecuteResult LaunchDefaultApp(const tuwString& url);

--- a/include/json_utils.h
+++ b/include/json_utils.h
@@ -1,8 +1,8 @@
 // Functions related to json.
 
 #pragma once
-#include <string>
 #include "rapidjson/document.h"
+#include "string_utils.h"
 
 enum CmdPredefinedIds: int {
     CMD_ID_PERCENT = -1,
@@ -18,7 +18,7 @@ namespace json_utils {
 
 struct JsonResult {
     bool ok;
-    std::string msg;
+    tuwString msg;
 };
 
 #define JSON_RESULT_OK { true, "" }
@@ -26,9 +26,9 @@ struct JsonResult {
 // Max binary size for JSON files.
 #define JSON_SIZE_MAX 128 * 1024
 
-JsonResult LoadJson(const std::string& file, rapidjson::Document& json);
-JsonResult SaveJson(rapidjson::Document& json, const std::string& file);
-std::string JsonToString(rapidjson::Document& json);
+JsonResult LoadJson(const tuwString& file, rapidjson::Document& json);
+JsonResult SaveJson(rapidjson::Document& json, const tuwString& file);
+tuwString JsonToString(rapidjson::Document& json);
 
 const char* GetString(const rapidjson::Value& json, const char* key, const char* def);
 bool GetBool(const rapidjson::Value& json, const char* key, bool def);

--- a/include/json_utils.h
+++ b/include/json_utils.h
@@ -40,6 +40,6 @@ void CheckVersion(JsonResult& result, rapidjson::Document& definition);
 void CheckDefinition(JsonResult& result, rapidjson::Document& definition);
 void CheckSubDefinition(JsonResult& result, rapidjson::Value& sub_definition,
                         rapidjson::Document::AllocatorType& alloc);
-void CheckHelpURLs(JsonResult& result, const rapidjson::Document& definition);
+void CheckHelpURLs(JsonResult& result, rapidjson::Document& definition);
 
 }  // namespace json_utils

--- a/include/json_utils.h
+++ b/include/json_utils.h
@@ -39,6 +39,7 @@ void GetDefaultDefinition(rapidjson::Document& definition);
 void CheckVersion(JsonResult& result, rapidjson::Document& definition);
 void CheckDefinition(JsonResult& result, rapidjson::Document& definition);
 void CheckSubDefinition(JsonResult& result, rapidjson::Value& sub_definition,
+                        int index,
                         rapidjson::Document::AllocatorType& alloc);
 void CheckHelpURLs(JsonResult& result, rapidjson::Document& definition);
 

--- a/include/main_frame.h
+++ b/include/main_frame.h
@@ -1,9 +1,9 @@
 #pragma once
 #include <vector>
-#include <string>
 #include "rapidjson/document.h"
 #include "component.h"
 #include "json_utils.h"
+#include "string_utils.h"
 #include "ui.h"
 
 // Main window
@@ -26,9 +26,15 @@ class MainFrame {
     void CreateMenu();
     json_utils::JsonResult CheckDefinition(rapidjson::Document& definition);
     void UpdateConfig();
-    void ShowSuccessDialog(const std::string& msg, const std::string& title = "Success");
-    void ShowErrorDialog(const std::string& msg, const std::string& title = "Error");
-    void JsonLoadFailed(const std::string& msg);
+    void ShowSuccessDialog(const char* msg, const char* title = "Success");
+    void ShowErrorDialog(const char* msg, const char* title = "Error");
+    inline void ShowSuccessDialog(const tuwString& msg, const tuwString& title = "Success") {
+        ShowSuccessDialog(msg.c_str(), title.c_str());
+    }
+    inline void ShowErrorDialog(const tuwString& msg, const tuwString& title = "Error") {
+        ShowErrorDialog(msg.c_str(), title.c_str());
+    }
+    void JsonLoadFailed(const tuwString& msg);
 
  public:
     explicit MainFrame(const rapidjson::Document& definition =
@@ -38,7 +44,7 @@ class MainFrame {
     void UpdatePanel(unsigned definition_id);
     void OpenURL(int id);
     bool Validate();
-    std::string GetCommand();
+    tuwString GetCommand();
     void RunCommand();
     void GetDefinition(rapidjson::Document& json);
     void SaveConfig();

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdio>
 #include "env_utils.h"
 
 enum StringError : int {
@@ -117,6 +118,9 @@ inline bool operator!=(const char* str1, const tuwString& str2) {
     return str2 != str1;
 }
 
+// Returns only the last line and removes trailing line feeds (\n and \r.)
+tuwString GetLastLine(const tuwString& str);
+
 class tuwWstring {
  private:
     wchar_t* m_str;
@@ -156,11 +160,13 @@ uint32_t Fnv1Hash32(const tuwString& str);
 #ifdef _WIN32
 tuwString UTF16toUTF8(const wchar_t* str);
 tuwWstring UTF8toUTF16(const char* str);
-void PrintFmt(const char* fmt, ...);
+void FprintFmt(FILE* out, const char* fmt, ...);
 void EnableCSI();
 #elif defined(__TUW_UNIX__)
 void SetLogEntry(void* log_entry);
-void PrintFmt(const char* fmt, ...);
+void FprintFmt(FILE* out, const char* fmt, ...);
 #else
-#define PrintFmt(...) printf(__VA_ARGS__)
+#define FprintFmt(...) fprintf(__VA_ARGS__)
 #endif
+
+#define PrintFmt(...) FprintFmt(stdout, __VA_ARGS__)

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -1,30 +1,161 @@
 #pragma once
-#include <string>
 #include "env_utils.h"
 
-inline std::string envuStr(char *cstr) {
+enum StringError : int {
+    STR_OK = 0,
+    STR_ALLOCATION_ERROR,  // Failed to allocate memory for string.
+    STR_BOUNDARY_ERROR,  // Accessed out-of-bounds with substr or [].
+    STR_FORMAT_ERROR,  // Failed to convert number to string.
+    STR_ERROR_MAX,
+};
+
+// Returns the error status for tuwString.
+StringError GetStringError();
+
+// Set STR_OK to the error status.
+void ClearStringError();
+
+// String class that doesn't raise std errors.
+// It works without any crashes even when it got a memory allocation error.
+// But you have to check GetStringError() after string allocations
+// or it might have an unexpected value (an empty string).
+class tuwString {
+ private:
+    char* m_str;
+    size_t m_size;
+    void alloc_cstr(const char* str, size_t size);
+    void append(const char* str, size_t size);
+
+ public:
+    tuwString() : m_str(nullptr), m_size(0) {}
+    tuwString(const char* str);  // NOLINT(runtime/explicit)
+    tuwString(const char* str, size_t size);
+    tuwString(const tuwString& str);
+    tuwString(tuwString&& str);
+
+    // This allocates null bytes to use them as a buffer.
+    explicit tuwString(size_t size);
+
+    ~tuwString() { clear(); }
+    size_t length() const { return m_size; }
+    size_t size() const { return m_size; }
+
+    bool empty() const { return !m_str || m_str[0] == '\0' || m_size == 0; }
+
+    // Returns an immutable C string. This can't be null.
+    const char* c_str() const {
+        if (m_str)
+            return m_str;
+        return "";
+    }
+
+    // Returns a pointer to the actual buffer.
+    char* data() const { return m_str; }
+
+    void clear() {
+        if (m_str)
+            free(m_str);
+        m_str = nullptr;
+        m_size = 0;
+    }
+
+    const char& operator[](size_t id) const;
+
+    tuwString& operator=(const char* str);
+    tuwString& operator=(const tuwString& str);
+    tuwString& operator=(tuwString&& str);
+
+    tuwString& operator+=(const char* str);
+    tuwString& operator+=(const tuwString& str);
+
+    tuwString operator+(const char* str) const;
+    tuwString operator+(const tuwString& str) const;
+
+    // You can append numbers as strings
+    tuwString operator+(int num) const;
+    tuwString operator+(size_t num) const;
+    tuwString operator+(uint32_t num) const;
+
+    bool operator==(const char* str) const;
+    bool operator==(const tuwString& str) const;
+    inline bool operator!=(const char* str) const {
+        return !(*this == str);
+    }
+    inline bool operator!=(const tuwString& str) const {
+        return !(*this == str);
+    }
+
+    const char* begin() const {
+        return c_str();
+    }
+
+    const char* end() const {
+        return c_str() + m_size;
+    }
+
+    static const size_t npos;
+    size_t find(const char c) const;
+    size_t find(const char* str) const;
+    inline size_t find(const tuwString& str) const {
+        return find(str.c_str());
+    }
+
+    void push_back(const char c) {
+        this->append(&c, 1);
+    }
+
+    tuwString substr(size_t start, size_t size) const;
+};
+
+tuwString operator+(const char* str1, const tuwString& str2);
+
+inline bool operator==(const char* str1, const tuwString& str2) {
+    return str2 == str1;
+}
+
+inline bool operator!=(const char* str1, const tuwString& str2) {
+    return str2 != str1;
+}
+
+class tuwWstring {
+ private:
+    wchar_t* m_str;
+    size_t m_size;
+
+ public:
+    tuwWstring(const wchar_t* str);  // NOLINT(runtime/explicit)
+    ~tuwWstring() { clear(); }
+    size_t length() const { return m_size; }
+    size_t size() const { return m_size; }
+    bool empty() const { return !m_str || m_str[0] == L'\0' || m_size == 0; }
+
+    const wchar_t* c_str() const {
+        if (m_str)
+            return m_str;
+        return L"";
+    }
+
+    void clear() {
+        if (m_str)
+            free(m_str);
+        m_str = nullptr;
+        m_size = 0;
+    }
+};
+
+inline tuwString envuStr(char *cstr) {
     if (cstr == NULL)
         return "";
-    std::string str = cstr;
+    tuwString str = cstr;
     envuFree(cstr);
     return str;
 }
 
-uint32_t Fnv1Hash32(const std::string& str);
-
-// Efficient way to concat two or three char* strings.
-// str2 can be int, size_t, or uint32_t as well. It will be converted to string internally.
-template<typename T>
-std::string ConcatCStrings(const char* str1, T str2, const char* str3);
-
-template<typename T>
-inline std::string ConcatCStrings(const char* str1, T str2) {
-    return ConcatCStrings(str1, str2, nullptr);
-}
+uint32_t Fnv1Hash32(const tuwString& str);
 
 #ifdef _WIN32
-std::string UTF16toUTF8(const wchar_t* str);
-std::wstring UTF8toUTF16(const char* str);
+tuwString UTF16toUTF8(const wchar_t* str);
+tuwWstring UTF8toUTF16(const char* str);
 void PrintFmt(const char* fmt, ...);
 void EnableCSI();
 #elif defined(__TUW_UNIX__)

--- a/include/tuw_constants.h
+++ b/include/tuw_constants.h
@@ -10,8 +10,8 @@ namespace tuw_constants {
         "       CLI tools\n";
     constexpr char TOOL_NAME[] = "Tuw";
     constexpr char AUTHOR[] = "matyalatte";
-    constexpr char VERSION[] = "0.7.2";
-    constexpr int VERSION_INT = 702;
+    constexpr char VERSION[] = "0.8.0";
+    constexpr int VERSION_INT = 800;
 
 #ifdef _WIN32
     #define TUW_CONSTANTS_OS "win"

--- a/include/validator.h
+++ b/include/validator.h
@@ -1,19 +1,20 @@
 #pragma once
-#include <string>
 #include <vector>
 #include "rapidjson/document.h"
 
+#include "string_utils.h"
+
 class Validator {
  private:
-    std::string m_regex;
-    std::string m_wildcard;
+    tuwString m_regex;
+    tuwString m_wildcard;
     bool m_not_empty;
     bool m_exist;
-    std::string m_regex_error;
-    std::string m_wildcard_error;
-    std::string m_not_empty_error;
-    std::string m_exist_error;
-    std::string m_error_msg;
+    tuwString m_regex_error;
+    tuwString m_wildcard_error;
+    tuwString m_not_empty_error;
+    tuwString m_exist_error;
+    tuwString m_error_msg;
 
  public:
     Validator() : m_regex(""), m_wildcard(""),
@@ -21,6 +22,6 @@ class Validator {
                   m_error_msg("") {}
     ~Validator() {}
     void Initialize(const rapidjson::Value& j);
-    bool Validate(const std::string& str);
-    const std::string& GetError() const { return m_error_msg; }
+    bool Validate(const tuwString& str);
+    const tuwString& GetError() const { return m_error_msg; }
 };

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1,29 +1,33 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "properties": {
-    "recommended": { "$ref": "#/definitions/types/version" },
-    "recommended_version": { "$ref": "#/definitions/types/version" },
-    "minimum_required": { "$ref": "#/definitions/types/version" },
-    "minimum_required_version": { "$ref": "#/definitions/types/version" },
-    "gui": {
-      "if": { "type": "object" },
-      "then": { "$ref": "#/definitions/types/gui_item" },
-      "else": {
-        "type": "array",
-        "items": { "$ref": "#/definitions/types/gui_item" }
-      }
-    },
-    "help":  {
-      "if": { "type": "object" },
-      "then": { "$ref": "#/definitions/types/help_item" },
-      "else": {
-        "type": "array",
-        "items": { "$ref": "#/definitions/types/help_item" }
-      }
+  "if": {
+    "required": [ "gui" ]
+  },
+  "then": {
+    "properties": {
+      "recommended": { "$ref": "#/definitions/types/version" },
+      "recommended_version": { "$ref": "#/definitions/types/version" },
+      "minimum_required": { "$ref": "#/definitions/types/version" },
+      "minimum_required_version": { "$ref": "#/definitions/types/version" },
+      "gui": { "$ref": "#/definitions/types/gui_array" },
+      "help": { "$ref": "#/definitions/types/help_array" }
     }
   },
-  "required": [ "gui" ],
+  "else": {
+    "allOf": [
+      { "$ref": "#/definitions/types/gui_item" },
+      {
+        "properties": {
+          "recommended": { "$ref": "#/definitions/types/version" },
+          "recommended_version": { "$ref": "#/definitions/types/version" },
+          "minimum_required": { "$ref": "#/definitions/types/version" },
+          "minimum_required_version": { "$ref": "#/definitions/types/version" },
+          "help": { "$ref": "#/definitions/types/help_array" }
+        }
+      }
+    ]
+  },
   "definitions": {
     "types": {
       "version": {
@@ -183,6 +187,14 @@
           }
         ]
       },
+      "gui_array": {
+        "if": { "type": "object" },
+        "then": { "$ref": "#/definitions/types/gui_item" },
+        "else": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/types/gui_item" }
+        }
+      },
       "help_item": {
         "type": "object",
         "properties": {
@@ -221,6 +233,14 @@
             }
           }
         ]
+      },
+      "help_array":  {
+        "if": { "type": "object" },
+        "then": { "$ref": "#/definitions/types/help_item" },
+        "else": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/types/help_item" }
+        }
       }
     },
     "components": {

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -7,8 +7,130 @@
     "minimum_required": { "$ref": "#/definitions/types/version" },
     "minimum_required_version": { "$ref": "#/definitions/types/version" },
     "gui": {
-      "type": "array",
-      "items": {
+      "if": { "type": "object" },
+      "then": { "$ref": "#/definitions/types/gui_item" },
+      "else": {
+        "type": "array",
+        "items": { "$ref": "#/definitions/types/gui_item" }
+      }
+    },
+    "help":  {
+      "if": { "type": "object" },
+      "then": { "$ref": "#/definitions/types/help_item" },
+      "else": {
+        "type": "array",
+        "items": { "$ref": "#/definitions/types/help_item" }
+      }
+    }
+  },
+  "required": [ "gui" ],
+  "definitions": {
+    "types": {
+      "version": {
+        "type": "string",
+        "pattern": "^[.0-9]+$",
+        "minLength": 1,
+        "maxLength": 8
+      },
+      "component": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "static_text",
+              "file",
+              "folder",
+              "dir",
+              "choice",
+              "combo",
+              "radio",
+              "check",
+              "check_array",
+              "checks",
+              "text",
+              "text_box",
+              "int",
+              "integer",
+              "float"
+            ]
+          },
+          "label": { "type": "string" },
+          "id": { "type": "string" },
+          "add_quotes": { "type": "boolean" },
+          "optional": { "type": "boolean" },
+          "prefix": { "type": "string" },
+          "suffix": { "type": "string" },
+          "platforms": { "$ref": "#/definitions/types/platform_array" },
+          "platform_array": { "$ref": "#/definitions/types/platform_array" }
+        },
+        "allOf": [
+          { "$ref": "#/definitions/components/file" },
+          { "$ref": "#/definitions/components/folder_or_text" },
+          { "$ref": "#/definitions/components/check" },
+          { "$ref": "#/definitions/components/int" },
+          { "$ref": "#/definitions/components/float" },
+          { "$ref": "#/definitions/components/combo" },
+          { "$ref": "#/definitions/components/check_array" },
+          { "$ref": "#/definitions/components/validator" }
+        ],
+        "required": [ "type", "label" ]
+      },
+      "component_array": {
+        "if": { "type": "object" },
+        "then": { "$ref": "#/definitions/types/component" },
+        "else": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/types/component" }
+        }
+      },
+      "platform": {
+        "type": "string",
+        "enum": [ "win", "mac", "linux" ]
+      },
+      "platform_array": {
+        "if": { "type": "string" },
+        "then": { "$ref": "#/definitions/types/platform" },
+        "else": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/types/platform" }
+        }
+      },
+      "combo_item": {
+        "type": "object",
+        "properties": {
+          "label": { "type": "string" },
+          "value": { "type": "string" }
+        },
+        "required": [ "label" ]
+      },
+      "combo_item_array": {
+        "if": { "type": "object" },
+        "then": { "$ref": "#/definitions/types/combo_item" },
+        "else": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/types/combo_item" }
+        }
+      },
+      "checks_item": {
+        "type": "object",
+        "properties": {
+          "label": { "type": "string" },
+          "value": { "type": "string" },
+          "tooltip": { "type": "string" },
+          "default": { "type": "boolean" }
+        },
+        "required": [ "label" ]
+      },
+      "checks_item_array": {
+        "if": { "type": "object" },
+        "then": { "$ref": "#/definitions/types/checks_item" },
+        "else": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/types/checks_item" }
+        }
+      },
+      "gui_item": {
         "type": "object",
         "properties": {
           "label": { "type": "string" },
@@ -28,8 +150,8 @@
             "type": "string",
             "enum": [ "default", "utf8", "utf-8" ]
           },
-          "components": { "$ref": "#/definitions/types/components" },
-          "component_array": { "$ref": "#/definitions/types/components" }
+          "components": { "$ref": "#/definitions/types/component_array" },
+          "component_array": { "$ref": "#/definitions/types/component_array" }
         },
         "required": [
           "label"
@@ -60,11 +182,8 @@
             }
           }
         ]
-      }
-    },
-    "help": {
-      "type": "array",
-      "items": {
+      },
+      "help_item": {
         "type": "object",
         "properties": {
           "type": {
@@ -102,100 +221,6 @@
             }
           }
         ]
-      }
-    }
-  },
-  "required": [ "gui" ],
-  "definitions": {
-    "types": {
-      "version": {
-        "type": "string",
-        "pattern": "^[.0-9]+$",
-        "minLength": 1,
-        "maxLength": 8
-      },
-      "components": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "static_text",
-                "file",
-                "folder",
-                "dir",
-                "choice",
-                "combo",
-                "radio",
-                "check",
-                "check_array",
-                "checks",
-                "text",
-                "text_box",
-                "int",
-                "integer",
-                "float"
-              ]
-            },
-            "label": { "type": "string" },
-            "id": { "type": "string" },
-            "add_quotes": { "type": "boolean" },
-            "optional": { "type": "boolean" },
-            "prefix": { "type": "string" },
-            "suffix": { "type": "string" },
-            "platforms": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "enum": [ "win", "mac", "linux" ]
-              }
-            },
-            "platform_array": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "enum": [ "win", "mac", "linux" ]
-              }
-            }
-          },
-          "allOf": [
-            { "$ref": "#/definitions/components/file" },
-            { "$ref": "#/definitions/components/folder_or_text" },
-            { "$ref": "#/definitions/components/check" },
-            { "$ref": "#/definitions/components/int" },
-            { "$ref": "#/definitions/components/float" },
-            { "$ref": "#/definitions/components/combo" },
-            { "$ref": "#/definitions/components/check_array" },
-            { "$ref": "#/definitions/components/validator" }
-          ],
-          "required": [ "type", "label" ]
-        }
-      },
-      "combo_items": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "label": { "type": "string" },
-            "value": { "type": "string" }
-          },
-          "required": [ "label" ]
-        }
-      },
-      "checks_items": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "label": { "type": "string" },
-            "value": { "type": "string" },
-            "tooltip": { "type": "string" },
-            "default": { "type": "boolean" }
-          },
-          "required": [ "label" ]
-        }
       }
     },
     "components": {
@@ -291,8 +316,8 @@
           "properties": {
             "default": { "type": "integer" },
             "tooltip": { "type": "string" },
-            "items": { "$ref": "#/definitions/types/combo_items" },
-            "item_array": { "$ref": "#/definitions/types/combo_items" }
+            "items": { "$ref": "#/definitions/types/combo_item_array" },
+            "item_array": { "$ref": "#/definitions/types/combo_item_array" }
           },
           "if": {
             "not": {
@@ -312,8 +337,8 @@
         },
         "then": {
           "properties": {
-            "items": { "$ref": "#/definitions/types/checks_items" },
-            "item_array": { "$ref": "#/definitions/types/checks_items" }
+            "items": { "$ref": "#/definitions/types/checks_item_array" },
+            "item_array": { "$ref": "#/definitions/types/checks_item_array" }
           },
           "if": {
             "not": {

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -157,9 +157,6 @@
           "components": { "$ref": "#/definitions/types/component_array" },
           "component_array": { "$ref": "#/definitions/types/component_array" }
         },
-        "required": [
-          "label"
-        ],
         "allOf": [
           {
             "if": {

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -6,23 +6,6 @@
 #include "windows.h"
 #endif
 
-inline bool IsNewline(char ch) {
-    return ch == '\n' || ch == '\r';
-}
-
-static tuwString GetLastLine(const tuwString& input) {
-    if (input.empty()) return "";
-    size_t end = input.length();
-
-    // Trim trailing newlines
-    while (end > 0 && IsNewline(input[end - 1])) end--;
-    if (end == 0) return "";
-
-    size_t start = end - 1;
-    while (start > 0 && input[start - 1] != '\n') start--;
-    return input.substr(start, end - start);
-}
-
 enum READ_IO_TYPE : int {
     READ_STDOUT = 0,
     READ_STDERR,
@@ -31,7 +14,7 @@ enum READ_IO_TYPE : int {
 unsigned ReadIO(subprocess_s &process,
                 int read_io_type,
                 char *buf, const unsigned buf_size,
-                tuwString& str, const unsigned str_size) {
+                tuwString& str, const size_t str_size) {
     unsigned read_size = 0;
     if (read_io_type == READ_STDOUT) {
         read_size = subprocess_read_stdout(&process, buf, buf_size);
@@ -53,6 +36,28 @@ void DestroyProcess(subprocess_s &process, int *return_code, tuwString &err_msg)
         *return_code = -1;
         err_msg = "Failed to manage subprocess.\n";
     }
+}
+
+void RedirectOutput(FILE* out, const char* buf,
+                    unsigned read_size, bool use_utf8_on_windows) {
+    if (read_size) {
+#ifdef _WIN32
+        if (use_utf8_on_windows) {
+            tuwWstring wout = UTF8toUTF16(buf);
+            fprintf(out, "%ls", wout.c_str());
+        } else {
+            fprintf(out, "%s", buf);
+        }
+#else
+        FprintFmt(out, "%s", buf);
+#endif
+    }
+}
+
+inline tuwString TruncateStr(const tuwString& str, size_t size) {
+    if (str.size() > size)
+        return "..." + str.substr(str.size() - size, size);
+    return str;
 }
 
 ExecuteResult Execute(const tuwString& cmd, bool use_utf8_on_windows) {
@@ -96,6 +101,8 @@ ExecuteResult Execute(const tuwString& cmd, bool use_utf8_on_windows) {
         return { -1, "Failed to create a subprocess.\n", ""};
 
     const unsigned BUF_SIZE = 1024;
+    const size_t LAST_LINE_MAX_LEN = BUF_SIZE;
+    const size_t ERR_MSG_MAX_LEN = BUF_SIZE * 2;
     char out_buf[BUF_SIZE + 1];
     char err_buf[BUF_SIZE + 1];
     tuwString last_line;
@@ -104,30 +111,26 @@ ExecuteResult Execute(const tuwString& cmd, bool use_utf8_on_windows) {
     unsigned err_read_size = 0;
 
     do {
-        out_read_size = ReadIO(process, READ_STDOUT, out_buf, BUF_SIZE, last_line, BUF_SIZE);
-        err_read_size = ReadIO(process, READ_STDERR, err_buf, BUF_SIZE, err_msg, BUF_SIZE * 2);
-        if (out_read_size) {
-#ifdef _WIN32
-            if (use_utf8_on_windows) {
-                tuwWstring wout = UTF8toUTF16(out_buf);
-                printf("%ls", wout.c_str());
-            } else {
-                printf("%s", out_buf);
-            }
-#else
-            PrintFmt("%s", out_buf);
-#endif
-        }
+        out_read_size = ReadIO(process, READ_STDOUT,
+                               out_buf, BUF_SIZE, last_line, LAST_LINE_MAX_LEN);
+        err_read_size = ReadIO(process, READ_STDERR,
+                               err_buf, BUF_SIZE, err_msg, ERR_MSG_MAX_LEN);
+        RedirectOutput(stdout, out_buf, out_read_size, use_utf8_on_windows);
+        RedirectOutput(stderr, err_buf, err_read_size, use_utf8_on_windows);
     } while (subprocess_alive(&process) || out_read_size || err_read_size);
 
     // Sometimes stdout and stderr still have unread characters
-    ReadIO(process, READ_STDOUT, out_buf, BUF_SIZE, last_line, BUF_SIZE);
-    ReadIO(process, READ_STDERR, err_buf, BUF_SIZE, err_msg, BUF_SIZE * 2);
+    out_read_size = ReadIO(process, READ_STDOUT, out_buf, BUF_SIZE, last_line, LAST_LINE_MAX_LEN);
+    err_read_size = ReadIO(process, READ_STDERR, err_buf, BUF_SIZE, err_msg, ERR_MSG_MAX_LEN);
+    RedirectOutput(stdout, out_buf, out_read_size, use_utf8_on_windows);
+    RedirectOutput(stderr, err_buf, err_read_size, use_utf8_on_windows);
 
     int return_code;
     DestroyProcess(process, &return_code, err_msg);
 
     last_line = GetLastLine(last_line);
+    last_line = TruncateStr(last_line, LAST_LINE_MAX_LEN);
+    err_msg = TruncateStr(err_msg, ERR_MSG_MAX_LEN);
 
     return { return_code, err_msg, last_line };
 }

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -10,7 +10,7 @@ inline bool IsNewline(char ch) {
     return ch == '\n' || ch == '\r';
 }
 
-static std::string GetLastLine(const std::string& input) {
+static tuwString GetLastLine(const tuwString& input) {
     if (input.empty()) return "";
     size_t end = input.length();
 
@@ -31,7 +31,7 @@ enum READ_IO_TYPE : int {
 unsigned ReadIO(subprocess_s &process,
                 int read_io_type,
                 char *buf, const unsigned buf_size,
-                std::string& str, const unsigned str_size) {
+                tuwString& str, const unsigned str_size) {
     unsigned read_size = 0;
     if (read_io_type == READ_STDOUT) {
         read_size = subprocess_read_stdout(&process, buf, buf_size);
@@ -48,16 +48,23 @@ unsigned ReadIO(subprocess_s &process,
     return read_size;
 }
 
-void DestroyProcess(subprocess_s &process, int *return_code, std::string &err_msg) {
+void DestroyProcess(subprocess_s &process, int *return_code, tuwString &err_msg) {
     if (subprocess_join(&process, return_code) || subprocess_destroy(&process)) {
         *return_code = -1;
         err_msg = "Failed to manage subprocess.\n";
     }
 }
 
-ExecuteResult Execute(const std::string& cmd, bool use_utf8_on_windows) {
+ExecuteResult Execute(const tuwString& cmd, bool use_utf8_on_windows) {
 #ifdef _WIN32
-    std::wstring wcmd = UTF8toUTF16(cmd.c_str());
+    tuwWstring wcmd = UTF8toUTF16(cmd.c_str());
+
+    if (GetStringError() != STR_OK) {
+        // Reject the command as it might have unexpected value.
+        return { -1,
+                 "Fatal error has occored while editing strings.\n",
+                 "" };
+    }
 
     int argc;
     wchar_t** parsed = CommandLineToArgvW(wcmd.c_str(), &argc);
@@ -91,8 +98,8 @@ ExecuteResult Execute(const std::string& cmd, bool use_utf8_on_windows) {
     const unsigned BUF_SIZE = 1024;
     char out_buf[BUF_SIZE + 1];
     char err_buf[BUF_SIZE + 1];
-    std::string last_line;
-    std::string err_msg;
+    tuwString last_line;
+    tuwString err_msg;
     unsigned out_read_size = 0;
     unsigned err_read_size = 0;
 
@@ -102,7 +109,7 @@ ExecuteResult Execute(const std::string& cmd, bool use_utf8_on_windows) {
         if (out_read_size) {
 #ifdef _WIN32
             if (use_utf8_on_windows) {
-                std::wstring wout = UTF8toUTF16(out_buf);
+                tuwWstring wout = UTF8toUTF16(out_buf);
                 printf("%ls", wout.c_str());
             } else {
                 printf("%s", out_buf);
@@ -113,7 +120,8 @@ ExecuteResult Execute(const std::string& cmd, bool use_utf8_on_windows) {
         }
     } while (subprocess_alive(&process) || out_read_size || err_read_size);
 
-    // Sometimes stderr still have unread characters
+    // Sometimes stdout and stderr still have unread characters
+    ReadIO(process, READ_STDOUT, out_buf, BUF_SIZE, last_line, BUF_SIZE);
     ReadIO(process, READ_STDERR, err_buf, BUF_SIZE, err_msg, BUF_SIZE * 2);
 
     int return_code;
@@ -124,9 +132,9 @@ ExecuteResult Execute(const std::string& cmd, bool use_utf8_on_windows) {
     return { return_code, err_msg, last_line };
 }
 
-ExecuteResult LaunchDefaultApp(const std::string& url) {
+ExecuteResult LaunchDefaultApp(const tuwString& url) {
 #ifdef _WIN32
-    std::wstring utf16_url = UTF8toUTF16(url.c_str());
+    tuwWstring utf16_url = UTF8toUTF16(url.c_str());
     const wchar_t* argv[] = {L"cmd.exe", L"/c", L"start", utf16_url.c_str(), NULL};
 #elif defined(__TUW_UNIX__) && !defined(__HAIKU__)
     // Linux and BSD
@@ -143,7 +151,7 @@ ExecuteResult LaunchDefaultApp(const std::string& url) {
         return { -1, "Failed to create a subprocess.\n", ""};
 
     int return_code;
-    std::string err_msg;
+    tuwString err_msg;
     DestroyProcess(process, &return_code, err_msg);
 
     return { return_code, err_msg, "" };

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -229,7 +229,7 @@ namespace json_utils {
 
     // get default definition of gui
     void GetDefaultDefinition(rapidjson::Document& definition) {
-        static const char* def_str = "{\"gui\":{"
+        static const char* def_str = "{"
             "\"label\":\"Default GUI\","
     #ifdef _WIN32
             "\"command\":\"dir\","
@@ -239,7 +239,7 @@ namespace json_utils {
             "\"button\":\"run 'ls'\","
     #endif
             "\"components\":[]"
-            "}}";
+            "}";
         rapidjson::ParseResult ok = definition.Parse(def_str);
         assert(ok);
         JsonResult result = JSON_RESULT_OK;
@@ -685,7 +685,14 @@ namespace json_utils {
     }
 
     void CheckDefinition(JsonResult& result, rapidjson::Document& definition) {
-        CheckJsonArrayType(result, definition, "gui", JsonType::JSON, definition.GetAllocator());
+        rapidjson::Document::AllocatorType& alloc = definition.GetAllocator();
+        if (!definition.HasMember("gui")) {
+            // definition["gui"] = definition
+            rapidjson::Value n(rapidjson::kObjectType);
+            n.CopyFrom(definition, alloc);
+            definition.AddMember("gui", n, alloc);
+        }
+        CheckJsonArrayType(result, definition, "gui", JsonType::JSON, alloc);
         if (!result.ok) return;
         if (definition["gui"].Size() == 0) {
             result.ok = false;
@@ -694,7 +701,7 @@ namespace json_utils {
 
         for (rapidjson::Value& sub_d : definition["gui"].GetArray()) {
             if (!result.ok) return;
-            CheckSubDefinition(result, sub_d, definition.GetAllocator());
+            CheckSubDefinition(result, sub_d, alloc);
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,4 @@
 #include <stdio.h>
-#include <string.h>
 #ifdef _WIN32
 #include <locale.h>
 #else
@@ -49,8 +48,8 @@ bool AskOverwrite(const char *path) {
     return ret == 1 && (answer == "y"[0] || answer == "Y"[0]);
 }
 
-json_utils::JsonResult Merge(const std::string& exe_path, const std::string& json_path,
-                             const std::string& new_path, const bool force) {
+json_utils::JsonResult Merge(const tuwString& exe_path, const tuwString& json_path,
+                             const tuwString& new_path, const bool force) {
     rapidjson::Document json;
     json_utils::JsonResult result = json_utils::LoadJson(json_path, json);
     if (!result.ok) return result;
@@ -82,8 +81,8 @@ json_utils::JsonResult Merge(const std::string& exe_path, const std::string& jso
     return JSON_RESULT_OK;
 }
 
-json_utils::JsonResult Split(const std::string& exe_path, const std::string& json_path,
-                             const std::string& new_path, const bool force) {
+json_utils::JsonResult Split(const tuwString& exe_path, const tuwString& json_path,
+                             const tuwString& new_path, const bool force) {
     ExeContainer exe;
     json_utils::JsonResult result = exe.Read(exe_path);
     if (!result.ok) return result;
@@ -207,7 +206,7 @@ int wmain(int argc, wchar_t* argv[]) {
 #else
 int main(int argc, char* argv[]) {
 #endif
-    std::vector<std::string> args;
+    std::vector<tuwString> args;
     for (int i = 0; i < argc; i++) {
 #ifdef _WIN32
         args.emplace_back(UTF16toUTF8(argv[i]));
@@ -218,7 +217,7 @@ int main(int argc, char* argv[]) {
     char *exe_path_cstr = envuGetExecutablePath();
     char *exe_dir = envuGetDirectory(exe_path_cstr);
     envuSetCwd(exe_dir);
-    std::string exe_path = envuStr(exe_path_cstr);
+    tuwString exe_path = envuStr(exe_path_cstr);
     envuFree(exe_dir);
 
     // Launch GUI if no args.
@@ -232,8 +231,8 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
-    std::string json_path;
-    std::string new_exe_path;
+    tuwString json_path;
+    tuwString new_exe_path;
     bool force = false;
 
     for (int i = 2; i < argc; i++) {

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -313,8 +313,10 @@ static void OnClicked(uiButton *sender, void *data) {
 void MainFrame::UpdatePanel(unsigned definition_id) {
     m_definition_id = definition_id;
     rapidjson::Value& sub_definition = m_definition["gui"][m_definition_id];
-    const char* label = sub_definition["label"].GetString();
-    PrintFmt("[UpdatePanel] Label: %s\n", label);
+    if (m_definition["gui"].Size() > 1) {
+        const char* label = sub_definition["label"].GetString();
+        PrintFmt("[UpdatePanel] Label: %s\n", label);
+    }
     const char* cmd_str = sub_definition["command_str"].GetString();
     PrintFmt("[UpdatePanel] Command: %s\n", cmd_str);
     const char* window_name = json_utils::GetString(sub_definition,

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -17,7 +17,7 @@ MainFrame::MainFrame(const rapidjson::Document& definition, const rapidjson::Doc
 
     m_grid = NULL;
     m_menu_item = NULL;
-    std::string exe_path = envuStr(envuGetExecutablePath());
+    tuwString exe_path = envuStr(envuGetExecutablePath());
 
     m_definition.CopyFrom(definition, m_definition.GetAllocator());
     m_config.CopyFrom(config, m_config.GetAllocator());
@@ -88,8 +88,8 @@ MainFrame::MainFrame(const rapidjson::Document& definition, const rapidjson::Doc
 #endif
 
     if (ignore_external_json) {
-        std::string msg = ConcatCStrings("WARNING: Using embedded JSON. ",
-                                         json_path, " was ignored.\n");
+        tuwString msg = tuwString("WARNING: Using embedded JSON. ") +
+                        json_path + " was ignored.\n";
         PrintFmt("[LoadDefinition] %s", msg.c_str());
         ShowSuccessDialog(msg, "Warning");
     }
@@ -216,9 +216,9 @@ void MainFrame::CreateMenu() {
     m_menu_item = uiMenuAppendCheckItem(menu, "Safe Mode");
 }
 
-static bool IsValidURL(const std::string &url) {
+static bool IsValidURL(const tuwString &url) {
     for (const char c : { ' ', ';', '|', '&', '\r', '\n' }) {
-        if (url.find(c) != std::string::npos)
+        if (url.find(c) != tuwString::npos)
             return false;
     }
     return true;
@@ -227,7 +227,7 @@ static bool IsValidURL(const std::string &url) {
 void MainFrame::OpenURL(int id) {
     rapidjson::Value& help = m_definition["help"].GetArray()[id];
     const char* type = help["type"].GetString();
-    std::string url;
+    tuwString url;
     const char* tag = "";
 
     if (strcmp(type, "url") == 0) {
@@ -235,19 +235,18 @@ void MainFrame::OpenURL(int id) {
         tag = "[OpenURL] ";
 
         size_t pos = url.find("://");
-        if (pos != std::string::npos) {
-            std::string scheme = url.substr(0, pos);
+        if (pos != tuwString::npos) {
+            tuwString scheme = url.substr(0, pos);
             // scheme should be http or https
             if (scheme == "file") {
-                std::string msg = ConcatCStrings("Use 'file' type for a path, not 'url' type. (",
-                                                 url.c_str(), ")");
+                tuwString msg = "Use 'file' type for a path, not 'url' type. (" +
+                                url + ")";
                 PrintFmt("%sError: %s\n", tag, msg.c_str());
                 ShowErrorDialog(msg);
                 return;
             } else if (scheme != "https" && scheme != "http") {
-                std::string msg = ConcatCStrings(
-                                    "Unsupported scheme detected. "
-                                    "It should be http or https. (", scheme.c_str(), ")");
+                tuwString msg = "Unsupported scheme detected. "
+                                "It should be http or https. (" + scheme + ")";
                 PrintFmt("%sError: %s\n", tag, msg.c_str());
                 ShowErrorDialog(msg);
                 return;
@@ -263,7 +262,7 @@ void MainFrame::OpenURL(int id) {
         tag = "[OpenFile] ";
 
         if (!exists) {
-            std::string msg = ConcatCStrings("File does not exist. (", url.c_str(), ")");
+            tuwString msg = "File does not exist. (" + url + ")";
             PrintFmt("%sError: %s\n", tag, msg.c_str());
             ShowErrorDialog(msg);
             return;
@@ -277,7 +276,7 @@ void MainFrame::OpenURL(int id) {
     }
 
     if (!IsValidURL(url)) {
-        std::string msg = "URL should NOT contains ' ', ';', '|', '&', '\\r', nor '\\n'.\n"
+        tuwString msg = "URL should NOT contains ' ', ';', '|', '&', '\\r', nor '\\n'.\n"
                           "URL: " + url;
         PrintFmt("%sError: %s\n", tag, msg.c_str());
         ShowErrorDialog(msg.c_str());
@@ -285,17 +284,26 @@ void MainFrame::OpenURL(int id) {
     }
 
     if (IsSafeMode()) {
-        std::string msg = "The URL was not opened because the safe mode is enabled.\n"
+        tuwString msg = "The URL was not opened because the safe mode is enabled.\n"
                           "You can disable it from the menu bar (Debug > Safe Mode.)\n"
                           "\n"
                           "URL: " + url;
         ShowSuccessDialog(msg, "Safe Mode");
     } else {
-        ExecuteResult result = LaunchDefaultApp(url);
-        if (result.exit_code != 0) {
-            std::string msg = ConcatCStrings("Failed to open a ", type, " by an unexpected error.");
-            PrintFmt("%sError: %s\n", tag, msg.c_str());
-            ShowErrorDialog(msg.c_str());
+        if (GetStringError() != STR_OK) {
+            // Reject the URL as it might have an unexpected value.
+            const char* msg = "The URL was not opened "
+                              "because a fatal error has occurred while editing strings. "
+                              "Please reboot the application.";
+            PrintFmt("%sError: %s\n", tag, msg);
+            ShowErrorDialog(msg);
+        } else {
+            ExecuteResult result = LaunchDefaultApp(url);
+            if (result.exit_code != 0) {
+                tuwString msg = tuwString("Failed to open a ") + type + " by an unexpected error.";
+                PrintFmt("%sError: %s\n", tag, msg.c_str());
+                ShowErrorDialog(msg.c_str());
+            }
         }
     }
 }
@@ -389,10 +397,10 @@ void MainFrame::Fit(bool keep_width) {
 bool MainFrame::Validate() {
     bool validate = true;
     bool redraw_flag = false;
-    std::string val_first_err;
+    tuwString val_first_err;
     for (Component* comp : m_components) {
         if (!comp->Validate(&redraw_flag)) {
-            const std::string& val_err = comp->GetValidationError();
+            const tuwString& val_err = comp->GetValidationError();
             if (validate)
                 val_first_err = val_err;
             validate = false;
@@ -414,8 +422,8 @@ bool MainFrame::Validate() {
 }
 
 // Make command string
-std::string MainFrame::GetCommand() {
-    std::vector<std::string> cmd_ary;
+tuwString MainFrame::GetCommand() {
+    std::vector<tuwString> cmd_ary;
     rapidjson::Value& sub_definition = m_definition["gui"][m_definition_id];
     for (rapidjson::Value& c : sub_definition["command_splitted"].GetArray())
         cmd_ary.emplace_back(c.GetString());
@@ -423,12 +431,12 @@ std::string MainFrame::GetCommand() {
     for (rapidjson::Value& c : sub_definition["command_ids"].GetArray())
         cmd_ids.emplace_back(c.GetInt());
 
-    std::vector<std::string> comp_strings = std::vector<std::string>(m_components.size());
+    std::vector<tuwString> comp_strings = std::vector<tuwString>(m_components.size());
     for (size_t i = 0; i < m_components.size(); i++) {
         comp_strings[i] = m_components[i]->GetString();
     }
 
-    std::string cmd = cmd_ary[0];
+    tuwString cmd = cmd_ary[0];
     for (size_t i = 0; i < cmd_ids.size(); i++) {
         int id = cmd_ids[i];
         if (id == CMD_ID_PERCENT) {
@@ -448,11 +456,11 @@ std::string MainFrame::GetCommand() {
 }
 
 void MainFrame::RunCommand() {
-    std::string cmd = GetCommand();
+    tuwString cmd = GetCommand();
     PrintFmt("[RunCommand] Command: %s\n", cmd.c_str());
 
     if (IsSafeMode()) {
-        std::string msg = "The command was not executed because the safe mode is enabled.\n"
+        tuwString msg = "The command was not executed because the safe mode is enabled.\n"
                           "You can disable it from the menu bar (Debug > Safe Mode.)\n"
                           "\n"
                           "Command: " + cmd;
@@ -480,6 +488,14 @@ void MainFrame::RunCommand() {
     bool show_last_line = json_utils::GetBool(sub_definition, "show_last_line", false);
     bool show_success_dialog = json_utils::GetBool(sub_definition, "show_success_dialog", true);
 
+    if (GetStringError() != STR_OK) {
+        const char* msg = "Fatal error has occurred while editing strings. "
+                          "Please reboot the application.";
+        PrintFmt("[RunCommand] Error: %s\n", msg);
+        ShowErrorDialog(msg);
+        return;
+    }
+
     if (!result.err_msg.empty()) {
         PrintFmt("[RunCommand] Error: %s\n", result.err_msg.c_str());
         ShowErrorDialog(result.err_msg);
@@ -487,11 +503,11 @@ void MainFrame::RunCommand() {
     }
 
     if (check_exit_code && result.exit_code != exit_success) {
-        std::string err_msg;
+        tuwString err_msg;
         if (show_last_line)
             err_msg = result.last_line;
         else
-            err_msg = ConcatCStrings("Invalid exit code (", result.exit_code, ")");
+            err_msg = tuwString("Invalid exit code (") + result.exit_code + ")";
         PrintFmt("[RunCommand] Error: %s\n", err_msg.c_str());
         ShowErrorDialog(err_msg);
         return;
@@ -530,7 +546,7 @@ json_utils::JsonResult MainFrame::CheckDefinition(rapidjson::Document& definitio
     return result;
 }
 
-void MainFrame::JsonLoadFailed(const std::string& msg) {
+void MainFrame::JsonLoadFailed(const tuwString& msg) {
     PrintFmt("[LoadDefinition] Error: %s\n", msg.c_str());
     ShowErrorDialog(msg);
 }
@@ -555,14 +571,14 @@ void MainFrame::SaveConfig() {
 
 bool g_no_dialog = false;
 
-void MainFrame::ShowSuccessDialog(const std::string& msg, const std::string& title) {
+void MainFrame::ShowSuccessDialog(const char* msg, const char* title) {
     if (g_no_dialog) return;
-    uiMsgBox(m_mainwin, title.c_str(), msg.c_str());
+    uiMsgBox(m_mainwin, title, msg);
 }
 
-void MainFrame::ShowErrorDialog(const std::string& msg, const std::string& title) {
+void MainFrame::ShowErrorDialog(const char* msg, const char* title) {
     if (g_no_dialog) return;
-    uiMsgBoxError(m_mainwin, title.c_str(), msg.c_str());
+    uiMsgBoxError(m_mainwin, title, msg);
 }
 
 void MainFrameDisableDialog() {

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -2,6 +2,7 @@
 #include "validator.h"
 #include "json_utils.h"
 #include "env_utils.h"
+#include "string_utils.h"
 
 void Validator::Initialize(const rapidjson::Value& j) {
     m_regex = json_utils::GetString(j, "regex", "");
@@ -32,7 +33,7 @@ static int IsUnsupportedPattern(const char *pattern) {
     return 0;
 }
 
-bool Validator::Validate(const std::string& str) {
+bool Validator::Validate(const tuwString& str) {
     if (m_not_empty && str.empty()) {
         if (m_not_empty_error.empty())
             m_error_msg = "Empty string is NOT allowed.";

--- a/tests/exe_container_test.cpp
+++ b/tests/exe_container_test.cpp
@@ -1,4 +1,3 @@
-#pragma once
 // Tests for json embedding
 // Todo: Write more tests
 
@@ -12,9 +11,11 @@ TEST(JsonEmbeddingTest, Embed) {
         ExeContainer exe;
         json_utils::JsonResult result = exe.Read(JSON_ALL_KEYS);
         EXPECT_TRUE(result.ok);
+        EXPECT_STREQ("", result.msg.c_str());
         exe.SetJson(test_json);
         result = exe.Write("embedded.json");
         EXPECT_TRUE(result.ok);
+        EXPECT_STREQ("", result.msg.c_str());
     }
     {
         rapidjson::Document test_json;
@@ -25,6 +26,7 @@ TEST(JsonEmbeddingTest, Embed) {
         ExeContainer exe;
         json_utils::JsonResult result = exe.Read("embedded.json");
         EXPECT_TRUE(result.ok);
+        EXPECT_STREQ("", result.msg.c_str());
         exe.GetJson(embedded_json);
         EXPECT_EQ(embedded_json, test_json);
     }

--- a/tests/json/relaxed.jsonc
+++ b/tests/json/relaxed.jsonc
@@ -3,7 +3,6 @@
     /*
      * Multi-line comments
      */
-    "label": "test",
     "command": "echo hello",
     "components": [],
     "help": {

--- a/tests/json/relaxed.jsonc
+++ b/tests/json/relaxed.jsonc
@@ -3,8 +3,12 @@
     /*
      * Multi-line comments
      */
-    "ary": [
-        "",
-        "trailing_comma",
-    ]
+    "label": "test",
+    "command": "echo hello",
+    "components": [],
+    "help": {
+        "label": "test",
+        "type": "url",
+        "url": "example.com",
+    },
 }

--- a/tests/json_check_test.cpp
+++ b/tests/json_check_test.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 // Tests for json checking
 // Todo: Write more tests
 

--- a/tests/json_check_test.cpp
+++ b/tests/json_check_test.cpp
@@ -71,6 +71,14 @@ TEST(JsonCheckTest, checkGUISuccess4) {
     EXPECT_TRUE(result.ok);
 }
 
+TEST(JsonCheckTest, checkGUISuccessRelaxed) {
+    rapidjson::Document test_json;
+    json_utils::JsonResult result = json_utils::LoadJson(JSON_RELAXED, test_json);
+    EXPECT_TRUE(result.ok);
+    json_utils::CheckDefinition(result, test_json);
+    EXPECT_TRUE(result.ok);
+}
+
 void CheckGUIError(rapidjson::Document& test_json, const char* expected) {
     json_utils::JsonResult result = JSON_RESULT_OK;
     json_utils::CheckDefinition(result, test_json);
@@ -82,7 +90,7 @@ TEST(JsonCheckTest, checkGUIFail) {
     rapidjson::Document test_json;
     GetTestJson(test_json);
     test_json.RemoveMember("gui");
-    CheckGUIError(test_json, "['gui'] not found.");
+    CheckGUIError(test_json, "['components'] not found.");
 }
 
 TEST(JsonCheckTest, checkGUIFail2) {
@@ -133,6 +141,14 @@ TEST(JsonCheckTest, checkGUIFail7) {
         " echo file: __comp2__ & echo folder: __comp3__ & echo combo: __comp4__"
         " & echo radio: __comp5__ & echo check: __comp6__ & echo check_array: __comp7__"
         " & echo textbox: __comp8__ & echo int: __comp9__ & echo float: __comp???__");
+}
+
+TEST(JsonCheckTest, checkGUIFailRelaxed) {
+    rapidjson::Document test_json;
+    json_utils::JsonResult result = json_utils::LoadJson(JSON_RELAXED, test_json);
+    EXPECT_TRUE(result.ok);
+    test_json.AddMember("exit_success", "a", test_json.GetAllocator());
+    CheckGUIError(test_json, "['exit_success'] should be an int.");
 }
 
 TEST(JsonCheckTest, checkHelpSuccess) {

--- a/tests/main_frame_test.cpp
+++ b/tests/main_frame_test.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 // Tests for main_frame.cpp
 // Todo: Write more tests
 
@@ -17,6 +15,7 @@ class MainFrameTest : public ::testing::Test {
         if (msg != NULL)
             printf("%s\n", msg);
         EXPECT_TRUE(msg == NULL);
+        EXPECT_EQ(STR_OK, GetStringError());
         uiMainSteps();
     }
 
@@ -27,9 +26,10 @@ class MainFrameTest : public ::testing::Test {
         // Need to reset the pointer to the log.
         SetLogEntry(NULL);
     #endif
+        EXPECT_EQ(STR_OK, GetStringError());
     }
 
-    void TestConfig(rapidjson::Document& test_json, std::string config) {
+    void TestConfig(rapidjson::Document& test_json, tuwString config) {
         rapidjson::Document test_config;
         json_utils::JsonResult result = json_utils::LoadJson(config, test_config);
         EXPECT_TRUE(result.ok);
@@ -98,7 +98,7 @@ TEST_F(MainFrameTest, GetCommand2) {
     rapidjson::Document dummy_config;
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
-    std::string expected = "echo file: \"test.txt\" & echo folder: \"testdir\"";
+    tuwString expected = "echo file: \"test.txt\" & echo folder: \"testdir\"";
     expected += " & echo combo: value3 & echo radio: value3 & echo check: flag!";
     expected += " & echo check_array:  --f2 & echo textbox: remove this text!";
     expected += " & echo int: 10 & echo float: 0.01";
@@ -111,7 +111,7 @@ TEST_F(MainFrameTest, GetCommand3) {
     rapidjson::Document dummy_config;
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
-    std::string expected = "echo file:  & echo folder:  & echo combo: value1 & echo radio: value1";
+    tuwString expected = "echo file:  & echo folder:  & echo combo: value1 & echo radio: value1";
     expected += " & echo check:  & echo check_array:  & echo textbox: ";
     expected += " & echo int: 0 & echo float: 0.0";
     EXPECT_STREQ(expected.c_str(), main_frame->GetCommand().c_str());
@@ -128,7 +128,7 @@ TEST_F(MainFrameTest, RunCommandSuccess) {
     main_frame->GetDefinition(actual_json);
     ASSERT_EQ(test_json["help"], actual_json["help"]);
 
-    std::string cmd = main_frame->GetCommand();
+    tuwString cmd = main_frame->GetCommand();
     ExecuteResult result = Execute(cmd);
     EXPECT_EQ(0, result.exit_code);
     EXPECT_STREQ("", result.err_msg.c_str());
@@ -143,7 +143,7 @@ TEST_F(MainFrameTest, RunCommandFail) {
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
 
-    std::string cmd = main_frame->GetCommand();
+    tuwString cmd = main_frame->GetCommand();
     ExecuteResult result = Execute(cmd);
     EXPECT_NE(0, result.exit_code);
     EXPECT_STRNE("", result.err_msg.c_str());
@@ -169,7 +169,7 @@ TEST_F(MainFrameTest, RunCommandShowLast) {
     main_frame = new MainFrame(test_json, dummy_config);
     main_frame->UpdatePanel(2);
 
-    std::string cmd = main_frame->GetCommand();
+    tuwString cmd = main_frame->GetCommand();
     ExecuteResult result = Execute(cmd);
     EXPECT_EQ(0, result.exit_code);
     EXPECT_STREQ("", result.err_msg.c_str());
@@ -187,8 +187,8 @@ TEST_F(MainFrameTest, LoadSaveConfigUTF) {
     rapidjson::Document test_json;
     GetTestJson(test_json);
     test_json["gui"][0].Swap(test_json["gui"][1]);
-    std::string cmd = test_json["gui"][0]["command"].GetString();
-    cmd.replace(12, 4, "ファイル");
+    tuwString cmd = test_json["gui"][0]["command"].GetString();
+    memcpy(cmd.data() + 12, "ファイル", 4);
     test_json["gui"][0]["command"].SetString(rapidjson::StringRef(cmd.c_str()));
     test_json["gui"][0]["components"][1]["id"].SetString("ファイル");
     TestConfig(test_json, JSON_CONFIG_UTF);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -7,6 +7,7 @@ test_sources = [
     'json_check_test.cpp',
     'main_frame_test.cpp',
     'string_utils_test.cpp',
+    'validator_test.cpp',
 ]
 
 # build tests

--- a/tests/string_utils_test.cpp
+++ b/tests/string_utils_test.cpp
@@ -1,37 +1,331 @@
-#pragma once
-
-// Tests for json checking
+// Tests for string utils
 // Todo: Write more tests
 
 #include "test_utils.h"
 
-TEST(StringUtilsTest, ConcatCStringsChar) {
-    std::string result = ConcatCStrings("test", "foo", "bar");
-    EXPECT_STREQ("testfoobar", result.c_str());
-    result = ConcatCStrings("test", "foo", nullptr);
-    EXPECT_STREQ("testfoo", result.c_str());
+void expect_nullstr(const tuwString& str) {
+    EXPECT_TRUE(str.empty());
+    EXPECT_EQ(str.size(), 0);
+    EXPECT_EQ(str.data(), nullptr);
+    EXPECT_STREQ(str.c_str(), "");
+    EXPECT_EQ(str, "");
 }
 
-TEST(StringUtilsTest, ConcatCStringsInt) {
+void expect_tuwstr(const char* expected, const tuwString& actual) {
+    size_t size = strlen(expected);
+    EXPECT_EQ(actual.size(), size);
+    EXPECT_STREQ(actual.data(), expected);
+    EXPECT_STREQ(actual.c_str(), expected);
+    EXPECT_EQ(actual, expected);
+}
+
+// Test tuwString()
+TEST(tuwStringTest, Construct) {
+    tuwString str;
+    expect_nullstr(str);
+}
+
+TEST(tuwStringTest, ConstructWithNull) {
+    tuwString str(nullptr);
+    expect_nullstr(str);
+}
+
+TEST(tuwStringTest, ConstructWithCstr) {
+    tuwString str("test");
+    EXPECT_FALSE(str.empty());
+    expect_tuwstr("test", str);
+}
+
+TEST(tuwStringTest, ConstructWithCstrAndSize) {
+    tuwString str("testtest", 4);
+    expect_tuwstr("test", str);
+}
+
+TEST(tuwStringTest, ConstructWithNullAndSize) {
+    tuwString str(nullptr, 4);
+    expect_nullstr(str);
+}
+
+TEST(tuwStringTest, ConstructWithTuwstr) {
+    tuwString str2("test");
+    tuwString str(str2);
+    expect_tuwstr("test", str);
+    expect_tuwstr("test", str2);
+}
+
+TEST(tuwStringTest, ConstructWithMovedTuwstr) {
+    tuwString str2("test");
+    tuwString str(std::move(str2));
+    expect_tuwstr("test", str);
+    expect_nullstr(str2);
+}
+
+TEST(tuwStringTest, ConstructWithSize) {
+    tuwString str(4);
+    EXPECT_TRUE(str.empty());
+    EXPECT_EQ(str.size(), 4);
+    EXPECT_EQ(str.data()[3], '\0');
+    EXPECT_STREQ(str.c_str(), "");
+    EXPECT_EQ(str, "");
+}
+
+// Test =
+TEST(tuwStringTest, AssignNull) {
+    tuwString str = nullptr;
+    expect_nullstr(str);
+}
+
+TEST(tuwStringTest, AssignCstr) {
+    tuwString str = "test";
+    expect_tuwstr("test", str);
+}
+
+TEST(tuwStringTest, AssignTuwstr) {
+    tuwString str2 ="test";
+    tuwString str = str2;
+    expect_tuwstr("test", str);
+    expect_tuwstr("test", str2);
+}
+
+TEST(tuwStringTest, AssingMovedTuwstr) {
+    tuwString str2 = "test";
+    tuwString str = std::move(str2);
+    expect_tuwstr("test", str);
+    expect_nullstr(str2);
+}
+
+TEST(tuwStringTest, AssingSelf) {
+    tuwString str = "test";
+    str = str;
+    expect_tuwstr("test", str);
+}
+
+TEST(tuwStringTest, AssingMovedSelf) {
+    tuwString str = "test";
+    str = std::move(str);
+    expect_tuwstr("test", str);
+}
+
+// Test +=
+TEST(tuwStringTest, AppendCstr) {
+    tuwString str = "test";
+    str += "foo";
+    expect_tuwstr("testfoo", str);
+}
+
+TEST(tuwStringTest, AppendNull) {
+    tuwString str = "test";
+    str += nullptr;
+    expect_tuwstr("test", str);
+}
+
+TEST(tuwStringTest, AppendToNull) {
+    tuwString str = nullptr;
+    str += "test";
+    expect_tuwstr("test", str);
+}
+
+TEST(tuwStringTest, AppendTuwstr) {
+    tuwString str = "test";
+    tuwString str2 = "foo";
+    str += str2;
+    expect_tuwstr("testfoo", str);
+    expect_tuwstr("foo", str2);
+}
+
+// Test +
+TEST(tuwStringTest, PlusCstr) {
+    tuwString str = tuwString("test") + "foo";
+    expect_tuwstr("testfoo", str);
+}
+
+TEST(tuwStringTest, PlusNull) {
+    tuwString str = tuwString("test") + nullptr;
+    expect_tuwstr("test", str);
+}
+
+TEST(tuwStringTest, PlusToNull) {
+    tuwString str = tuwString(nullptr) + "test";
+    expect_tuwstr("test", str);
+}
+
+TEST(tuwStringTest, PlusTuwstr) {
+    tuwString str = "test";
+    tuwString str2 = "foo";
+    tuwString str3 = str + str2;
+    expect_tuwstr("test", str);
+    expect_tuwstr("foo", str2);
+    expect_tuwstr("testfoo", str3);
+}
+
+TEST(tuwStringTest, PlusInt) {
     int a = -1;
-    std::string result = ConcatCStrings("test", a, "bar");
+    tuwString result = tuwString("test") + a + "bar";
     EXPECT_STREQ("test-1bar", result.c_str());
-    result = ConcatCStrings("test", a, nullptr);
-    EXPECT_STREQ("test-1", result.c_str());
 }
 
-TEST(StringUtilsTest, ConcatCStringsSizet) {
+TEST(tuwStringTest, PlusSizet) {
     size_t a = 100;
-    std::string result = ConcatCStrings("test", a, "bar");
+    tuwString result = tuwString("test") + a + "bar";
     EXPECT_STREQ("test100bar", result.c_str());
-    result = ConcatCStrings("test", a, nullptr);
-    EXPECT_STREQ("test100", result.c_str());
 }
 
-TEST(StringUtilsTest, ConcatCStringsUint32) {
+TEST(tuwStringTest, PlusUint32) {
     uint32_t a = 100;
-    std::string result = ConcatCStrings("test", a, "bar");
+    tuwString result = tuwString("test") + a + "bar";
     EXPECT_STREQ("test100bar", result.c_str());
-    result = ConcatCStrings("test", a, nullptr);
-    EXPECT_STREQ("test100", result.c_str());
+}
+
+TEST(tuwStringTest, CstrPlusTuwstr) {
+    tuwString str = "test" + tuwString("foo");
+    expect_tuwstr("testfoo", str);
+}
+
+TEST(tuwStringTest, NullPlusTuwstr) {
+    tuwString str = nullptr + tuwString("test");
+    expect_tuwstr("test", str);
+}
+
+// Test []
+TEST(tuwStringTest, Index) {
+    tuwString str = "test";
+    EXPECT_EQ('t', str[0]);
+    EXPECT_EQ('e', str[1]);
+    EXPECT_EQ('s', str[2]);
+    EXPECT_EQ('t', str[3]);
+    EXPECT_EQ('\0', str[4]);
+    EXPECT_EQ(STR_OK, GetStringError());
+    EXPECT_EQ('\0', str[5]);
+    EXPECT_EQ(STR_BOUNDARY_ERROR, GetStringError());
+    ClearStringError();
+}
+
+TEST(tuwStringTest, IndexNull) {
+    tuwString str;
+    EXPECT_EQ('\0', str[0]);
+}
+
+// Test == and !=
+TEST(tuwStringTest, EqualToStr) {
+    tuwString str = "test";
+    EXPECT_TRUE(str != nullptr);
+    EXPECT_EQ(str, "test");
+    EXPECT_EQ(str, tuwString("test"));
+    EXPECT_NE(str, "task");
+    EXPECT_NE(str, tuwString("task"));
+}
+
+TEST(tuwStringTest, EqualToStrReverse) {
+    tuwString str = "test";
+    EXPECT_NE(nullptr, str);
+    EXPECT_EQ("test", str);
+    EXPECT_NE("task", str);
+}
+
+TEST(tuwStringTest, EqualToNull) {
+    tuwString str;
+    EXPECT_EQ(str, nullptr);
+    EXPECT_EQ(str, "");
+    EXPECT_EQ(str, tuwString());
+    EXPECT_NE(str, "test");
+    EXPECT_NE(str, tuwString("test"));
+}
+
+TEST(tuwStringTest, EqualToNullReverse) {
+    tuwString str;
+    EXPECT_EQ(nullptr, str);
+    EXPECT_EQ("", str);
+    EXPECT_NE("test", str);
+}
+
+// Test find()
+TEST(tuwStringTest, FindChar) {
+    tuwString str = "footestfoo";
+    EXPECT_EQ(0, str.find('f'));
+    EXPECT_EQ(3, str.find('t'));
+    EXPECT_EQ(5, str.find('s'));
+    EXPECT_EQ(tuwString::npos, str.find('a'));
+    EXPECT_EQ(tuwString::npos, tuwString().find('a'));
+}
+
+TEST(tuwStringTest, FindCstr) {
+    tuwString str = "footestfoo";
+    EXPECT_EQ(0, str.find("foo"));
+    EXPECT_EQ(3, str.find("test"));
+    EXPECT_EQ(tuwString::npos, str.find(nullptr));
+    EXPECT_EQ(tuwString::npos, str.find("task"));
+    EXPECT_EQ(tuwString::npos, str.find("fooo"));
+    EXPECT_EQ(tuwString::npos, tuwString().find("test"));
+}
+
+TEST(tuwStringTest, FindTuwstr) {
+    tuwString str = "footestfoo";
+    EXPECT_EQ(0, str.find(tuwString("foo")));
+    EXPECT_EQ(3, str.find(tuwString("test")));
+    EXPECT_EQ(0, str.find(tuwString(nullptr)));
+    EXPECT_EQ(tuwString::npos, str.find(tuwString("task")));
+    EXPECT_EQ(tuwString::npos, str.find(tuwString("fooo")));
+    EXPECT_EQ(tuwString::npos, tuwString().find(tuwString("test")));
+}
+
+// Test push_back()
+TEST(tuwStringTest, Pushback) {
+    tuwString str;
+    expect_nullstr(str);
+    str.push_back('t');
+    expect_tuwstr("t", str);
+    str.push_back('e');
+    str.push_back('s');
+    str.push_back('t');
+    expect_tuwstr("test", str);
+}
+
+// Test substr()
+TEST(tuwStringTest, Substr) {
+    tuwString str = "footestfoo";
+    expect_tuwstr("foo", str.substr(0, 3));
+    expect_tuwstr("test", str.substr(3, 4));
+    EXPECT_EQ(STR_OK, GetStringError());
+    expect_nullstr(str.substr(7, 10));
+    expect_nullstr(str.substr(20, 4));
+    expect_nullstr(tuwString().substr(0, 3));
+    EXPECT_EQ(STR_BOUNDARY_ERROR, GetStringError());
+    ClearStringError();
+}
+
+// Test begin() and end()
+TEST(tuwStringTest, Iter) {
+    tuwString str = "footestfoo";
+    EXPECT_EQ(&str.data()[0], str.begin());
+    EXPECT_EQ(&str.data()[str.size()], str.end());
+}
+
+TEST(tuwStringTest, IterForNull) {
+    tuwString str;
+    EXPECT_EQ(&str.c_str()[0], str.begin());
+    EXPECT_EQ(&str.c_str()[0], str.end());
+}
+
+// Test tuwWstring
+void expect_nullwstr(const tuwWstring& str) {
+    EXPECT_TRUE(str.empty());
+    EXPECT_EQ(str.size(), 0);
+    EXPECT_STREQ(str.c_str(), L"");
+}
+
+void expect_tuwwstr(const wchar_t* expected, const tuwWstring& actual) {
+    size_t size = wcslen(expected);
+    EXPECT_EQ(actual.size(), size);
+    EXPECT_STREQ(actual.c_str(), expected);
+}
+
+TEST(tuwWstringTest, ConstructWithNull) {
+    tuwWstring str(nullptr);
+    expect_nullwstr(str);
+}
+
+TEST(tuwWstringTest, ConstructWithCstr) {
+    tuwWstring str(L"test");
+    EXPECT_FALSE(str.empty());
+    expect_tuwwstr(L"test", str);
 }

--- a/tests/string_utils_test.cpp
+++ b/tests/string_utils_test.cpp
@@ -306,6 +306,24 @@ TEST(tuwStringTest, IterForNull) {
     EXPECT_EQ(&str.c_str()[0], str.end());
 }
 
+// TestGetLastLine
+TEST(tuwStringTest, GetLastLine) {
+    expect_tuwstr("last", GetLastLine("last"));
+    expect_tuwstr("last", GetLastLine("last\n"));
+    expect_tuwstr("last", GetLastLine("\nlast"));
+    expect_tuwstr("last", GetLastLine("firs\nsecond\nlast\r\n\r\n"));
+}
+
+TEST(tuwStringTest, GetLastLineOneChar) {
+    expect_tuwstr("l", GetLastLine("l"));
+}
+
+TEST(tuwStringTest, GetLastLineNull) {
+    expect_nullstr(GetLastLine(nullptr));
+    expect_nullstr(GetLastLine(""));
+    expect_nullstr(GetLastLine("\n\n\n\n"));
+}
+
 // Test tuwWstring
 void expect_nullwstr(const tuwWstring& str) {
     EXPECT_TRUE(str.empty());
@@ -322,6 +340,8 @@ void expect_tuwwstr(const wchar_t* expected, const tuwWstring& actual) {
 TEST(tuwWstringTest, ConstructWithNull) {
     tuwWstring str(nullptr);
     expect_nullwstr(str);
+    tuwWstring str2(L"");
+    expect_nullwstr(str2);
 }
 
 TEST(tuwWstringTest, ConstructWithCstr) {

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <gtest/gtest.h>
-#include <string>
 #include "main_frame.h"
 #include "string_utils.h"
 #include "exec.h"

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -7,6 +7,7 @@
 #include "json_utils.h"
 #include "tuw_constants.h"
 #include "exe_container.h"
+#include "validator.h"
 #include "env_utils.h"
 
 // you need to copy it from examples/all_keys to the json folder

--- a/tests/validator_test.cpp
+++ b/tests/validator_test.cpp
@@ -1,0 +1,141 @@
+// Tests for json embedding
+// Todo: Write more tests
+
+#include "test_utils.h"
+
+Validator GetValidator(const char* config_str) {
+    rapidjson::Document config(rapidjson::kObjectType);
+    config.Parse(config_str);
+    Validator validator;
+    validator.Initialize(config);
+    return validator;
+}
+
+TEST(ValidatorTest, Regex) {
+    const char* config =
+        "{"
+        "    \"regex\": \"^[0-9]*$\""
+        "}";
+    Validator validator = GetValidator(config);
+    EXPECT_TRUE(validator.Validate("1234"));
+    EXPECT_FALSE(validator.Validate("1234abcd"));
+    EXPECT_STREQ("Regex match failed for pattern: ^[0-9]*$",
+                 validator.GetError().c_str());
+}
+
+TEST(ValidatorTest, RegexCompileError) {
+    const char* config =
+        "{"
+        "    \"regex\": \"^[0-9\""
+        "}";
+    Validator validator = GetValidator(config);
+    EXPECT_FALSE(validator.Validate("1234"));
+    EXPECT_STREQ("Failed to parse regex pattern: ^[0-9",
+                 validator.GetError().c_str());
+}
+
+TEST(ValidatorTest, RegexGroupOp) {
+    const char* config =
+        "{"
+        "    \"regex\": \"(a|b)\""
+        "}";
+    Validator validator = GetValidator(config);
+    EXPECT_FALSE(validator.Validate("1234"));
+    EXPECT_STREQ("Regex compile error: () operators are not supported.",
+                 validator.GetError().c_str());
+}
+
+TEST(ValidatorTest, RegexGroupOpEscape) {
+    const char* config =
+        "{"
+        "    \"regex\": \"^\\(a|b\\)\"$"
+        "}";
+    Validator validator = GetValidator(config);
+    EXPECT_TRUE(validator.Validate("(a"));
+    EXPECT_TRUE(validator.Validate("b)"));
+}
+
+TEST(ValidatorTest, RegexCustomError) {
+    const char* config =
+        "{"
+        "    \"regex\": \"^[0-9]*$\","
+        "    \"regex_error\": \"Should be numeric!\""
+        "}";
+    Validator validator = GetValidator(config);
+    EXPECT_FALSE(validator.Validate("abcd"));
+    EXPECT_STREQ("Should be numeric!",
+                 validator.GetError().c_str());
+}
+
+TEST(ValidatorTest, Wildcard) {
+    const char* config =
+        "{"
+        "    \"wildcard\": \"test*foo\""
+        "}";
+    Validator validator = GetValidator(config);
+    EXPECT_TRUE(validator.Validate("testfoo"));
+    EXPECT_TRUE(validator.Validate("testbarfoo"));
+    EXPECT_FALSE(validator.Validate("test"));
+    EXPECT_STREQ("Wildcard match failed for pattern: test*foo",
+                 validator.GetError().c_str());
+}
+
+TEST(ValidatorTest, WildcardCustomError) {
+    const char* config =
+        "{"
+        "    \"wildcard\": \"test*foo\","
+        "    \"wildcard_error\": \"Custom message!\""
+        "}";
+    Validator validator = GetValidator(config);
+    EXPECT_FALSE(validator.Validate("test"));
+    EXPECT_STREQ("Custom message!",
+                 validator.GetError().c_str());
+}
+
+TEST(ValidatorTest, NotEmpty) {
+    const char* config =
+        "{"
+        "    \"not_empty\": true"
+        "}";
+    Validator validator = GetValidator(config);
+    EXPECT_TRUE(validator.Validate("test"));
+    EXPECT_FALSE(validator.Validate(""));
+    EXPECT_STREQ("Empty string is NOT allowed.",
+                 validator.GetError().c_str());
+}
+
+TEST(ValidatorTest, NotEmptyCustomError) {
+    const char* config =
+        "{"
+        "    \"not_empty\": true,"
+        "    \"not_empty_error\": \"Custom message!\""
+        "}";
+    Validator validator = GetValidator(config);
+    EXPECT_FALSE(validator.Validate(""));
+    EXPECT_STREQ("Custom message!",
+                 validator.GetError().c_str());
+}
+
+TEST(ValidatorTest, Exist) {
+    const char* config =
+        "{"
+        "    \"exist\": true"
+        "}";
+    Validator validator = GetValidator(config);
+    EXPECT_TRUE(validator.Validate(JSON_ALL_KEYS));
+    EXPECT_FALSE(validator.Validate(tuwString(JSON_ALL_KEYS) + ".fake.does_not_exist"));
+    EXPECT_STREQ("Path does NOT exist.",
+                 validator.GetError().c_str());
+}
+
+TEST(ValidatorTest, ExistCustomError) {
+    const char* config =
+        "{"
+        "    \"exist\": true,"
+        "    \"exist_error\": \"Custom message!\""
+        "}";
+    Validator validator = GetValidator(config);
+    EXPECT_FALSE(validator.Validate(tuwString(JSON_ALL_KEYS) + ".fake.does_not_exist"));
+    EXPECT_STREQ("Custom message!",
+                 validator.GetError().c_str());
+}


### PR DESCRIPTION
Merge latest updates into the main branch.

- Array brackets can now be omitted when the array has only one item. (#51)
- GUI elements can now be defined in root object when the `"gui"` array has only one item. (#52)
- GUI labels became optional, and "window_name" can now be default values of GUI labels. (#54)
- Tuw now redirects stderr into the console window. (#57)
- Replaced std::string with a custom string class to reduce the binary size. (#56)
- Renamed Windows10 build from `*-Windows-x64-ucrt.zip` to `*-Windows10-x64.zip`. (#50)