### PR TITLE
make universal binary optional on macOS

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -68,7 +68,12 @@ jobs:
             exe_ext: ""
             zip_ext: tar.xz
             arch: ""
-            arch_suffix: ""
+            arch_suffix: "-arm64"
+          - os: macos-14
+            exe_ext: ""
+            zip_ext: tar.xz
+            arch: ""
+            arch_suffix: "-universal"
 
     name: build-${{ matrix.os }}${{ matrix.arch_suffix }}
     runs-on: ${{ matrix.os }}
@@ -98,8 +103,12 @@ jobs:
         run: batch_files/build.bat Release ${{ matrix.arch }}
 
       - name: Build exe for Unix
-        if: runner.os != 'Windows'
+        if: (runner.os != 'Windows') && (matrix.arch_suffix != '-universal')
         run: bash shell_scripts/build.sh Release
+
+      - name: Build universal binary for Unix
+        if: (runner.os != 'Windows') && (matrix.arch_suffix == '-universal')
+        run: bash shell_scripts/build_universal.sh Release
 
       - name: Show info about exe
         run: bash shell_scripts/exe_info.sh build/Release${{ matrix.arch }}/${{ env.TOOL_NAME }}${{ matrix.exe_ext }}

--- a/docs/Build-on-Mac.md
+++ b/docs/Build-on-Mac.md
@@ -19,8 +19,7 @@ You can install meson and ninja via Homebrew. (`brew install meson ninja`)
 
 ## Build
 
-Run `bash shell_scripts/build.sh`.  
-The executable will be generated in `build/Release/`.  
+Run `bash shell_scripts/build.sh`. The executable will be generated in `build/Release/`. You can also use `shell_scripts/build_universal.sh` instead of `build.sh` to build universal binary.
 
 ## Debug
 

--- a/meson.build
+++ b/meson.build
@@ -69,18 +69,20 @@ elif tuw_OS == 'darwin'
     add_global_arguments(macosx_version_min, language: languages)
     add_global_link_arguments(macosx_version_min, language: languages)
 
-    # Check if SDKs support universal binaries or not.
-    arch = ['-arch', 'x86_64', '-arch', 'arm64']
-    c_compiler = meson.get_compiler('c')
-    result = c_compiler.run(
-        'int main(void) { return 0; }',
-        name : 'universal binary test',
-        args: arch)
-    if result.compiled()
-        add_global_arguments(arch, language: languages)
-        add_global_link_arguments(arch, language: languages)
-    else
-        warning('Universal build is disabled since your SDKs do not support it.')
+    if get_option('macosx_universal')
+        # Check if SDKs support universal binaries or not.
+        arch = ['-arch', 'x86_64', '-arch', 'arm64']
+        c_compiler = meson.get_compiler('c')
+        result = c_compiler.run(
+            'int main(void) { return 0; }',
+            name : 'universal binary test',
+            args: arch)
+        if result.compiled()
+            add_global_arguments(arch, language: languages)
+            add_global_link_arguments(arch, language: languages)
+        else
+            warning('Universal build is disabled since your SDKs do not support it.')
+        endif
     endif
 
     if not tuw_compiler.startswith('clang')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,8 @@
 option('build_exe', type : 'boolean', value : true, description : 'Build executable')
 option('build_test', type : 'boolean', value : false, description : 'Build tests')
 option('macosx_version_min', type : 'string', value : '10.9',
-       description : 'Deployment target for macOS. This will affect to subprojects')
+       description : 'Deployment target for macOS.')
+option('macosx_universal', type : 'boolean', value : false,
+       description : 'Build universal binary for macOS.')
 option('use_ucrt', type : 'boolean', value : false,
-       description : 'Use Universal CRT for Windows 10 or later')
+       description : 'Use dynamic linked UCRT for Windows 10 or later')

--- a/shell_scripts/build_universal.sh
+++ b/shell_scripts/build_universal.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Build an universal binary for macOS.
+# Tuw will be generated in ../build/${build_type}
+
+# You can specify build type as an argument like "bash build_universal.sh Debug"
+if [ "$1" = "Debug" ]; then
+    build_type="Debug"
+    preset="--native-file presets/debug.ini"
+else
+    build_type="Release"
+    preset="--native-file presets/release.ini"
+fi
+
+echo "Build type: ${build_type}"
+
+os=$(uname -s)
+options=""
+if [[ "$build_type" == "Release" ]]; then
+    options="-Db_lto=true"
+fi
+
+pushd $(dirname "$0")/..
+    meson setup build/${build_type} ${preset} -Dmacosx_universal=true ${options} || exit 1
+    cd build/${build_type}
+    meson compile -v || exit 1
+
+    # Strip symbols to reduce the binary size
+    if [ "${build_type}" = "Release" ]; then
+        if [[ "$os" == "Linux" ]]; then
+            strip --strip-all ./Tuw
+        elif [[ "$os" == "Darwin" ]]; then
+            strip ./Tuw
+        fi
+    fi
+popd


### PR DESCRIPTION
x64-based Mac was discontinued already. Most people use arm64 chips for macOS nowadays. So, I made the universal build optional and added arm64-only build to release packages for macOS.