### PR TITLE
Launch with JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.jsonc
 !examples/**/gui_definition.jsonc
 !tests/**/*.jsonc
+*.tuw
 
 *.txt
 !changelog.txt

--- a/include/main_frame.h
+++ b/include/main_frame.h
@@ -13,6 +13,8 @@ struct MenuData {
     int menu_id;
 };
 
+#define EMPTY_DOCUMENT rapidjson::Document(rapidjson::kObjectType)
+
 // Main window
 class MainFrame {
  private:
@@ -47,10 +49,20 @@ class MainFrame {
     void JsonLoadFailed(const noex::string& msg) noexcept;
 
  public:
-    explicit MainFrame(const rapidjson::Document& definition =
-                           rapidjson::Document(rapidjson::kObjectType),
-                       const rapidjson::Document& config =
-                           rapidjson::Document(rapidjson::kObjectType)) noexcept;
+    explicit MainFrame(const rapidjson::Document& definition = EMPTY_DOCUMENT,
+                       const rapidjson::Document& config = EMPTY_DOCUMENT,
+                       const char* json_path = nullptr) noexcept {
+        Initialize(definition, config, json_path);
+    }
+
+    explicit MainFrame(const char* json_path) noexcept {
+        Initialize(EMPTY_DOCUMENT, EMPTY_DOCUMENT, json_path);
+    }
+
+    void Initialize(const rapidjson::Document& definition,
+                    const rapidjson::Document& config,
+                    const char* json_path) noexcept;
+
     void UpdatePanel(unsigned definition_id) noexcept;
     void OpenURL(int id) noexcept;
     bool Validate() noexcept;

--- a/include/noex/string.hpp
+++ b/include/noex/string.hpp
@@ -89,13 +89,23 @@ class basic_string {
     }
 
     static const size_t npos;
-    size_t find(const charT c) const noexcept;
+    size_t find(charT c) const noexcept;
     size_t find(const charT* str) const noexcept;
     inline size_t find(const basic_string& str) const noexcept {
         return find(str.c_str());
     }
 
-    inline void push_back(const charT c) noexcept {
+    inline bool contains(charT c) const noexcept {
+        return find(c) != npos;
+    }
+    inline bool contains(const charT* str) const noexcept {
+        return find(str) != npos;
+    }
+    inline bool contains(const basic_string& str) const noexcept {
+        return find(str) != npos;
+    }
+
+    inline void push_back(charT c) noexcept {
         this->append(&c, 1);
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,7 @@
 #include "string_utils.h"
 #include "tuw_constants.h"
 
-int main_app() noexcept {
+int main_app(const char* json_path = nullptr) noexcept {
 #ifdef _WIN32
     // Enable ANSI escape sequences on the console window.
     EnableCSI();
@@ -34,7 +34,7 @@ int main_app() noexcept {
     uiMainSteps();
 #endif
 
-    MainFrame main_frame = MainFrame();
+    MainFrame main_frame = MainFrame(json_path);
     uiMain();
     return 0;
 }
@@ -221,8 +221,12 @@ int main(int argc, char* argv[]) noexcept {
     envuFree(exe_dir);
 
     // Launch GUI if no args.
-    if (argc == 1) return main_app();
+    if (argc <= 1) return main_app();
 
+    // Launch GUI with a JSON path.
+    if (args[1].contains('.')) return main_app(args[1].c_str());
+
+    // Run as a CLI tool
     const char* cmd_str = args[1].c_str();
     int cmd_int = CmdToInt(cmd_str);
     if (cmd_int == CMD_UNKNOWN) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -214,11 +214,8 @@ int main(int argc, char* argv[]) noexcept {
         args.emplace_back(argv[i]);
 #endif
     }
-    char *exe_path_cstr = envuGetExecutablePath();
-    char *exe_dir = envuGetDirectory(exe_path_cstr);
-    envuSetCwd(exe_dir);
-    noex::string exe_path = envuStr(exe_path_cstr);
-    envuFree(exe_dir);
+
+    noex::string exe_path = envuStr(envuGetExecutablePath());
 
     // Launch GUI if no args.
     if (argc <= 1) return main_app();

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -97,15 +97,20 @@ void MainFrame::Initialize(const rapidjson::Document& definition,
     uiMainStep(1);  // Need uiMainStep before using uiMsgBox
 #endif
 
-    // Set working directory
-    if (workdir.empty()) {
-        // Failed to determine a workdir.
+    if (!workdir.empty()) {
+        // Set working directory
+        int ret = envuSetCwd(workdir.c_str());
+        if (ret != 0) {
+            // Failed to set CWD
+            PrintFmt("[LoadDefinition] Failed to set a path as CWD. (%s)\n", workdir.c_str());
+        }
+    }
+
+    {
+        // Show CWD
         char* cwd = envuGetCwd();
         PrintFmt("[LoadDefinition] CWD: %s\n", cwd);
         envuFree(cwd);
-    } else {
-        PrintFmt("[LoadDefinition] CWD: %s\n", workdir.c_str());
-        envuSetCwd(workdir.c_str());
     }
 
     if (ignore_external_json) {

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -10,8 +10,9 @@ constexpr char DEF_JSON[] = "gui_definition.json";
 constexpr char DEF_JSONC[] = "gui_definition.jsonc";
 
 // Main window
-MainFrame::MainFrame(const rapidjson::Document& definition,
-                     const rapidjson::Document& config) noexcept {
+void MainFrame::Initialize(const rapidjson::Document& definition,
+                           const rapidjson::Document& config,
+                           const char* json_path) noexcept {
     PrintFmt("%s v%s by %s\n", tuw_constants::TOOL_NAME,
               tuw_constants::VERSION, tuw_constants::AUTHOR);
     PrintFmt(tuw_constants::LOGO);
@@ -23,19 +24,21 @@ MainFrame::MainFrame(const rapidjson::Document& definition,
     m_definition.CopyFrom(definition, m_definition.GetAllocator());
     m_config.CopyFrom(config, m_config.GetAllocator());
     bool ignore_external_json = false;
-    const char* json_path = DEF_JSON;
-    json_utils::JsonResult result = JSON_RESULT_OK;
-    if (!m_definition.IsObject() || m_definition.ObjectEmpty()) {
-        bool exists_external_json = true;
+
+    bool exists_external_json = true;
+    if (!json_path) {
         // Find gui_definition.json
-        if (!envuFileExists(DEF_JSON)) {
+        json_path = DEF_JSON;
+        if (!envuFileExists(json_path)) {
             // Find gui_definition.jsonc
             if (envuFileExists(DEF_JSONC))
                 json_path = DEF_JSONC;
-            else
-                exists_external_json = false;
         }
+    }
+    exists_external_json = envuFileExists(json_path);
 
+    json_utils::JsonResult result = JSON_RESULT_OK;
+    if (!m_definition.IsObject() || m_definition.ObjectEmpty()) {
         ExeContainer exe;
 
         result = exe.Read(exe_path);

--- a/src/noex/string.cpp
+++ b/src/noex/string.cpp
@@ -238,7 +238,7 @@ template <typename charT>
 const size_t basic_string<charT>::npos = static_cast<size_t>(-1);
 
 template <typename charT>
-size_t basic_string<charT>::find(const charT c) const noexcept {
+size_t basic_string<charT>::find(charT c) const noexcept {
     if (empty()) return npos;
     const charT* p = begin();
     for (; p < end(); p++) {


### PR DESCRIPTION
Related to #55.

Tuw now takes the first argument as a JSON path. If you rename JSON files to `*.tuw` and set Tuw as a default application for opening `*.tuw`, you can launch GUI just by clicking `*.tuw` files.

**Changes**
- When the first argument contains `.`, tuw uses it as a JSON file for gui definition. And working directory will be the JSON file's directory.
- Tuw now uses the default CWD to resolve paths in command-line arguments. (Old versions used executable's directory as CWD.)

