### PR TITLE
fix an error when launching tuw as a macOS application

### DIFF
--- a/include/noex/string.hpp
+++ b/include/noex/string.hpp
@@ -105,6 +105,8 @@ class basic_string {
         return find(str) != npos;
     }
 
+    bool starts_with(const charT* str) const noexcept;
+
     inline void push_back(charT c) noexcept {
         this->append(&c, 1);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -205,20 +205,27 @@ int wmain(int argc, wchar_t* argv[]) noexcept {
     setlocale(LC_CTYPE, "");
 #else
 int main(int argc, char* argv[]) noexcept {
-#endif
+#endif  // _WIN32
     noex::vector<noex::string> args;
     for (int i = 0; i < argc; i++) {
+#if defined(__APPLE__)
+        // Note: When you run Tuw as a macOS application,
+        //       The first argument will be its PSN (process serial number).
+        noex::string arg = argv[i];
+        if (arg.starts_with("-psn_"))
+            continue;  // Ignore the PSN
+#endif  // defined(__APPLE__)
 #ifdef _WIN32
         args.emplace_back(UTF16toUTF8(argv[i]));
 #else
         args.emplace_back(argv[i]);
-#endif
+#endif  // _WIN32
     }
 
     noex::string exe_path = envuStr(envuGetExecutablePath());
 
     // Launch GUI if no args.
-    if (argc <= 1) return main_app();
+    if (args.size() <= 1) return main_app();
 
     // Launch GUI with a JSON path.
     if (args[1].contains('.')) return main_app(args[1].c_str());
@@ -236,10 +243,10 @@ int main(int argc, char* argv[]) noexcept {
     noex::string new_exe_path;
     bool force = false;
 
-    for (int i = 2; i < argc; i++) {
+    for (size_t i = 2; i < args.size(); i++) {
         const char* opt_str = args[i].c_str();
         int opt_int = OptToInt(opt_str);
-        if ((opt_int == OPT_JSON || opt_int == OPT_EXE) && argc <= i + 1) {
+        if ((opt_int == OPT_JSON || opt_int == OPT_EXE) && args.size() <= i + 1) {
             PrintUsage();
             fprintf(stderr, "Error: This option requires a file path. (%s)\n", opt_str);
             return 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -208,13 +208,13 @@ int main(int argc, char* argv[]) noexcept {
 #endif  // _WIN32
     noex::vector<noex::string> args;
     for (int i = 0; i < argc; i++) {
-#if defined(__APPLE__)
+#ifdef __APPLE__
         // Note: When you run Tuw as a macOS application,
         //       The first argument will be its PSN (process serial number).
         noex::string arg = argv[i];
         if (arg.starts_with("-psn_"))
             continue;  // Ignore the PSN
-#endif  // defined(__APPLE__)
+#endif  // __APPLE__
 #ifdef _WIN32
         args.emplace_back(UTF16toUTF8(argv[i]));
 #else

--- a/src/noex/string.cpp
+++ b/src/noex/string.cpp
@@ -268,6 +268,12 @@ size_t basic_string<charT>::find(const charT* str) const noexcept {
 }
 
 template <typename charT>
+bool basic_string<charT>::starts_with(const charT* str) const noexcept {
+    size_t len = get_strlen(str);
+    return m_size >= len && streq(str, substr(0, len).c_str());
+}
+
+template <typename charT>
 basic_string<charT> basic_string<charT>::substr(size_t start, size_t size) const noexcept {
     if (start + size > m_size) {
         set_error_no(STR_BOUNDARY_ERROR);

--- a/tests/string_test.cpp
+++ b/tests/string_test.cpp
@@ -288,6 +288,20 @@ TEST(StringTest, Pushback) {
     expect_tuwstr("test", str);
 }
 
+// Test starts_with()
+TEST(StringTest, StartsWith) {
+    noex::string str = "teststr";
+    EXPECT_TRUE(str.starts_with("t"));
+    EXPECT_TRUE(str.starts_with("test"));
+    EXPECT_TRUE(str.starts_with("teststr"));
+    EXPECT_FALSE(str.starts_with("e"));
+    EXPECT_FALSE(str.starts_with("est"));
+    EXPECT_FALSE(str.starts_with("teststrt"));
+    str = "-psn_0_xxxxxx";
+    EXPECT_TRUE(str.starts_with("-psn_"));
+    EXPECT_FALSE(str.starts_with("-help"));
+}
+
 // Test substr()
 TEST(StringTest, Substr) {
     noex::string str = "footestfoo";


### PR DESCRIPTION
Tuw raises an error when launching it as a macOS application, because the first argument is its PSN (process serial number).
https://stackoverflow.com/questions/10242115/os-x-strange-psn-command-line-parameter-when-launched-from-finder

This PR ignores the `-psn_*` arguments to fix the issue.