### PR TITLE
v0.9.0 release

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -146,24 +146,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ x64, arm64 ]
-    runs-on: ubuntu-latest
+        include:
+          - host: ubuntu-latest
+            arch: x64
+          - host: ubuntu-24.04-arm
+            arch: arm64
+
+    runs-on: ${{ matrix.host }}
     needs: setup
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build x64 version on Ubuntu 20.04
-        if : matrix.arch == 'x64'
+      - name: Build with docker
         run: |
           sudo apt-get update
           docker build -t tuw_ubuntu -f docker/ubuntu.dockerfile ./
-
-      - name: Build ARM64 version on Ubuntu 20.04
-        if : matrix.arch == 'arm64'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static binfmt-support
-          docker buildx build --platform linux/arm64 -t tuw_ubuntu -f docker/ubuntu.dockerfile ./
 
       - name: Copy files
         run: |

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -190,3 +190,38 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ needs.setup.outputs.tag }} archive/${{ env.TOOL_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}-${{ matrix.arch }}.tar.xz
+
+  # Upload source files with subprojects
+  upload-source:
+    name: upload-source
+    strategy:
+      fail-fast: false
+
+    runs-on: ubuntu-latest
+
+    needs: setup
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install packages
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install libgtk-3-dev
+          pip3 install meson ninja
+
+      - name: Archive source files with subprojects
+        run: |
+          meson setup build
+          cd build
+          meson dist --include-subprojects --no-tests --allow-dirty
+          cd meson-dist
+          mv ${{ env.TOOL_NAME }}-undefined.tar.xz ${{ env.TOOL_NAME }}-${{ needs.setup.outputs.tag }}_source-with-subprojects.tar.xz
+
+      - name: Upload Release Asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ needs.setup.outputs.tag }} build/meson-dist/${{ env.TOOL_NAME }}-${{ needs.setup.outputs.tag }}_source-with-subprojects.tar.xz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,30 +63,16 @@ jobs:
           brew install --cask xquartz
           bash shell_scripts/test.sh
 
-  test_linux_arm64:
-    runs-on: ubuntu-latest
+  test_linux:
     needs: lint
     strategy:
       matrix:
+        host: [ubuntu-latest, ubuntu-24.04-arm]
         os: [ubuntu, alpine]
+    runs-on: ${{ matrix.host }}
     steps:
       - uses: actions/checkout@v4
-      - name: Run tests on arm64 image
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static binfmt-support
-          docker buildx build --platform linux/arm64 -t tuw_arm_test -f docker/${{ matrix.os }}.dockerfile ./
-          docker run --rm --init -i tuw_arm_test xvfb-run bash test.sh
-
-  test_linux_x64:
-    runs-on: ubuntu-latest
-    needs: lint
-    strategy:
-      matrix:
-        os: [ubuntu, alpine]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run tests on x64 image
+      - name: Test with docker
         run: |
           docker build -t tuw_test -f docker/${{ matrix.os }}.dockerfile ./
           docker run --rm --init -i tuw_test xvfb-run bash test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.jsonc
 !examples/**/gui_definition.jsonc
 !tests/**/*.jsonc
+*.tuw
 
 *.txt
 !changelog.txt

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 !examples/**/gui_definition.jsonc
 !tests/**/*.jsonc
 *.tuw
