### PR TITLE
Use Linux arm64 hosted runners

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -146,24 +146,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ x64, arm64 ]
-    runs-on: ubuntu-latest
+        include:
+          - host: ubuntu-latest
+            arch: x64
+          - host: ubuntu-24.04-arm
+            arch: arm64
+
+    runs-on: ${{ matrix.host }}
     needs: setup
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build x64 version on Ubuntu 20.04
-        if : matrix.arch == 'x64'
+      - name: Build with docker
         run: |
           sudo apt-get update
           docker build -t tuw_ubuntu -f docker/ubuntu.dockerfile ./
-
-      - name: Build ARM64 version on Ubuntu 20.04
-        if : matrix.arch == 'arm64'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static binfmt-support
-          docker buildx build --platform linux/arm64 -t tuw_ubuntu -f docker/ubuntu.dockerfile ./
 
       - name: Copy files
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,30 +63,16 @@ jobs:
           brew install --cask xquartz
           bash shell_scripts/test.sh
 
-  test_linux_arm64:
-    runs-on: ubuntu-latest
+  test_linux:
     needs: lint
     strategy:
       matrix:
+        host: [ubuntu-latest, ubuntu-24.04-arm]
         os: [ubuntu, alpine]
+    runs-on: ${{ matrix.host }}
     steps:
       - uses: actions/checkout@v4
-      - name: Run tests on arm64 image
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static binfmt-support
-          docker buildx build --platform linux/arm64 -t tuw_arm_test -f docker/${{ matrix.os }}.dockerfile ./
-          docker run --rm --init -i tuw_arm_test xvfb-run bash test.sh
-
-  test_linux_x64:
-    runs-on: ubuntu-latest
-    needs: lint
-    strategy:
-      matrix:
-        os: [ubuntu, alpine]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run tests on x64 image
+      - name: Test with docker
         run: |
           docker build -t tuw_test -f docker/${{ matrix.os }}.dockerfile ./
           docker run --rm --init -i tuw_test xvfb-run bash test.sh


### PR DESCRIPTION
Finally, ARM machines are available for Linux workflows.
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

Workflows will be faster than the simulated ARM images.