### PR TITLE
fix a bug where tuw can not open paths contain utf-8 characters on windows

### DIFF
--- a/include/json_utils.h
+++ b/include/json_utils.h
@@ -15,9 +15,9 @@ constexpr char CMD_TOKEN_CURRENT_DIR[] = "__CWD__";
 constexpr char CMD_TOKEN_HOME_DIR[] = "__HOME__";
 
 #ifdef _WIN32
-FILE* FileOpen(const char* path, const char* perm) noexcept;
+FILE* FileOpen(const char* path, const char* mode) noexcept;
 #else
-#define FileOpen(path, perm) fopen(path, perm)
+#define FileOpen(path, mode) fopen(path, mode)
 #endif
 
 namespace json_utils {

--- a/include/json_utils.h
+++ b/include/json_utils.h
@@ -14,6 +14,12 @@ constexpr char CMD_TOKEN_PERCENT[] = "";
 constexpr char CMD_TOKEN_CURRENT_DIR[] = "__CWD__";
 constexpr char CMD_TOKEN_HOME_DIR[] = "__HOME__";
 
+#ifdef _WIN32
+FILE* FileOpen(const char* path, const char* perm) noexcept;
+#else
+#define FileOpen(path, perm) fopen(path, perm)
+#endif
+
 namespace json_utils {
 
 struct JsonResult {

--- a/src/exe_container.cpp
+++ b/src/exe_container.cpp
@@ -81,7 +81,7 @@ json_utils::JsonResult ExeContainer::Read(const noex::string& exe_path) noexcept
     }
 
     m_exe_path = exe_path;
-    FILE* file_io = fopen(exe_path.c_str(), "rb");
+    FILE* file_io = FileOpen(exe_path.c_str(), "rb");
     if (!file_io)
         return { false, "Failed to open " + exe_path };
 
@@ -160,11 +160,11 @@ json_utils::JsonResult ExeContainer::Write(const noex::string& exe_path) noexcep
     if (JSON_SIZE_MAX <= json_size)
         return { false, noex::string("Unexpected json size. (") + json_size + ")" };
 
-    FILE* old_io = fopen(m_exe_path.c_str(), "rb");
+    FILE* old_io = FileOpen(m_exe_path.c_str(), "rb");
     if (!old_io)
         return { false, "Failed to open a file. (" + m_exe_path + ")" };
 
-    FILE* new_io = fopen(exe_path.c_str(), "wb");
+    FILE* new_io = FileOpen(exe_path.c_str(), "wb");
     if (!new_io) {
         fclose(old_io);
         return { false, "Failed to open a file. (" + exe_path + ")" };

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -12,6 +12,17 @@
 #include "string_utils.h"
 #include "noex/vector.hpp"
 
+#ifdef _WIN32
+FILE* FileOpen(const char* path, const char* perm) noexcept {
+    // Use wfopen as fopen might not use utf-8.
+    noex::wstring wpath = UTF8toUTF16(path);
+    noex::wstring wperm = UTF8toUTF16(perm);
+    if (wpath.empty() || wperm.empty())
+        return nullptr;
+    return _wfopen(wpath.c_str(), wperm.c_str());
+}
+#endif
+
 namespace json_utils {
 
     enum ComponentType: int {
@@ -35,7 +46,7 @@ namespace json_utils {
         rapidjson::kParseCommentsFlag | rapidjson::kParseTrailingCommasFlag;
 
     JsonResult LoadJson(const noex::string& file, rapidjson::Document& json) noexcept {
-        FILE* fp = fopen(file.c_str(), "rb");
+        FILE* fp = FileOpen(file.c_str(), "rb");
         if (!fp)
             return { false, "Failed to open " + file };
 
@@ -58,7 +69,7 @@ namespace json_utils {
     }
 
     JsonResult SaveJson(rapidjson::Document& json, const noex::string& file) noexcept {
-        FILE* fp = fopen(file.c_str(), "wb");
+        FILE* fp = FileOpen(file.c_str(), "wb");
         if (!fp)
             return { false, "Failed to open " + file + "." };
 

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -13,13 +13,13 @@
 #include "noex/vector.hpp"
 
 #ifdef _WIN32
-FILE* FileOpen(const char* path, const char* perm) noexcept {
+FILE* FileOpen(const char* path, const char* mode) noexcept {
     // Use wfopen as fopen might not use utf-8.
     noex::wstring wpath = UTF8toUTF16(path);
-    noex::wstring wperm = UTF8toUTF16(perm);
-    if (wpath.empty() || wperm.empty())
+    noex::wstring wmode = UTF8toUTF16(mode);
+    if (wpath.empty() || wmode.empty())
         return nullptr;
-    return _wfopen(wpath.c_str(), wperm.c_str());
+    return _wfopen(wpath.c_str(), wmode.c_str());
 }
 #endif
 


### PR DESCRIPTION
related to #80.
`fopen` uses ANSI code page (that might not be UTF-8 on some Asian enviroments) on Windows. It can fail to open UTF-8 paths.
```
[LoadDefinition] ERROR: Failed to open D:\日本語\Tuw.exe
```

So, I replaced `fopen` with `_wfopen` for Windows build.