+!examples/**/*.tuw
 
 *.txt
 !changelog.txt

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,9 +61,12 @@ You can use it to validate definitions while editing files.
 For VSCode, you can add the schema path to `settings.json` (`File > Preferences > Settings > JSON:Schemas > Edit in settings.json`.)  
 
 ```json
+"files.associations": {
+    "*.tuw": "jsonc"
+},
 "json.schemas": [
     {
-        "fileMatch": [ "gui_definition.json", "gui_definition.jsonc" ],
+        "fileMatch": [ "gui_definition.json", "gui_definition.jsonc", "*.tuw" ],
         "url": "https://raw.githubusercontent.com/matyalatte/tuw/main/schema/schema.json"
     }
 ]

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,14 @@
+ver 0.9.0
+- Tuw now takes the first argument as a JSON path. (#67)
+  (You can now launch GUI just by clicking *.tuw files
+   if you rename JSON files to *.tuw and set Tuw as a default application for opening *.tuw.)
+- Tuw now uses the default CWD to resolve paths in command-line arguments. (#67)
+  (Old versions used executable's directory as CWD.)
+- Fixed an error when launching tuw as a macOS application. (#68)
+- Disabled the best-fit mapping on Windows to remove potential issues. (#71)
+- Disabled c++ stack unwinding on Linux and macOS. (#72)
+- Uploaded source files with subprojects to the release page. (#69)
+
 ver 0.8.1
 - Fixed a memory leak on Linux. (#59)
 - Removed std::exception from tuw. (#63)

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,8 +6,9 @@ You can see some JSON files to learn how to use Tuw.
 
 -   [Minimal](./get_start/minimal/): Example for a minimal GUI.
 -   [Title and Button](./get_start/title_button/): Options to rename the window title and the execution button.
--   [Putting Components](./get_start/put_component/): Example for a text box.
+-   [Put Components](./get_start/put_component/): Example for a text box.
 -   [JSON Embedding](./get_start/json_embed): You can embed JSON into exe!
+-   [Open a JSON with Tuw](./get_start/open_json_with_tuw): You can open any JSON files with Tuw to launch GUI!
 
 ![minimal](https://github.com/matyalatte/tuw/assets/69258547/7be563b8-1ee0-4500-94c4-5ca575ad185f)  
 

--- a/examples/all_keys/gui_definition.json
+++ b/examples/all_keys/gui_definition.json
@@ -1,5 +1,5 @@
 {
-    "recommended": "0.8.1",
+    "recommended": "0.9.0",
     "minimum_required": "0.8.0",
     "gui": [
         {

--- a/examples/get_start/open_json_with_tuw/README.md
+++ b/examples/get_start/open_json_with_tuw/README.md
@@ -1,0 +1,75 @@
+# Open a JSON file with Tuw
+
+Tuw can take the first argument as a JSON path if the path includes a file extension. 
+By renaming your JSON files to `*.tuw` and setting Tuw as a default application for `*.tuw` files, 
+you can launch GUIs just by clicking on these files.  
+
+![default app](https://github.com/user-attachments/assets/73e42775-d609-4f0d-b2a1-43cb8f4455cf)
+
+On Windows, setting Tuw as the default application is straightforward. However, for other operating systems, the process is a bit more complex. Below are examples of how to set it up on Ubuntu 20.04 and macOS 10.15.
+
+## Ubuntu 20.04
+
+### 1. Add `application/x-tuw` to `~/.local/share/mime/packages/Overrides.xml`
+
+(Make `Overrides.xml` if it does not exist.)
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="application/x-tuw">
+    <comment>TUW custom file</comment>
+    <glob pattern="*.tuw"/>
+  </mime-type>
+</mime-info>
+```
+
+### 2. Make `~/.local/share/applications/tuw.desktop`.
+
+Replace `/full/path/to/Tuw` with your path to Tuw. And save it as `tuw.desktop`.
+
+```ini
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Tuw
+Comment=Tiny GUI wrapper for CLI tools
+Exec=/full/path/to/Tuw %f
+Terminal=false
+MimeType=application/x-tuw;
+Categories=Utility;Application;
+```
+
+### 3. Update database
+```console
+$ update-mime-database ~/.local/share/mime
+$ update-desktop-database ~/.local/share/applications/
+$ xdg-mime default tuw.desktop application/x-tuw
+```
+
+## macOS 10.15
+
+### 1. Make a wrapper with AppleScript
+
+Open the script editor and write the following AppleScript. And replace `/full/path/to/Tuw` with your path to Tuw.
+
+```scpt
+on open fileList
+    -- Modify this variable for your environment
+    set exePath to "/full/path/to/Tuw"
+
+    set filePath to item 1 of fileList
+    set posixFilePath to POSIX path of filePath
+
+    tell application "Terminal"
+        do script exePath & " " & posixFilePath & "; exit;"
+    end tell
+end open
+```
+
+### 2. Export the script as an application. (File > Export...)
+
+![export_applescript](https://github.com/user-attachments/assets/29a9f20f-804c-46ac-b134-a1a127b84153)
+
+
+### 3. Right click a .tuw file and set Tuw as a default application.

--- a/examples/get_start/open_json_with_tuw/README.md
+++ b/examples/get_start/open_json_with_tuw/README.md
@@ -1,8 +1,6 @@
 # Open a JSON file with Tuw
 
-Tuw can take the first argument as a JSON path if the path includes a file extension. 
-By renaming your JSON files to `*.tuw` and setting Tuw as a default application for `*.tuw` files, 
-you can launch GUIs just by clicking on these files.  
+Tuw can take the first argument as a JSON path if the path includes a file extension. By renaming your JSON files to `*.tuw` and setting Tuw as a default application for `*.tuw` files, you can launch GUIs just by clicking on the files.  
 
 ![default app](https://github.com/user-attachments/assets/73e42775-d609-4f0d-b2a1-43cb8f4455cf)
 
@@ -24,7 +22,7 @@ On Windows, setting Tuw as the default application is straightforward. However, 
 </mime-info>
 ```
 
-### 2. Make `~/.local/share/applications/tuw.desktop`.
+### 2. Make `~/.local/share/applications/tuw.desktop`
 
 Replace `/full/path/to/Tuw` with your path to Tuw. And save it as `tuw.desktop`.
 
@@ -41,10 +39,13 @@ Categories=Utility;Application;
 ```
 
 ### 3. Update database
+
+You can apply the changes with the following commands.
+
 ```console
-$ update-mime-database ~/.local/share/mime
-$ update-desktop-database ~/.local/share/applications/
-$ xdg-mime default tuw.desktop application/x-tuw
+update-mime-database ~/.local/share/mime
+update-desktop-database ~/.local/share/applications/
+xdg-mime default tuw.desktop application/x-tuw
 ```
 
 ## macOS 10.15
@@ -67,9 +68,8 @@ on open fileList
 end open
 ```
 
-### 2. Export the script as an application. (File > Export...)
+### 2. Export the script as an application (File > Export...)
 
 ![export_applescript](https://github.com/user-attachments/assets/29a9f20f-804c-46ac-b134-a1a127b84153)
 
-
-### 3. Right click a .tuw file and set Tuw as a default application.
+### 3. Right click a .tuw file and set Tuw as a default application

--- a/examples/get_start/open_json_with_tuw/hello.tuw
+++ b/examples/get_start/open_json_with_tuw/hello.tuw
@@ -1,0 +1,13 @@
+{
+    "gui": {
+        "window_name": "Title here!",
+        "command": "echo %-%",
+        "button": "Hello!",
+        "components": [
+            {
+                "type": "text",
+                "label": "Type 'Hello!'"
+            }
+        ]
+    }
+}

--- a/examples/get_start/put_component/README.md
+++ b/examples/get_start/put_component/README.md
@@ -1,4 +1,4 @@
-# Putting Components
+# Put Components
 
 You can put a text box in the GUI.  
 

--- a/include/main_frame.h
+++ b/include/main_frame.h
@@ -13,6 +13,8 @@ struct MenuData {
     int menu_id;
 };
 
+#define EMPTY_DOCUMENT rapidjson::Document(rapidjson::kObjectType)
+
 // Main window
 class MainFrame {
  private:
@@ -47,10 +49,20 @@ class MainFrame {
     void JsonLoadFailed(const noex::string& msg) noexcept;
 
  public:
-    explicit MainFrame(const rapidjson::Document& definition =
-                           rapidjson::Document(rapidjson::kObjectType),
-                       const rapidjson::Document& config =
-                           rapidjson::Document(rapidjson::kObjectType)) noexcept;
+    explicit MainFrame(const rapidjson::Document& definition = EMPTY_DOCUMENT,
+                       const rapidjson::Document& config = EMPTY_DOCUMENT,
+                       const char* json_path = nullptr) noexcept {
+        Initialize(definition, config, json_path);
+    }
+
+    explicit MainFrame(const char* json_path) noexcept {
+        Initialize(EMPTY_DOCUMENT, EMPTY_DOCUMENT, json_path);
+    }
+
+    void Initialize(const rapidjson::Document& definition,
+                    const rapidjson::Document& config,
+                    const char* json_path) noexcept;
+
     void UpdatePanel(unsigned definition_id) noexcept;
     void OpenURL(int id) noexcept;
     bool Validate() noexcept;

--- a/include/noex/string.hpp
+++ b/include/noex/string.hpp
@@ -89,13 +89,23 @@ class basic_string {
     }
 
     static const size_t npos;
-    size_t find(const charT c) const noexcept;
+    size_t find(charT c) const noexcept;
     size_t find(const charT* str) const noexcept;
     inline size_t find(const basic_string& str) const noexcept {
         return find(str.c_str());
     }
 
-    inline void push_back(const charT c) noexcept {
+    inline bool contains(charT c) const noexcept {
+        return find(c) != npos;
+    }
+    inline bool contains(const charT* str) const noexcept {
+        return find(str) != npos;
+    }
+    inline bool contains(const basic_string& str) const noexcept {
+        return find(str) != npos;
+    }
+
+    inline void push_back(charT c) noexcept {
         this->append(&c, 1);
     }
 

--- a/include/noex/string.hpp
+++ b/include/noex/string.hpp
@@ -105,6 +105,8 @@ class basic_string {
         return find(str) != npos;
     }
 
+    bool starts_with(const charT* str) const noexcept;
+
     inline void push_back(charT c) noexcept {
         this->append(&c, 1);
     }

--- a/include/tuw_constants.h
+++ b/include/tuw_constants.h
@@ -10,8 +10,8 @@ namespace tuw_constants {
         "       CLI tools\n";
     constexpr char TOOL_NAME[] = "Tuw";
     constexpr char AUTHOR[] = "matyalatte";
-    constexpr char VERSION[] = "0.8.1";
-    constexpr int VERSION_INT = 801;
+    constexpr char VERSION[] = "0.9.0";
+    constexpr int VERSION_INT = 900;
 
 #ifdef _WIN32
     #define TUW_CONSTANTS_OS "win"

--- a/license.txt
+++ b/license.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2024 matyalatte
+Copyright (c) 2022-2025 matyalatte
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/shell_scripts/build.sh
+++ b/shell_scripts/build.sh
@@ -8,7 +8,7 @@ if [ "$1" = "Debug" ]; then
     preset="--native-file presets/debug.ini"
 else
     build_type="Release"
-    preset="--native-file presets/release.ini"
+    preset="--native-file presets/release.ini -Dcpp_eh=none"
 fi
 
 echo "Build type: ${build_type}"

--- a/shell_scripts/build_universal.sh
+++ b/shell_scripts/build_universal.sh
@@ -8,7 +8,7 @@ if [ "$1" = "Debug" ]; then
     preset="--native-file presets/debug.ini"
 else
     build_type="Release"
-    preset="--native-file presets/release.ini"
+    preset="--native-file presets/release.ini -Dcpp_eh=none"
 fi
 
 echo "Build type: ${build_type}"

--- a/shell_scripts/test.sh
+++ b/shell_scripts/test.sh
@@ -7,7 +7,7 @@ if [ "$1" = "Debug" ]; then
     preset="--native-file presets/debug.ini --native-file presets/test.ini"
 else
     build_type="Release"
-    preset="--native-file presets/release.ini --native-file presets/test.ini"
+    preset="--native-file presets/release.ini --native-file presets/test.ini -Dcpp_eh=none"
 fi
 echo "Build type: ${build_type}"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,7 @@
 #include "string_utils.h"
 #include "tuw_constants.h"
 
-int main_app() noexcept {
+int main_app(const char* json_path = nullptr) noexcept {
 #ifdef _WIN32
     // Enable ANSI escape sequences on the console window.
     EnableCSI();
@@ -34,7 +34,7 @@ int main_app() noexcept {
     uiMainSteps();
 #endif
 
-    MainFrame main_frame = MainFrame();
+    MainFrame main_frame = MainFrame(json_path);
     uiMain();
     return 0;
 }
@@ -214,15 +214,16 @@ int main(int argc, char* argv[]) noexcept {
         args.emplace_back(argv[i]);
 #endif
     }
-    char *exe_path_cstr = envuGetExecutablePath();
-    char *exe_dir = envuGetDirectory(exe_path_cstr);
-    envuSetCwd(exe_dir);
-    noex::string exe_path = envuStr(exe_path_cstr);
-    envuFree(exe_dir);
+
+    noex::string exe_path = envuStr(envuGetExecutablePath());
 
     // Launch GUI if no args.
-    if (argc == 1) return main_app();
+    if (argc <= 1) return main_app();
 
+    // Launch GUI with a JSON path.
+    if (args[1].contains('.')) return main_app(args[1].c_str());
+
+    // Run as a CLI tool
     const char* cmd_str = args[1].c_str();
     int cmd_int = CmdToInt(cmd_str);
     if (cmd_int == CMD_UNKNOWN) {

--- a/src/noex/string.cpp
+++ b/src/noex/string.cpp
@@ -268,6 +268,12 @@ size_t basic_string<charT>::find(const charT* str) const noexcept {
 }
 
 template <typename charT>
+bool basic_string<charT>::starts_with(const charT* str) const noexcept {
+    size_t len = get_strlen(str);
+    return m_size >= len && streq(str, substr(0, len).c_str());
+}
+
+template <typename charT>
 basic_string<charT> basic_string<charT>::substr(size_t start, size_t size) const noexcept {
     if (start + size > m_size) {
         set_error_no(STR_BOUNDARY_ERROR);

--- a/src/noex/string.cpp
+++ b/src/noex/string.cpp
@@ -238,7 +238,7 @@ template <typename charT>
 const size_t basic_string<charT>::npos = static_cast<size_t>(-1);
 
 template <typename charT>
-size_t basic_string<charT>::find(const charT c) const noexcept {
+size_t basic_string<charT>::find(charT c) const noexcept {
     if (empty()) return npos;
     const charT* p = begin();
     for (; p < end(); p++) {

--- a/subprojects/env_utils.wrap
+++ b/subprojects/env_utils.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/matyalatte/c-env-utils.git
-revision = f52f3a99ef3e989d79c272bd4004adc8e364bf33
+revision = v0.3.1
 depth = 1
 
 [provide]

--- a/tests/string_test.cpp
+++ b/tests/string_test.cpp
@@ -288,6 +288,20 @@ TEST(StringTest, Pushback) {
     expect_tuwstr("test", str);
 }
 
+// Test starts_with()
+TEST(StringTest, StartsWith) {
+    noex::string str = "teststr";
+    EXPECT_TRUE(str.starts_with("t"));
+    EXPECT_TRUE(str.starts_with("test"));
+    EXPECT_TRUE(str.starts_with("teststr"));
+    EXPECT_FALSE(str.starts_with("e"));
+    EXPECT_FALSE(str.starts_with("est"));
+    EXPECT_FALSE(str.starts_with("teststrt"));
+    str = "-psn_0_xxxxxx";
+    EXPECT_TRUE(str.starts_with("-psn_"));
+    EXPECT_FALSE(str.starts_with("-help"));
+}
+
 // Test substr()
 TEST(StringTest, Substr) {
     noex::string str = "footestfoo";


### PR DESCRIPTION
- Tuw now takes the first argument as a JSON path. (#67)
  (You can now launch GUIs just by clicking `*.tuw` files
   if you rename JSON files to `*.tuw` and set Tuw as a default application for `*.tuw`.)
- Tuw now uses the default CWD to resolve paths in command-line utilities. (#67)
  (Old versions used executable's directory as CWD.)
- Fixed an error when launching tuw as a macOS application. (#68)
- Disabled the best-fit mapping on Windows to remove potential issues. (#71)
- Disabled c++ stack unwinding on Linux and macOS. (#72)
- Uploaded source files with subprojects to the release page. (#69)