### PR TITLE
Replace ubuntu 20.04 runners with docker images

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -64,11 +64,6 @@ jobs:
             zip_ext: zip
             arch: UCRT
             arch_suffix: 10-x64
-          - os: ubuntu-20.04
-            exe_ext: ""
-            zip_ext: tar.bz2
-            arch: ""
-            arch_suffix: -x64
           - os: macos-14
             exe_ext: ""
             zip_ext: tar.bz2
@@ -98,15 +93,10 @@ jobs:
         with:
           architecture: x64
 
-      - name: Install gtk for Linux
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install libgtk-3-dev
-
       - name: Build exe for Windows
         if: runner.os == 'Windows'
         run: batch_files/build.bat Release ${{ matrix.arch }}
+
       - name: Build exe for Unix
         if: runner.os != 'Windows'
         run: bash shell_scripts/build.sh Release
@@ -142,23 +132,34 @@ jobs:
         run: |
           gh release upload ${{ needs.setup.outputs.tag }} archive/${{ env.TOOL_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}${{ matrix.arch_suffix }}.${{ matrix.zip_ext }}
 
-  build-ubuntu-arm64:
+  build-ubuntu:
+    name: build-ubuntu-${{ matrix.arch }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ x64, arm64 ]
     runs-on: ubuntu-latest
     needs: setup
-    env:
-      zip_ext: tar.bz2
     steps:
       - uses: actions/checkout@v4
-      - name: Build ARM64 version on Ubuntu
+
+      - name: Build x64 version on Ubuntu 20.04
+        if : matrix.arch == 'x64'
+        run: |
+          sudo apt-get update
+          docker build -t tuw_ubuntu -f docker/ubuntu.dockerfile ./
+
+      - name: Build ARM64 version on Ubuntu 20.04
+        if : matrix.arch == 'arm64'
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user-static binfmt-support
-          docker buildx build --platform linux/arm64 -t tuw_ubuntu_arm -f docker/ubuntu.dockerfile ./
-          docker run --name tuw_ubuntu_arm tuw_ubuntu_arm
-          docker cp tuw_ubuntu_arm:/Tuw/build/Release/${{ env.TOOL_NAME }} ./
+          docker buildx build --platform linux/arm64 -t tuw_ubuntu -f docker/ubuntu.dockerfile ./
 
       - name: Copy files
         run: |
+          docker run --name tuw_ubuntu tuw_ubuntu
+          docker cp tuw_ubuntu:/Tuw/build/Release/${{ env.TOOL_NAME }} ./
           mkdir -p archive/${{ env.TOOL_NAME }}
           cp ${{ env.TOOL_NAME }} archive/${{ env.TOOL_NAME }}
           cp examples/other_features/help/gui_definition.json archive/${{ env.TOOL_NAME }}
@@ -173,10 +174,10 @@ jobs:
       - name: Archive release for Unix
         run: |
           cd archive
-          tar -jcvf ${{ env.TOOL_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}-arm64.tar.bz2 ${{ env.TOOL_NAME }}
+          tar -jcvf ${{ env.TOOL_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}-${{ matrix.arch }}.tar.bz2 ${{ env.TOOL_NAME }}
 
       - name: Upload Release Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ needs.setup.outputs.tag }} archive/${{ env.TOOL_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}-arm64.tar.bz2
+          gh release upload ${{ needs.setup.outputs.tag }} archive/${{ env.TOOL_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}-${{ matrix.arch }}.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, ubuntu-20.04, macos-14]
+        os: [windows-2022, macos-14]
     runs-on: ${{ matrix.os }}
     needs: lint
     steps:
@@ -50,24 +50,11 @@ jobs:
         with:
           architecture: x64
 
-      - name: install gtk for linux
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install libgtk-3-dev
-
       - name: build and run tests for Windows
         if: runner.os == 'Windows'
         run: |
           cd batch_files
           ./test.bat
-
-      # need xvfb for gui test
-      - name: build and run tests for Linux
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get -y install xvfb at-spi2-core
-          xvfb-run bash shell_scripts/test.sh
 
       # xquartz has xvfb functions
       - name: build and run tests for mac
@@ -91,15 +78,18 @@ jobs:
           docker buildx build --platform linux/arm64 -t tuw_arm_test -f docker/${{ matrix.os }}.dockerfile ./
           docker run --rm --init -i tuw_arm_test xvfb-run bash test.sh
 
-  test_alpine:
+  test_linux_x64:
     runs-on: ubuntu-latest
     needs: lint
+    strategy:
+      matrix:
+        os: [ubuntu, alpine]
     steps:
       - uses: actions/checkout@v4
-      - name: Run tests on alpine
+      - name: Run tests on x64 image
         run: |
-          docker build -t tuw_alpine_test -f docker/alpine.dockerfile ./
-          docker run --rm --init -i tuw_alpine_test xvfb-run bash test.sh
+          docker build -t tuw_test -f docker/${{ matrix.os }}.dockerfile ./
+          docker run --rm --init -i tuw_test xvfb-run bash test.sh
 
   build_tests_windows_arm64:
     runs-on: windows-2022


### PR DESCRIPTION
We should build Linux version on Ubuntu 20.04 to support all GLIBC versions that tuw can support, but github actions started to remove 20.04 runners.
https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#ubuntu-20-image-is-closing-down

So, I replaced the ubuntu workflows with docker images.