### PR TITLE
use tar.xz for unix packages

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -66,7 +66,7 @@ jobs:
             arch_suffix: 10-x64
           - os: macos-14
             exe_ext: ""
-            zip_ext: tar.bz2
+            zip_ext: tar.xz
             arch: ""
             arch_suffix: ""
 
@@ -124,7 +124,7 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           cd archive
-          tar -jcvf ${{ env.TOOL_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}${{ matrix.arch_suffix }}.${{ matrix.zip_ext }} ${{ env.TOOL_NAME }}
+          tar -Jcvf ${{ env.TOOL_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}${{ matrix.arch_suffix }}.${{ matrix.zip_ext }} ${{ env.TOOL_NAME }}
 
       - name: Upload Release Asset
         env:
@@ -174,10 +174,10 @@ jobs:
       - name: Archive release for Unix
         run: |
           cd archive
-          tar -jcvf ${{ env.TOOL_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}-${{ matrix.arch }}.tar.bz2 ${{ env.TOOL_NAME }}
+          tar -Jcvf ${{ env.TOOL_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}-${{ matrix.arch }}.tar.xz ${{ env.TOOL_NAME }}
 
       - name: Upload Release Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ needs.setup.outputs.tag }} archive/${{ env.TOOL_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}-${{ matrix.arch }}.tar.bz2
+          gh release upload ${{ needs.setup.outputs.tag }} archive/${{ env.TOOL_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}-${{ matrix.arch }}.tar.xz

--- a/docs/Github-Actions.md
+++ b/docs/Github-Actions.md
@@ -44,6 +44,6 @@ Github will upload a zip file on the release page.
 
 ## 10. Download zip
 
-Download `Tuw*.zip` or `*.tar.bz2`.  
+Download `Tuw*.zip` or `*.tar.xz`.  
 
 <img src=https://user-images.githubusercontent.com/69258547/154955303-45705ac4-cf93-4b93-bf7f-cf82537d6c71.png width=500>

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,8 +41,8 @@ You can download executables from [the release page](https://github.com/matyalat
 
 -   `Tuw-*-Windows-*.zip` is for Windows (7 or later.)  
 -   `Tuw-*-Windows10-*.zip` requires Windows 10 or later, but it's much smaller than the standard version.  
--   `Tuw-*-macOS.tar.bz2` is for macOS (10.9 or later.)  
--   `Tuw-*-Linux-*.tar.bz2` is for Linux (with GTK3.14, GLIBC2.15, and GLIBCXX3.4.21, or later versions of the libraries.)  
+-   `Tuw-*-macOS.tar.xz` is for macOS (10.9 or later.)  
+-   `Tuw-*-Linux-*.tar.xz` is for Linux (with GTK3.14, GLIBC2.15, and GLIBCXX3.4.21, or later versions of the libraries.)  
 
 > [!Note]
 > Tuw also supports [Linux distributions using musl](https://github.com/matyalatte/tuw/blob/main/docs/Build-on-Linux.md) and [other Unix-like systems (BSD, Haiku, illumos, etc.)](https://github.com/matyalatte/Tuw/blob/main/docs/Build-on-Other.md). While there is no release package available for these systems, you can build Tuw from the source code.


### PR DESCRIPTION
I replaced `.tar.bz2` with `.tar.xz` in the building workflow. Release packages will be about 20% smaller.