### PR TITLE
Remove c++ stack unwinding from Linux and macOS builds

### DIFF
--- a/shell_scripts/build.sh
+++ b/shell_scripts/build.sh
@@ -8,7 +8,7 @@ if [ "$1" = "Debug" ]; then
     preset="--native-file presets/debug.ini"
 else
     build_type="Release"
-    preset="--native-file presets/release.ini"
+    preset="--native-file presets/release.ini -Dcpp_eh=none"
 fi
 
 echo "Build type: ${build_type}"

--- a/shell_scripts/build_universal.sh
+++ b/shell_scripts/build_universal.sh
@@ -8,7 +8,7 @@ if [ "$1" = "Debug" ]; then
     preset="--native-file presets/debug.ini"
 else
     build_type="Release"
-    preset="--native-file presets/release.ini"
+    preset="--native-file presets/release.ini -Dcpp_eh=none"
 fi
 
 echo "Build type: ${build_type}"

--- a/shell_scripts/test.sh
+++ b/shell_scripts/test.sh
@@ -7,7 +7,7 @@ if [ "$1" = "Debug" ]; then
     preset="--native-file presets/debug.ini --native-file presets/test.ini"
 else
     build_type="Release"
-    preset="--native-file presets/release.ini --native-file presets/test.ini"
+    preset="--native-file presets/release.ini --native-file presets/test.ini -Dcpp_eh=none"
 fi
 echo "Build type: ${build_type}"
 


### PR DESCRIPTION
At #63, I removed c++ exceptions from Linux and macOS builds. So, we don't need [c++ stack unwinding](https://www.ibm.com/docs/en/xl-c-and-cpp-aix/16.1?topic=only-stack-unwinding-c) as well. Linux and macOS binaries will be a little bit smaller by removing the stack unwinding. (Windows build still requires it because a subproject uses STL.)