### PR TITLE
Fix a bug where message box can not show redirected non-utf characters correctly on Windows

### DIFF
--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -14,6 +14,7 @@ uint32_t Fnv1Hash32(const noex::string& str) noexcept;
 #ifdef _WIN32
 noex::string UTF16toUTF8(const wchar_t* str) noexcept;
 noex::wstring UTF8toUTF16(const char* str) noexcept;
+noex::string ANSItoUTF8(const noex::string& str) noexcept;
 void FprintFmt(FILE* out, const char* fmt, ...) noexcept;
 void EnableCSI() noexcept;
 #elif defined(__TUW_UNIX__)
@@ -23,4 +24,7 @@ void FprintFmt(FILE* out, const char* fmt, ...) noexcept;
 #define FprintFmt(...) fprintf(__VA_ARGS__)
 #endif
 
+// Note: PrintFmt() and FprintFmt() only support UTF-8 strings.
+//       Some localized versions of Windows might require ANSItoUTF8()
+//       before printing strings.
 #define PrintFmt(...) FprintFmt(stdout, __VA_ARGS__)

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -46,6 +46,7 @@ void RedirectOutput(FILE* out, const char* buf,
             noex::wstring wout = UTF8toUTF16(buf);
             fprintf(out, "%ls", wout.c_str());
         } else {
+            // ANSI code page (It might not be UTF8)
             fprintf(out, "%s", buf);
         }
 #else
@@ -135,7 +136,7 @@ ExecuteResult Execute(const noex::string& cmd,
     last_line = TruncateStr(last_line, LAST_LINE_MAX_LEN);
     err_msg = TruncateStr(err_msg, ERR_MSG_MAX_LEN);
 
-    return { return_code, err_msg, last_line };
+    return { return_code, ANSItoUTF8(err_msg), ANSItoUTF8(last_line) };
 }
 
 ExecuteResult LaunchDefaultApp(const noex::string& url) noexcept {
@@ -160,5 +161,5 @@ ExecuteResult LaunchDefaultApp(const noex::string& url) noexcept {
     noex::string err_msg;
     DestroyProcess(process, &return_code, err_msg);
 
-    return { return_code, err_msg, "" };
+    return { return_code, ANSItoUTF8(err_msg), "" };
 }

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -58,6 +58,27 @@ noex::wstring UTF8toUTF16(const char* str) noexcept {
     return wstr;
 }
 
+// Note: Some localized versions of Windows (e.g. Japanese, Chinese, Korean, etc.)
+//       still use non-UTF encodings for char strings.
+//       So, we have to convert redirected buffers to UTF8 with this function.
+noex::string ANSItoUTF8(const noex::string& str) noexcept {
+    if (str.empty())
+        return "";
+
+    int wstr_len = MultiByteToWideChar(CP_ACP, 0, str.data(), str.size() + 1, NULL, 0);
+    if (wstr_len == 0)
+        return "";  // Failed to convert
+
+    noex::wstring wstr(wstr_len);
+    if (wstr.empty())
+        return "";  // Allocation error
+
+    int ret = MultiByteToWideChar(CP_ACP, 0, str.data(), str.size() + 1, wstr.data(), wstr.size());
+    if (ret != wstr_len)
+        return "";  // Failed to convert
+    return UTF16toUTF8(wstr.data());
+}
+
 void FprintFmt(FILE* out, const char* fmt, ...) noexcept {
     va_list va;
     va_start(va, fmt);


### PR DESCRIPTION
Tuw assumed that redirected strings used UTF8.
But some Asian versions of Windows still uses non-utf encodings for char* strings (e.g. Shift-JIS for Japanese).

![error](https://github.com/user-attachments/assets/01f3435b-6cec-42d6-b5b7-d590e94ef856)

So, I added "ANSI to UTF8" conversion for the redirected strings.
Tuw can now show redirected messages correctly on Windows with Asian encodings.
![error2](https://github.com/user-attachments/assets/fc8d8a3b-edc4-4ee2-88e7-8d580e13de96)
