### PR TITLE
v0.8.1 release

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@
 ![test](https://github.com/matyalatte/tuw/actions/workflows/test.yml/badge.svg)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/4aee3ee5172e4c38915d07f9c62725d3)](https://app.codacy.com/gh/matyalatte/tuw/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
-## Only 500KB for a portable GUI
+## Only 300KB for a portable GUI
 
 Tuw provides a very simple GUI for your scripts.  
 All you need is a JSON file and a tiny executable.  

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,11 @@
+ver 0.8.1
+- Fixed a memory leak on Linux. (#59)
+- Removed std::exception from tuw. (#63)
+  (but libui still uses STL for Windows build.)
+- Linux/UNIX packages now uses .tar.xz as a compression format. (#62)
+- Universal binary became optional on macOS. (#64)
+- Added arm64-only build to the release packages for macOS. (#64)
+
 ver 0.8.0
 - Array brackets can now be omitted when there is only one element.
 - GUI elements can now be defined in root object.

--- a/examples/all_keys/gui_definition.json
+++ b/examples/all_keys/gui_definition.json
@@ -1,5 +1,5 @@
 {
-    "recommended": "0.8.0",
+    "recommended": "0.8.1",
     "minimum_required": "0.8.0",
     "gui": [
         {

--- a/include/tuw_constants.h
+++ b/include/tuw_constants.h
@@ -10,8 +10,8 @@ namespace tuw_constants {
         "       CLI tools\n";
     constexpr char TOOL_NAME[] = "Tuw";
     constexpr char AUTHOR[] = "matyalatte";
-    constexpr char VERSION[] = "0.8.0";
-    constexpr int VERSION_INT = 800;
+    constexpr char VERSION[] = "0.8.1";
+    constexpr int VERSION_INT = 801;
 
 #ifdef _WIN32
     #define TUW_CONSTANTS_OS "win"


### PR DESCRIPTION
- Fixed a memory leak on Linux. (#59)
- Removed std::exception from Linux/UNIX builds. (#63)
  (A subproject still uses STL for Windows build.)
- Linux/UNIX packages now uses `.tar.xz` as a compression format. (#62)
- Added arm64-only build to the release packages for macOS. (#64)
