### PR TITLE
Upload source files with subprojects

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -190,3 +190,38 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ needs.setup.outputs.tag }} archive/${{ env.TOOL_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}-${{ matrix.arch }}.tar.xz
+
+  # Upload source files with subprojects
+  upload-source:
+    name: upload-source
+    strategy:
+      fail-fast: false
+
+    runs-on: ubuntu-latest
+
+    needs: setup
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install packages
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install libgtk-3-dev
+          pip3 install meson ninja
+
+      - name: Archive source files with subprojects
+        run: |
+          meson setup build
+          cd build
+          meson dist --include-subprojects --no-tests --allow-dirty
+          cd meson-dist
+          mv ${{ env.TOOL_NAME }}-undefined.tar.xz ${{ env.TOOL_NAME }}-${{ needs.setup.outputs.tag }}_source-with-subprojects.tar.xz
+
+      - name: Upload Release Asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ needs.setup.outputs.tag }} build/meson-dist/${{ env.TOOL_NAME }}-${{ needs.setup.outputs.tag }}_source-with-subprojects.tar.xz


### PR DESCRIPTION
Github uploads source files to the release page automatically but it's just a copy of the repository. It does not contain files from subprojects.
![default source package](https://github.com/user-attachments/assets/3038c7d5-c8e6-426e-87dd-8aa2fb489ae1)

With this PR, the building workflow can make a package (`Tuw-*_source-with-subprojects.tar.xz`) with [the `meson dist` command](https://mesonbuild.com/Creating-releases.html).

![new source package](https://github.com/user-attachments/assets/9f411847-88f9-43c1-99e3-2dbd260bd9e4)

With the new package, users can get all source files without using meson commands.