### PR TITLE
update glibc dependencies

### DIFF
--- a/docs/Build-on-Linux.md
+++ b/docs/Build-on-Linux.md
@@ -48,9 +48,9 @@ Required GLIBC versions
 2.4
 2.7
 2.15
+2.28
 Required GLIBCXX versions
 3.4
-3.4.21
 ```
 
 ## Dockerfiles

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -30,5 +30,5 @@ You will be able to launch the executable by double-click.
 ## My Linux machine says `File not found` (or nothing) when clicking the executable
 
 It could be due to glibc dependencies.  
-The released binary requires GTK+ 3.10, GLIBC 2.15, and GLIBCXX 3.4.21 (or newer versions of the libraries).  
+The released binary requires GTK+ 3.10, GLIBC 2.28, and GLIBCXX 3.4 (or newer versions of the libraries).  
 You should get the libs, or [build the executable](./Building.md) by yourself.  

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,7 @@ You can download executables from [the release page](https://github.com/matyalat
 -   `Tuw-*-Windows-*.zip` is for Windows (7 or later.)  
 -   `Tuw-*-Windows10-*.zip` requires Windows 10 or later, but it's much smaller than the standard version.  
 -   `Tuw-*-macOS.tar.xz` is for macOS (10.9 or later.)  
--   `Tuw-*-Linux-*.tar.xz` is for Linux (with GTK3.14, GLIBC2.15, and GLIBCXX3.4.21, or later versions of the libraries.)  
+-   `Tuw-*-Linux-*.tar.xz` is for Linux (with GTK3.14, GLIBC2.28, and GLIBCXX3.4, or later versions of the libraries.)  
 
 > [!Note]
 > Tuw also supports [Linux distributions using musl](https://github.com/matyalatte/tuw/blob/main/docs/Build-on-Linux.md) and [other Unix-like systems (BSD, Haiku, illumos, etc.)](https://github.com/matyalatte/Tuw/blob/main/docs/Build-on-Other.md). While there is no release package available for these systems, you can build Tuw from the source code.


### PR DESCRIPTION
Updated glibc dependencies in markdown files. The latest version of Tuw seems to require GLIBC 2.28 for `fcntl64`. (Idk which part of my code made that symbol tho.) Also, the minimum required version of GLIBCXX changed from 3.4.21 to 3.4, as I removed most of the STL functions from Linux build.