### PR TITLE
Support `gui_definition.tuw` as a default JSON path

### DIFF
--- a/examples/get_start/minimal/README.md
+++ b/examples/get_start/minimal/README.md
@@ -1,6 +1,6 @@
 # Minimal GUI
 
-Tuw will read `./gui_definition.json` (or `./gui_definition.jsonc`) when launching the executable. You can define a GUI in the JSON file.  
+Tuw reads `./gui_definition.json` (, `.jsonc`, or `.tuw`) when launching the executable. You can define a GUI in the JSON file.  
   
 The following JSON is for a minimal GUI that you can create.  
 It has only a button to echo `Hello!`.  

--- a/include/main_frame.h
+++ b/include/main_frame.h
@@ -15,6 +15,9 @@ struct MenuData {
 
 #define EMPTY_DOCUMENT rapidjson::Document(rapidjson::kObjectType)
 
+// Get "gui_definition.*"
+noex::string GetDefaultJsonPath();
+
 // Main window
 class MainFrame {
  private:
@@ -61,7 +64,7 @@ class MainFrame {
 
     void Initialize(const rapidjson::Document& definition,
                     const rapidjson::Document& config,
-                    const char* json_path) noexcept;
+                    noex::string json_path) noexcept;
 
     void UpdatePanel(unsigned definition_id) noexcept;
     void OpenURL(int id) noexcept;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -277,7 +277,7 @@ int main(int argc, char* argv[]) noexcept {
 
     if (json_path.empty()) {
         if (cmd_int == CMD_MERGE)
-            json_path = "gui_definition.json";
+            json_path = GetDefaultJsonPath();
         else
             json_path = "new.json";
     }
@@ -299,11 +299,6 @@ int main(int argc, char* argv[]) noexcept {
 
     switch (cmd_int) {
         case CMD_MERGE:
-            if (!envuFileExists(json_path.c_str()) &&
-                envuFileExists((json_path + "c").c_str())) {
-                // Not found .json but found .jsonc
-                json_path.push_back('c');
-            }
             result = Merge(exe_path, json_path, new_exe_path, force);
             break;
         case CMD_SPLIT:

--- a/tests/string_utils_test.cpp
+++ b/tests/string_utils_test.cpp
@@ -24,7 +24,7 @@ TEST(StringTest, GetLastLine) {
     expect_tuwstr("last", GetLastLine("last"));
     expect_tuwstr("last", GetLastLine("last\n"));
     expect_tuwstr("last", GetLastLine("\nlast"));
-    expect_tuwstr("last", GetLastLine("firs\nsecond\nlast\r\n\r\n"));
+    expect_tuwstr("last", GetLastLine("first\nsecond\nlast\r\n\r\n"));
 }
 
 TEST(StringTest, GetLastLineOneChar) {


### PR DESCRIPTION
Tuw can now use `gui_definition.tuw` as a default JSON path.
`gui_definition.json`, `gui_definition.jsonc`, and `gui_definition.tuw` are the supported file names now.

The `Tuw merge` command can also find `gui_definition.tuw`.