### PR TITLE
disable best-fit mapping for c-env-utils

### DIFF
--- a/subprojects/env_utils.wrap
+++ b/subprojects/env_utils.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/matyalatte/c-env-utils.git
-revision = f52f3a99ef3e989d79c272bd4004adc8e364bf33
+revision = v0.3.1
 depth = 1
 
 [provide]


### PR DESCRIPTION
I disabled the best-fit mapping for c-env-utils on Windows, as it might cause some issues. (https://github.com/matyalatte/c-env-utils/commit/a0f35e431a766ea75e8217579552c476f48534ac)

(edit)
At least, there is no issue on my Windows 11 machine with Tuw v0.8.1.