### PR TITLE
Fix memory leak on Linux

### DIFF
--- a/include/exe_container.h
+++ b/include/exe_container.h
@@ -15,12 +15,23 @@ class ExeContainer {
                     m_json() {
         m_json.SetObject();
     }
-    json_utils::JsonResult Read(const tuwString& exe_path);
-    json_utils::JsonResult Write(const tuwString& exe_path);
-    bool HasJson() { return m_json.IsObject() && !m_json.ObjectEmpty(); }
-    void GetJson(rapidjson::Document& json) { json.CopyFrom(m_json, json.GetAllocator()); }
-    void SetJson(rapidjson::Document& json) { m_json.CopyFrom(json, m_json.GetAllocator()); }
-    void RemoveJson() {
+
+    json_utils::JsonResult Read(const tuwString& exe_path) noexcept;
+    json_utils::JsonResult Write(const tuwString& exe_path) noexcept;
+
+    bool HasJson() noexcept {
+        return m_json.IsObject() && !m_json.ObjectEmpty();
+    }
+
+    void GetJson(rapidjson::Document& json) noexcept {
+        json.CopyFrom(m_json, json.GetAllocator());
+    }
+
+    void SetJson(rapidjson::Document& json) noexcept {
+        m_json.CopyFrom(json, m_json.GetAllocator());
+    }
+
+    void RemoveJson() noexcept {
         rapidjson::Document doc;
         doc.SetObject();
         SetJson(doc);

--- a/include/exec.h
+++ b/include/exec.h
@@ -9,5 +9,6 @@ struct ExecuteResult {
 
 // When use_utf8_on_windows is true,
 // Tuw converts output strings from UTF-8 to UTF-16 on Windows.
-ExecuteResult Execute(const tuwString& cmd, bool use_utf8_on_windows = false);
-ExecuteResult LaunchDefaultApp(const tuwString& url);
+ExecuteResult Execute(const tuwString& cmd,
+                      bool use_utf8_on_windows = false) noexcept;
+ExecuteResult LaunchDefaultApp(const tuwString& url) noexcept;

--- a/include/json_utils.h
+++ b/include/json_utils.h
@@ -26,14 +26,14 @@ struct JsonResult {
 // Max binary size for JSON files.
 #define JSON_SIZE_MAX 128 * 1024
 
-JsonResult LoadJson(const tuwString& file, rapidjson::Document& json);
-JsonResult SaveJson(rapidjson::Document& json, const tuwString& file);
-tuwString JsonToString(rapidjson::Document& json);
+JsonResult LoadJson(const tuwString& file, rapidjson::Document& json) noexcept;
+JsonResult SaveJson(rapidjson::Document& json, const tuwString& file) noexcept;
+tuwString JsonToString(rapidjson::Document& json) noexcept;
 
-const char* GetString(const rapidjson::Value& json, const char* key, const char* def);
-bool GetBool(const rapidjson::Value& json, const char* key, bool def);
-int GetInt(const rapidjson::Value& json, const char* key, int def);
-double GetDouble(const rapidjson::Value& json, const char* key, double def);
+const char* GetString(const rapidjson::Value& json, const char* key, const char* def) noexcept;
+bool GetBool(const rapidjson::Value& json, const char* key, bool def) noexcept;
+int GetInt(const rapidjson::Value& json, const char* key, int def) noexcept;
+double GetDouble(const rapidjson::Value& json, const char* key, double def) noexcept;
 
 void GetDefaultDefinition(rapidjson::Document& definition);
 void CheckVersion(JsonResult& result, rapidjson::Document& definition);
@@ -41,6 +41,6 @@ void CheckDefinition(JsonResult& result, rapidjson::Document& definition);
 void CheckSubDefinition(JsonResult& result, rapidjson::Value& sub_definition,
                         int index,
                         rapidjson::Document::AllocatorType& alloc);
-void CheckHelpURLs(JsonResult& result, rapidjson::Document& definition);
+void CheckHelpURLs(JsonResult& result, rapidjson::Document& definition) noexcept;
 
 }  // namespace json_utils

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -11,10 +11,10 @@ enum StringError : int {
 };
 
 // Returns the error status for tuwString.
-StringError GetStringError();
+StringError GetStringError() noexcept;
 
 // Set STR_OK to the error status.
-void ClearStringError();
+void ClearStringError() noexcept;
 
 // String class that doesn't raise std errors.
 // It works without any crashes even when it got a memory allocation error.
@@ -24,102 +24,104 @@ class tuwString {
  private:
     char* m_str;
     size_t m_size;
-    void alloc_cstr(const char* str, size_t size);
-    void append(const char* str, size_t size);
+    void alloc_cstr(const char* str, size_t size) noexcept;
+    void append(const char* str, size_t size) noexcept;
 
  public:
-    tuwString() : m_str(nullptr), m_size(0) {}
-    tuwString(const char* str);  // NOLINT(runtime/explicit)
-    tuwString(const char* str, size_t size);
-    tuwString(const tuwString& str);
-    tuwString(tuwString&& str);
+    tuwString() noexcept : m_str(nullptr), m_size(0) {}
+    tuwString(const char* str) noexcept;  // NOLINT(runtime/explicit)
+    tuwString(const char* str, size_t size) noexcept;
+    tuwString(const tuwString& str) noexcept;
+    tuwString(tuwString&& str) noexcept;
 
     // This allocates null bytes to use them as a buffer.
-    explicit tuwString(size_t size);
+    explicit tuwString(size_t size) noexcept;
 
-    ~tuwString() { clear(); }
-    size_t length() const { return m_size; }
-    size_t size() const { return m_size; }
+    ~tuwString() noexcept { clear(); }
+    size_t length() const noexcept { return m_size; }
+    size_t size() const noexcept { return m_size; }
 
-    bool empty() const { return !m_str || m_str[0] == '\0' || m_size == 0; }
+    bool empty() const noexcept {
+        return !m_str || m_str[0] == '\0' || m_size == 0;
+    }
 
     // Returns an immutable C string. This can't be null.
-    const char* c_str() const {
+    const char* c_str() const noexcept {
         if (m_str)
             return m_str;
         return "";
     }
 
     // Returns a pointer to the actual buffer.
-    char* data() const { return m_str; }
+    char* data() const noexcept { return m_str; }
 
-    void clear() {
+    void clear() noexcept {
         if (m_str)
             free(m_str);
         m_str = nullptr;
         m_size = 0;
     }
 
-    const char& operator[](size_t id) const;
+    const char& operator[](size_t id) const noexcept;
 
-    tuwString& operator=(const char* str);
-    tuwString& operator=(const tuwString& str);
-    tuwString& operator=(tuwString&& str);
+    tuwString& operator=(const char* str) noexcept;
+    tuwString& operator=(const tuwString& str) noexcept;
+    tuwString& operator=(tuwString&& str) noexcept;
 
-    tuwString& operator+=(const char* str);
-    tuwString& operator+=(const tuwString& str);
+    tuwString& operator+=(const char* str) noexcept;
+    tuwString& operator+=(const tuwString& str) noexcept;
 
-    tuwString operator+(const char* str) const;
-    tuwString operator+(const tuwString& str) const;
+    tuwString operator+(const char* str) const noexcept;
+    tuwString operator+(const tuwString& str) const noexcept;
 
     // You can append numbers as strings
-    tuwString operator+(int num) const;
-    tuwString operator+(size_t num) const;
-    tuwString operator+(uint32_t num) const;
+    tuwString operator+(int num) const noexcept;
+    tuwString operator+(size_t num) const noexcept;
+    tuwString operator+(uint32_t num) const noexcept;
 
-    bool operator==(const char* str) const;
-    bool operator==(const tuwString& str) const;
-    inline bool operator!=(const char* str) const {
+    bool operator==(const char* str) const noexcept;
+    bool operator==(const tuwString& str) const noexcept;
+    inline bool operator!=(const char* str) const noexcept {
         return !(*this == str);
     }
-    inline bool operator!=(const tuwString& str) const {
+    inline bool operator!=(const tuwString& str) const noexcept {
         return !(*this == str);
     }
 
-    const char* begin() const {
+    const char* begin() const noexcept {
         return c_str();
     }
 
-    const char* end() const {
+    const char* end() const noexcept {
         return c_str() + m_size;
     }
 
     static const size_t npos;
-    size_t find(const char c) const;
-    size_t find(const char* str) const;
-    inline size_t find(const tuwString& str) const {
+    size_t find(const char c) const noexcept;
+    size_t find(const char* str) const noexcept;
+    inline size_t find(const tuwString& str) const noexcept {
         return find(str.c_str());
     }
 
-    void push_back(const char c) {
+    void push_back(const char c) noexcept {
         this->append(&c, 1);
     }
 
-    tuwString substr(size_t start, size_t size) const;
+    tuwString substr(size_t start, size_t size) const noexcept;
 };
 
-tuwString operator+(const char* str1, const tuwString& str2);
+tuwString operator+(const char* str1, const tuwString& str2) noexcept;
 
-inline bool operator==(const char* str1, const tuwString& str2) {
+inline bool operator==(const char* str1, const tuwString& str2) noexcept {
     return str2 == str1;
 }
 
-inline bool operator!=(const char* str1, const tuwString& str2) {
+inline bool operator!=(const char* str1, const tuwString& str2) noexcept {
     return str2 != str1;
 }
 
 // Returns only the last line and removes trailing line feeds (\n and \r.)
-tuwString GetLastLine(const tuwString& str);
+tuwString GetLastLine(const tuwString& str) noexcept;
 
 class tuwWstring {
  private:
@@ -127,19 +129,21 @@ class tuwWstring {
     size_t m_size;
 
  public:
-    tuwWstring(const wchar_t* str);  // NOLINT(runtime/explicit)
-    ~tuwWstring() { clear(); }
-    size_t length() const { return m_size; }
-    size_t size() const { return m_size; }
-    bool empty() const { return !m_str || m_str[0] == L'\0' || m_size == 0; }
+    tuwWstring(const wchar_t* str) noexcept;  // NOLINT(runtime/explicit)
+    ~tuwWstring() noexcept { clear(); }
+    size_t length() const noexcept { return m_size; }
+    size_t size() const noexcept { return m_size; }
+    bool empty() const noexcept {
+        return !m_str || m_str[0] == L'\0' || m_size == 0;
+    }
 
-    const wchar_t* c_str() const {
+    const wchar_t* c_str() const noexcept {
         if (m_str)
             return m_str;
         return L"";
     }
 
-    void clear() {
+    void clear() noexcept {
         if (m_str)
             free(m_str);
         m_str = nullptr;
@@ -147,7 +151,7 @@ class tuwWstring {
     }
 };
 
-inline tuwString envuStr(char *cstr) {
+inline tuwString envuStr(char *cstr) noexcept {
     if (cstr == NULL)
         return "";
     tuwString str = cstr;
@@ -155,16 +159,16 @@ inline tuwString envuStr(char *cstr) {
     return str;
 }
 
-uint32_t Fnv1Hash32(const tuwString& str);
+uint32_t Fnv1Hash32(const tuwString& str) noexcept;
 
 #ifdef _WIN32
-tuwString UTF16toUTF8(const wchar_t* str);
-tuwWstring UTF8toUTF16(const char* str);
-void FprintFmt(FILE* out, const char* fmt, ...);
-void EnableCSI();
+tuwString UTF16toUTF8(const wchar_t* str) noexcept;
+tuwWstring UTF8toUTF16(const char* str) noexcept;
+void FprintFmt(FILE* out, const char* fmt, ...) noexcept;
+void EnableCSI() noexcept;
 #elif defined(__TUW_UNIX__)
-void SetLogEntry(void* log_entry);
-void FprintFmt(FILE* out, const char* fmt, ...);
+void SetLogEntry(void* log_entry) noexcept;
+void FprintFmt(FILE* out, const char* fmt, ...) noexcept;
 #else
 #define FprintFmt(...) fprintf(__VA_ARGS__)
 #endif

--- a/include/validator.h
+++ b/include/validator.h
@@ -21,7 +21,7 @@ class Validator {
                   m_not_empty(false), m_exist(false),
                   m_error_msg("") {}
     ~Validator() {}
-    void Initialize(const rapidjson::Value& j);
-    bool Validate(const tuwString& str);
-    const tuwString& GetError() const { return m_error_msg; }
+    void Initialize(const rapidjson::Value& j) noexcept;
+    bool Validate(const tuwString& str) noexcept;
+    const tuwString& GetError() const noexcept { return m_error_msg; }
 };

--- a/src/exe_container.cpp
+++ b/src/exe_container.cpp
@@ -7,7 +7,7 @@
 
 #include "string_utils.h"
 
-static uint32_t ReadUint32(FILE* io) {
+static uint32_t ReadUint32(FILE* io) noexcept {
     unsigned char int_as_bin[4];
     if (fread(int_as_bin, 1, 4, io) != 4)
         return 0;
@@ -15,7 +15,7 @@ static uint32_t ReadUint32(FILE* io) {
            static_cast<uint32_t>(int_as_bin[2] << 16) | static_cast<uint32_t>(int_as_bin[3] << 24);
 }
 
-static void WriteUint32(FILE* io, const uint32_t& num) {
+static void WriteUint32(FILE* io, const uint32_t& num) noexcept {
     unsigned char int_as_bin[4] = {
         static_cast<unsigned char>(num & 0xFF),
         static_cast<unsigned char>((num >> 8) & 0xFF),
@@ -28,14 +28,14 @@ static void WriteUint32(FILE* io, const uint32_t& num) {
 #define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
 #define BUF_SIZE 1024
 
-static tuwString ReadStr(FILE* io, const uint32_t& size) {
+static tuwString ReadStr(FILE* io, const uint32_t& size) noexcept {
     tuwString str(size);
     if (fread(str.data(), 1, size, io) != size)
         return "";
     return str;
 }
 
-static void WriteStr(FILE* io, const tuwString& str) {
+static void WriteStr(FILE* io, const tuwString& str) noexcept {
     fwrite(str.data(), 1, str.size(), io);
 
     // Zero padding
@@ -44,7 +44,7 @@ static void WriteStr(FILE* io, const tuwString& str) {
     fwrite(padding_bytes, 1, padding, io);
 }
 
-static bool CopyBinary(FILE* reader, FILE* writer, uint32_t size) {
+static bool CopyBinary(FILE* reader, FILE* writer, uint32_t size) noexcept {
     char buff[BUF_SIZE];
     while (size > 0) {
         size_t copy_size = MIN(BUF_SIZE, size);
@@ -57,14 +57,14 @@ static bool CopyBinary(FILE* reader, FILE* writer, uint32_t size) {
     return true;
 }
 
-static void ReadMagic(FILE* io, char* magic) {
+static void ReadMagic(FILE* io, char* magic) noexcept {
     magic[4] = '\0';
     if (fread(magic, 1, 4, io) != 4)
         memset(magic, 0, sizeof(char) * 4);
     return;
 }
 
-static uint32_t Length(FILE* io) {
+static uint32_t Length(FILE* io) noexcept {
     uint32_t cur = ftell(io);
     fseek(io, 0, SEEK_END);
     uint32_t len = ftell(io);
@@ -74,7 +74,7 @@ static uint32_t Length(FILE* io) {
 
 static const uint32_t EXE_SIZE_MAX = 20000000;  // Allowed size of exe
 
-json_utils::JsonResult ExeContainer::Read(const tuwString& exe_path) {
+json_utils::JsonResult ExeContainer::Read(const tuwString& exe_path) noexcept {
     if (GetStringError() != STR_OK) {
         // Reject the operation as the exe_path might have an unexpected value.
         return { false, "Fatal error has occurred while editing strings." };
@@ -145,7 +145,7 @@ json_utils::JsonResult ExeContainer::Read(const tuwString& exe_path) {
     return JSON_RESULT_OK;
 }
 
-json_utils::JsonResult ExeContainer::Write(const tuwString& exe_path) {
+json_utils::JsonResult ExeContainer::Write(const tuwString& exe_path) noexcept {
     if (GetStringError() != STR_OK) {
         // Reject the operation as the exe_path might have an unexpected value.
         return { false, "Fatal error has occurred while editing strings." };

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -34,7 +34,7 @@ namespace json_utils {
     constexpr auto JSONC_FLAGS =
         rapidjson::kParseCommentsFlag | rapidjson::kParseTrailingCommasFlag;
 
-    JsonResult LoadJson(const tuwString& file, rapidjson::Document& json) {
+    JsonResult LoadJson(const tuwString& file, rapidjson::Document& json) noexcept {
         FILE* fp = fopen(file.c_str(), "rb");
         if (!fp)
             return { false, "Failed to open " + file };
@@ -57,7 +57,7 @@ namespace json_utils {
         return JSON_RESULT_OK;
     }
 
-    JsonResult SaveJson(rapidjson::Document& json, const tuwString& file) {
+    JsonResult SaveJson(rapidjson::Document& json, const tuwString& file) noexcept {
         FILE* fp = fopen(file.c_str(), "wb");
         if (!fp)
             return { false, "Failed to open " + file + "." };
@@ -70,38 +70,38 @@ namespace json_utils {
         return JSON_RESULT_OK;
     }
 
-    tuwString JsonToString(rapidjson::Document& json) {
+    tuwString JsonToString(rapidjson::Document& json) noexcept {
         rapidjson::StringBuffer buffer;
         rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
         json.Accept(writer);
         return buffer.GetString();
     }
 
-    const char* GetString(const rapidjson::Value& json, const char* key, const char* def) {
+    const char* GetString(const rapidjson::Value& json, const char* key, const char* def) noexcept {
         if (json.HasMember(key))
             return json[key].GetString();
         return def;
     }
 
-    bool GetBool(const rapidjson::Value& json, const char* key, bool def) {
+    bool GetBool(const rapidjson::Value& json, const char* key, bool def) noexcept {
         if (json.HasMember(key))
             return json[key].GetBool();
         return def;
     }
 
-    int GetInt(const rapidjson::Value& json, const char* key, int def) {
+    int GetInt(const rapidjson::Value& json, const char* key, int def) noexcept {
         if (json.HasMember(key))
             return json[key].GetInt();
         return def;
     }
 
-    double GetDouble(const rapidjson::Value& json, const char* key, double def) {
+    double GetDouble(const rapidjson::Value& json, const char* key, double def) noexcept {
         if (json.HasMember(key))
             return json[key].GetDouble();
         return def;
     }
 
-    static tuwString GetLabel(const char* label, const char* key) {
+    static tuwString GetLabel(const char* label, const char* key) noexcept {
         tuwString msg;
         if (*label != '\0') {
             msg = tuwString("['") + label + "']";
@@ -122,7 +122,7 @@ namespace json_utils {
     static const bool OPTIONAL = true;
 
     static void CheckJsonType(JsonResult& result, const rapidjson::Value& j, const char* key,
-            const JsonType& type, const char* label = "", const bool& optional = false) {
+            const JsonType& type, const char* label = "", const bool& optional = false) noexcept {
         if (!j.HasMember(key)) {
             if (optional) return;
             result.ok = false;
@@ -165,7 +165,7 @@ namespace json_utils {
 
 
     static bool IsJsonArray(rapidjson::Value& j, const char* key,
-                            rapidjson::Document::AllocatorType& alloc) {
+                            rapidjson::Document::AllocatorType& alloc) noexcept {
         if (!j[key].IsArray()) {
             if (!j[key].IsObject())
                 return false;
@@ -181,7 +181,7 @@ namespace json_utils {
     }
 
     static bool IsStringArray(rapidjson::Value& j, const char* key,
-                              rapidjson::Document::AllocatorType& alloc) {
+                              rapidjson::Document::AllocatorType& alloc) noexcept {
         if (!j[key].IsArray()) {
             if (!j[key].IsString())
                 return false;
@@ -198,7 +198,7 @@ namespace json_utils {
 
     static void CheckJsonArrayType(JsonResult& result, rapidjson::Value& j, const char* key,
             const JsonType& type, rapidjson::Document::AllocatorType& alloc,
-            const char* label = "", const bool& optional = false) {
+            const char* label = "", const bool& optional = false) noexcept {
         if (!j.HasMember(key)) {
             if (optional) return;
             result.ok = false;
@@ -249,7 +249,7 @@ namespace json_utils {
     static void CorrectKey(rapidjson::Value& j,
                            const char* false_key,
                            const char* true_key,
-                           rapidjson::Document::AllocatorType& alloc) {
+                           rapidjson::Document::AllocatorType& alloc) noexcept {
         if (!j.HasMember(true_key) && j.HasMember(false_key)) {
             rapidjson::Value n(true_key, alloc);
             j.AddMember(n, j[false_key], alloc);
@@ -397,7 +397,7 @@ namespace json_utils {
     }
 
     // don't use map. it will make exe larger.
-    int ComptypeToInt(const char* comptype) {
+    int ComptypeToInt(const char* comptype) noexcept {
         if (strcmp(comptype, "static_text") == 0)
             return COMP_STATIC_TEXT;
         else if (strcmp(comptype, "file") == 0)
@@ -432,7 +432,7 @@ namespace json_utils {
     }
 
     void CheckValidator(JsonResult& result, rapidjson::Value& validator,
-                        const char* label) {
+                        const char* label) noexcept {
         CheckJsonType(result, validator, "regex", JsonType::STRING, label, OPTIONAL);
         CheckJsonType(result, validator, "regex_error", JsonType::STRING, label, OPTIONAL);
         CheckJsonType(result, validator, "wildcard", JsonType::STRING, label, OPTIONAL);
@@ -714,7 +714,7 @@ namespace json_utils {
         }
     }
 
-    void CheckHelpURLs(JsonResult& result, rapidjson::Document& definition) {
+    void CheckHelpURLs(JsonResult& result, rapidjson::Document& definition) noexcept {
         if (!definition.HasMember("help")) return;
         CheckJsonArrayType(result, definition, "help", JsonType::JSON, definition.GetAllocator());
         if (!result.ok) return;

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -9,12 +9,21 @@
 #include "windows/uipriv_windows.hpp"
 #endif
 
-StringError g_error_status = STR_OK;
-StringError GetStringError() { return g_error_status; }
-void ClearStringError() { g_error_status = STR_OK; }
-inline static void SetStringError(StringError err) { g_error_status = err; }
+static StringError g_error_status = STR_OK;
 
-void tuwString::alloc_cstr(const char *str, size_t size) {
+StringError GetStringError() noexcept {
+    return g_error_status;
+}
+
+void ClearStringError() noexcept {
+    g_error_status = STR_OK;
+}
+
+inline static void SetStringError(StringError err) noexcept {
+    g_error_status = err;
+}
+
+void tuwString::alloc_cstr(const char *str, size_t size) noexcept {
     clear();
     if (!str || size == 0)
         return;
@@ -32,28 +41,28 @@ void tuwString::alloc_cstr(const char *str, size_t size) {
 
 #define get_strlen(str) ((str) ? strlen(str) : 0)
 
-tuwString::tuwString(const char* str) :
+tuwString::tuwString(const char* str) noexcept :
         m_str(nullptr), m_size(0) {
     alloc_cstr(str, get_strlen(str));
 }
 
-tuwString::tuwString(const char* str, size_t size) :
+tuwString::tuwString(const char* str, size_t size) noexcept :
         m_str(nullptr), m_size(0) {
     alloc_cstr(str, size);
 }
 
-tuwString::tuwString(const tuwString& str) :
+tuwString::tuwString(const tuwString& str) noexcept :
         m_str(nullptr), m_size(0) {
     alloc_cstr(str.c_str(), str.size());
 }
 
-tuwString::tuwString(tuwString&& str) :
+tuwString::tuwString(tuwString&& str) noexcept :
         m_str(str.m_str), m_size(str.m_size) {
     str.m_str = nullptr;
     str.m_size = 0;
 }
 
-tuwString::tuwString(size_t size) : m_size(size) {
+tuwString::tuwString(size_t size) noexcept : m_size(size) {
     m_str = reinterpret_cast<char*>(calloc(size + 1, sizeof(char)));
     if (!m_str) {
         m_size = 0;
@@ -61,18 +70,18 @@ tuwString::tuwString(size_t size) : m_size(size) {
     }
 }
 
-tuwString& tuwString::operator=(const char* str) {
+tuwString& tuwString::operator=(const char* str) noexcept {
     alloc_cstr(str, get_strlen(str));
     return *this;
 }
 
-tuwString& tuwString::operator=(const tuwString& str) {
+tuwString& tuwString::operator=(const tuwString& str) noexcept {
     if (this == &str) return *this;
     alloc_cstr(str.c_str(), str.size());
     return *this;
 }
 
-tuwString& tuwString::operator=(tuwString&& str) {
+tuwString& tuwString::operator=(tuwString&& str) noexcept {
     if (this == &str) return *this;
     clear();
     m_str = str.m_str;
@@ -82,7 +91,7 @@ tuwString& tuwString::operator=(tuwString&& str) {
     return *this;
 }
 
-void tuwString::append(const char* str, size_t size) {
+void tuwString::append(const char* str, size_t size) noexcept {
     if (!str || size == 0)
         return;
 
@@ -103,23 +112,23 @@ void tuwString::append(const char* str, size_t size) {
     m_size = new_size;
 }
 
-tuwString& tuwString::operator+=(const char* str) {
+tuwString& tuwString::operator+=(const char* str) noexcept {
     append(str, get_strlen(str));
     return *this;
 }
 
-tuwString& tuwString::operator+=(const tuwString& str) {
+tuwString& tuwString::operator+=(const tuwString& str) noexcept {
     append(str.c_str(), str.size());
     return *this;
 }
 
-tuwString tuwString::operator+(const char* str) const {
+tuwString tuwString::operator+(const char* str) const noexcept {
     tuwString new_str(*this);
     new_str += str;
     return new_str;
 }
 
-tuwString tuwString::operator+(const tuwString& str) const {
+tuwString tuwString::operator+(const tuwString& str) const noexcept {
     tuwString new_str(*this);
     new_str += str;
     return new_str;
@@ -127,7 +136,7 @@ tuwString tuwString::operator+(const tuwString& str) const {
 
 // Convert number to c string, and append it to string.
 # define DEFINE_PLUS_FOR_NUM(num_type, fmt) \
-tuwString tuwString::operator+(num_type num) const { \
+tuwString tuwString::operator+(num_type num) const noexcept { \
     tuwString new_str(*this); \
     \
     int num_size = snprintf(nullptr, 0, "%" fmt, num); \
@@ -158,17 +167,17 @@ DEFINE_PLUS_FOR_NUM(uint32_t, PRIu32)
 
 #define null_to_empty(str) ((str) ? str : "")
 
-bool tuwString::operator==(const char* str) const {
+bool tuwString::operator==(const char* str) const noexcept {
     return strcmp(c_str(), null_to_empty(str)) == 0;
 }
 
-bool tuwString::operator==(const tuwString& str) const {
+bool tuwString::operator==(const tuwString& str) const noexcept {
     return strcmp(c_str(), str.c_str()) == 0;
 }
 
 const size_t tuwString::npos = static_cast<size_t>(-1);
 
-size_t tuwString::find(const char c) const {
+size_t tuwString::find(const char c) const noexcept {
     if (empty()) return npos;
     const char* p = begin();
     for (; p < end(); p++) {
@@ -178,7 +187,7 @@ size_t tuwString::find(const char c) const {
     return npos;
 }
 
-size_t tuwString::find(const char* str) const {
+size_t tuwString::find(const char* str) const noexcept {
     if (empty() || !str) return npos;
 
     // Note: This function uses a slow algorithm.
@@ -196,7 +205,7 @@ size_t tuwString::find(const char* str) const {
     return npos;
 }
 
-tuwString tuwString::substr(size_t start, size_t size) const {
+tuwString tuwString::substr(size_t start, size_t size) const noexcept {
     if (start + size > m_size) {
         SetStringError(STR_BOUNDARY_ERROR);
         return tuwString();
@@ -205,7 +214,7 @@ tuwString tuwString::substr(size_t start, size_t size) const {
     return new_str;
 }
 
-const char& tuwString::operator[](size_t id) const {
+const char& tuwString::operator[](size_t id) const noexcept {
     if (id > m_size) {
         SetStringError(STR_BOUNDARY_ERROR);
         return ""[0];
@@ -213,17 +222,17 @@ const char& tuwString::operator[](size_t id) const {
     return c_str()[id];
 }
 
-tuwString operator+(const char* str1, const tuwString& str2) {
+tuwString operator+(const char* str1, const tuwString& str2) noexcept {
     tuwString new_str(str1);
     new_str += str2;
     return new_str;
 }
 
-static inline bool IsNewline(char ch) {
+static inline bool IsNewline(char ch) noexcept {
     return ch == '\n' || ch == '\r';
 }
 
-tuwString GetLastLine(const tuwString& str) {
+tuwString GetLastLine(const tuwString& str) noexcept {
     if (str.empty()) return "";
 
     const char* begin = str.begin();
@@ -239,7 +248,7 @@ tuwString GetLastLine(const tuwString& str) {
     return str.substr(static_cast<size_t>(sub_begin - begin), end - sub_begin + 1);
 }
 
-tuwWstring::tuwWstring(const wchar_t* str) :
+tuwWstring::tuwWstring(const wchar_t* str) noexcept :
         m_str(nullptr), m_size(0) {
     if (!str) return;
 
@@ -261,28 +270,28 @@ tuwWstring::tuwWstring(const wchar_t* str) :
 static const uint32_t FNV_OFFSET_BASIS_32 = 2166136261U;
 static const uint32_t FNV_PRIME_32 = 16777619U;
 
-uint32_t Fnv1Hash32(const tuwString& str) {
+uint32_t Fnv1Hash32(const tuwString& str) noexcept {
     uint32_t hash = FNV_OFFSET_BASIS_32;
     for (const char c : str) hash = (FNV_PRIME_32 * hash) ^ c;
     return hash;
 }
 
 #ifdef _WIN32
-tuwString UTF16toUTF8(const wchar_t* str) {
+tuwString UTF16toUTF8(const wchar_t* str) noexcept {
     char* uchar = toUTF8(str);
     tuwString ustr = uchar;
     uiprivFree(uchar);
     return ustr;
 }
 
-tuwWstring UTF8toUTF16(const char* str) {
+tuwWstring UTF8toUTF16(const char* str) noexcept {
     wchar_t* widechar = toUTF16(str);
     tuwWstring wstr = widechar;
     uiprivFree(widechar);
     return wstr;
 }
 
-void FprintFmt(FILE* out, const char* fmt, ...) {
+void FprintFmt(FILE* out, const char* fmt, ...) noexcept {
     va_list va;
     va_start(va, fmt);
 
@@ -304,7 +313,7 @@ void FprintFmt(FILE* out, const char* fmt, ...) {
 }
 
 // Enable ANSI escape sequences on the console window.
-void EnableCSI() {
+void EnableCSI() noexcept {
     HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
     if (hOut == INVALID_HANDLE_VALUE)
         return;
@@ -383,7 +392,7 @@ constexpr pango_tag BG_TAGS[] = {
 };
 
 // Get opening markup tag from ANSI escape sequence
-static const pango_tag GetOpeningTag(ansi_escape_code code) {
+static const pango_tag GetOpeningTag(ansi_escape_code code) noexcept {
     if (code == ANSI_BOLD)
         return PangoTag("<b>");
     else if (code == ANSI_ITALIC)
@@ -400,7 +409,7 @@ static const pango_tag GetOpeningTag(ansi_escape_code code) {
 }
 
 // Get closing markup tag from ANSI escape sequence
-static const pango_tag GetClosingTag(ansi_escape_code code) {
+static const pango_tag GetClosingTag(ansi_escape_code code) noexcept {
     if (code == ANSI_BOLD)
         return PangoTag("</b>");
     else if (code == ANSI_ITALIC)
@@ -424,21 +433,21 @@ class TagStack {
     int m_top;
 
  public:
-    TagStack() : m_tags(), m_top(-1) {}
+    TagStack() noexcept : m_tags(), m_top(-1) {}
 
-    void Push(ansi_escape_code code) {
+    void Push(ansi_escape_code code) noexcept {
         if (m_top < MAX_STACK_SIZE - 1)
             m_tags[++m_top] = code;
     }
 
-    int Size() const { return m_top + 1; }
+    int Size() const noexcept { return m_top + 1; }
 
-    void Clear() { m_top = -1; }
+    void Clear() noexcept { m_top = -1; }
 
     using GetTagFunc = const pango_tag (*)(ansi_escape_code);
 
     // Get length of stacked tags
-    int GetTagLength(GetTagFunc GetTag) const {
+    int GetTagLength(GetTagFunc GetTag) const noexcept {
         int len = 0;
         const ansi_escape_code* max_tag = m_tags + m_top;
         for (const ansi_escape_code* code = m_tags; code <= max_tag; code++) {
@@ -447,16 +456,16 @@ class TagStack {
         return len;
     }
 
-    inline int OpeningTagLength() const {
+    inline int OpeningTagLength() const noexcept {
         return GetTagLength(GetOpeningTag);
     }
 
-    inline int ClosingTagLength() const {
+    inline int ClosingTagLength() const noexcept {
         return GetTagLength(GetClosingTag);
     }
 
     // Copy stacked tags to char*
-    int CopyTag(char* output, GetTagFunc GetTag, bool reverse) const {
+    int CopyTag(char* output, GetTagFunc GetTag, bool reverse) const noexcept {
         char* start = output;
         for (int i = 0; i <= m_top; i++) {
             int idx = reverse ? m_top - i : i;
@@ -467,17 +476,17 @@ class TagStack {
         return static_cast<int>(output - start);
     }
 
-    inline int CopyOpeningTag(char* output) const {
+    inline int CopyOpeningTag(char* output) const noexcept {
         return CopyTag(output, GetOpeningTag, false);
     }
 
-    inline int CopyClosingTag(char* output) const {
+    inline int CopyClosingTag(char* output) const noexcept {
         return CopyTag(output, GetClosingTag, true);
     }
 };
 
 // Get string length for ConvertAnsiToPango()
-int ConvertAnsiToPangoLength(TagStack* stack, const char *input) {
+int ConvertAnsiToPangoLength(TagStack* stack, const char *input) noexcept {
     const char *p = input;
     int closing_tag_len = stack->ClosingTagLength();
     int len = stack->OpeningTagLength();
@@ -530,7 +539,7 @@ int ConvertAnsiToPangoLength(TagStack* stack, const char *input) {
 }
 
 // Function to replace ANSI escape sequences with Pango markup
-void ConvertAnsiToPango(TagStack* stack, const char *input, char *output) {
+void ConvertAnsiToPango(TagStack* stack, const char *input, char *output) noexcept {
     const char *p = input;
     char *q = output;
 
@@ -604,11 +613,11 @@ class Logger {
     int m_buffer_length;
 
  public:
-    Logger() : m_log_entry(NULL), m_log_buffer(""),
-               m_tag_stack(), m_buffer_length(0) {}
-    ~Logger() {}
+    Logger() noexcept : m_log_entry(NULL), m_log_buffer(""),
+                        m_tag_stack(), m_buffer_length(0) {}
+    ~Logger() noexcept {}
 
-    void SetLogEntry(void* log_entry) {
+    void SetLogEntry(void* log_entry) noexcept {
         m_log_entry = static_cast<uiMultilineEntry*>(log_entry);
         if (!m_log_buffer.empty()) {
             Log(m_log_buffer.c_str());
@@ -616,7 +625,7 @@ class Logger {
         }
     }
 
-    void Log(const char* str) {
+     void Log(const char* str) {
         int markup_length = ConvertAnsiToPangoLength(&m_tag_stack, str);
         char *markup_str = new char[markup_length + 1];
         ConvertAnsiToPango(&m_tag_stack, str, markup_str);
@@ -649,7 +658,7 @@ class Logger {
 
 Logger g_logger = Logger();
 
-void SetLogEntry(void* log_entry) {
+void SetLogEntry(void* log_entry) noexcept {
     g_logger.SetLogEntry(log_entry);
 }
 

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -4,7 +4,7 @@
 #include "env_utils.h"
 #include "string_utils.h"
 
-void Validator::Initialize(const rapidjson::Value& j) {
+void Validator::Initialize(const rapidjson::Value& j) noexcept {
     m_regex = json_utils::GetString(j, "regex", "");
     m_regex_error = json_utils::GetString(j, "regex_error", "");
     m_wildcard = json_utils::GetString(j, "wildcard", "");
@@ -16,7 +16,7 @@ void Validator::Initialize(const rapidjson::Value& j) {
     m_error_msg = "";
 }
 
-static int IsUnsupportedPattern(const char *pattern) {
+static int IsUnsupportedPattern(const char *pattern) noexcept {
     // () operators are unsupported in tiny-regex-c
     // https://github.com/matyalatte/tiny-str-match?tab=readme-ov-file#supported-regex-operators
     const char* p = pattern;
@@ -33,7 +33,7 @@ static int IsUnsupportedPattern(const char *pattern) {
     return 0;
 }
 
-bool Validator::Validate(const tuwString& str) {
+bool Validator::Validate(const tuwString& str) noexcept {
     if (m_not_empty && str.empty()) {
         if (m_not_empty_error.empty())
             m_error_msg = "Empty string is NOT allowed.";


### PR DESCRIPTION
Related to #60.
In the console window for GTK build, there was a temporary buffer (`char* markup_str`) that was not freed. This PR fixes the issue. I also added the `noexcept` specifier to functions that don't throw exceptions.