### PR TITLE
Better ANSI parser for the console window on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ subprojects/subprocess
 subprojects/google*
 subprojects/env_utils
 subprojects/tiny_str_match
+subprojects/gtk_ansi_parser
 
 # built files
 *.exe

--- a/docs/README.md
+++ b/docs/README.md
@@ -93,3 +93,4 @@ Files in this repository are available under the [MIT license](../license.txt).
 | [subprocess.h](https://github.com/sheredom/subprocess.h) | Command processor | [Unlicense](https://github.com/sheredom/subprocess.h/blob/master/LICENSE) |
 | [c-env-utils](https://github.com/matyalatte/c-env-utils) | Utilities for environment info | [MIT](http://opensource.org/licenses/MIT) |
 | [tiny-str-match](https://github.com/matyalatte/tiny-str-match) | String validator | [MIT](http://opensource.org/licenses/MIT) |
+| [gtk-ansi-parser](https://github.com/matyalatte/gtk-ansi-parser) | ANSI parser for GtkTextBuffer | [MIT](http://opensource.org/licenses/MIT) |

--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,7 @@ tuw_sources = []
 tuw_manifest = []
 tuw_link_args = []
 tuw_cpp_args = []
+tuw_dependencies = []
 tuw_OS = host_machine.system()
 tuw_compiler = meson.get_compiler('c').get_id()
 tuw_is_release = get_option('buildtype').startswith('release') or (get_option('buildtype').startswith('custom') and not get_option('debug'))
@@ -89,6 +90,9 @@ elif tuw_OS == 'darwin'
         warning('This project has NOT been tested with your compiler. (' + tuw_compiler + ')')
     endif
 else
+    gtkansi_dep = dependency('gtk_ansi_parser', fallback : ['gtk_ansi_parser', 'gtkansi_dep'])
+    tuw_dependencies += [gtkansi_dep]
+
     tuw_link_args += ['-no-pie']
     tuw_cpp_args += ['-D__TUW_UNIX__']
     if tuw_compiler != 'gcc'
@@ -121,7 +125,7 @@ subprocess_dep = dependency('subprocess', fallback : ['subprocess', 'subprocess_
 env_utils_dep = dependency('env_utils', fallback : ['env_utils', 'env_utils_dep'])
 tiny_str_match_dep = dependency('tiny_str_match', fallback : ['tiny_str_match', 'tiny_str_match_dep'])
 
-tuw_dependencies = [libui_dep, rapidjson_dep, subprocess_dep, env_utils_dep, tiny_str_match_dep]
+tuw_dependencies += [libui_dep, rapidjson_dep, subprocess_dep, env_utils_dep, tiny_str_match_dep]
 
 tuw_sources += [
     'src/main_frame.cpp',

--- a/presets/debug.ini
+++ b/presets/debug.ini
@@ -20,3 +20,7 @@ tests = false
 
 [tiny_str_match:project options]
 tests = false
+
+[gtk_ansi_parser:project options]
+demo = false
+tests = false

--- a/presets/release.ini
+++ b/presets/release.ini
@@ -26,3 +26,7 @@ tests = false
 
 [tiny_str_match:project options]
 tests = false
+
+[gtk_ansi_parser:project options]
+demo = false
+tests = false

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -155,23 +155,6 @@ static uiWindow* CreateLogWindowForGtk() {
     envuFree(exe_path);
     uiWindowOnClosing(log_win, OnClosing, NULL);
     uiMultilineEntry* log_entry = uiNewMultilineEntry();
-
-    /*
-    If your monospace font doesn't work,
-    you should make a config file to change the default font.
-    ```
-    <!-- ~/.config/fontconfig/fonts.conf -->
-    <match target="pattern">
-        <test name="family" qual="any">
-            <string>monospace</string>
-        </test>
-        <edit binding="strong" mode="prepend" name="family">
-            <string>Source Code Pro</string>
-        </edit>
-    </match>
-    ```
-    */
-    uiUnixMultilineEntrySetMonospace(log_entry, 1);
     uiMultilineEntrySetReadOnly(log_entry, 1);
     SetLogEntry(log_entry);
     uiBox* log_box = uiNewVerticalBox();

--- a/src/noex/string.cpp
+++ b/src/noex/string.cpp
@@ -47,8 +47,10 @@ void basic_string<charT>::reserve(size_t capacity) noexcept {
 template <typename charT>
 void basic_string<charT>::assign(const charT* str, size_t size, size_t capacity) noexcept {
     reserve(capacity);
-    if (!m_str || !str)
+    if (!m_str || !str) {
+        clear();
         return;
+    }
 
     memcpy(m_str, str, size * sizeof(charT));
     m_str[size] = 0;

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -165,6 +165,7 @@ class Logger {
         GtkTextView *text_view = GTK_TEXT_VIEW(text_widget);
         GtkTextBuffer *buf = gtk_text_view_get_buffer(text_view);
         m_ansi_parser = gtk_ansi_new(buf);
+        gtk_ansi_set_default_color_with_textview(m_ansi_parser, text_view);
         if (!m_log_buffer.empty()) {
             Log(m_log_buffer.c_str());
             m_log_buffer = "";

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -116,6 +116,26 @@ void EnableCSI() noexcept {
 #include "ui.h"
 #include "gtk_ansi.h"
 
+static void SetMonospaceFont(GtkWidget* text_widget) {
+    /*
+    If your monospace font doesn't work,
+    you should make a config file to change the default font.
+    ```
+    <!-- ~/.config/fontconfig/fonts.conf -->
+    <match target="pattern">
+        <test name="family" qual="any">
+            <string>monospace</string>
+        </test>
+        <edit binding="strong" mode="prepend" name="family">
+            <string>Source Code Pro</string>
+        </edit>
+    </match>
+    ```
+    */
+    GtkStyleContext* style = gtk_widget_get_style_context(text_widget);
+    gtk_style_context_add_class(style, "monospace");
+}
+
 class Logger {
  private:
     uiMultilineEntry* m_log_entry;
@@ -137,7 +157,12 @@ class Logger {
             return;
         GtkWidget *scrolled_window =
             reinterpret_cast<GtkWidget*>(uiControlHandle(uiControl(m_log_entry)));
-        GtkTextView *text_view = GTK_TEXT_VIEW(gtk_bin_get_child(GTK_BIN(scrolled_window)));
+
+        GtkWidget *text_widget = gtk_bin_get_child(GTK_BIN(scrolled_window));
+        SetMonospaceFont(text_widget);
+
+        // Make parser
+        GtkTextView *text_view = GTK_TEXT_VIEW(text_widget);
         GtkTextBuffer *buf = gtk_text_view_get_buffer(text_view);
         m_ansi_parser = gtk_ansi_new(buf);
         if (!m_log_buffer.empty()) {

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -166,17 +166,20 @@ class Logger {
         GtkTextBuffer *buf = gtk_text_view_get_buffer(text_view);
         m_ansi_parser = gtk_ansi_new(buf);
         gtk_ansi_set_default_color_with_textview(m_ansi_parser, text_view);
-        if (!m_log_buffer.empty()) {
-            Log(m_log_buffer.c_str());
-            m_log_buffer = "";
-        }
+        if (!m_log_buffer.empty())
+            Log("");
     }
 
     void Log(const char* str) noexcept {
         if (!m_log_entry) {
             m_log_buffer += str;
         } else {
-            gtk_ansi_append(m_ansi_parser, str);
+            // Note: gtk_ansi_append returns the last few bytes
+            //       when they are incomplete sequences
+            const char* rest;
+            m_log_buffer += str;
+            rest = gtk_ansi_append(m_ansi_parser, m_log_buffer.c_str());
+            m_log_buffer = rest;
             uiUnixMuntilineEntryScrollToEnd(m_log_entry);
         }
     }

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -114,329 +114,39 @@ void EnableCSI() noexcept {
 #elif defined(__TUW_UNIX__)
 #include <stdarg.h>
 #include "ui.h"
-
-// \e[XXm
-typedef int ansi_escape_code;
-enum ANSI_ESCAPE: ansi_escape_code {
-    ANSI_RESET         = 0,
-    ANSI_BOLD          = 1,
-    ANSI_ITALIC        = 3,
-    ANSI_UNDERLINE     = 4,
-    ANSI_STRIKETHROUGH = 9,
-    ANSI_FONT_BLACK    = 30,
-    ANSI_FONT_RED      = 31,
-    ANSI_FONT_GREEN    = 32,
-    ANSI_FONT_YELLOW   = 33,
-    ANSI_FONT_BLUE     = 34,
-    ANSI_FONT_MAGENTA  = 35,
-    ANSI_FONT_CYAN     = 36,
-    ANSI_FONT_WHITE    = 37,
-    ANSI_BG_BLACK      = 40,
-    ANSI_BG_RED        = 41,
-    ANSI_BG_GREEN      = 42,
-    ANSI_BG_YELLOW     = 43,
-    ANSI_BG_BLUE       = 44,
-    ANSI_BG_MAGENTA    = 45,
-    ANSI_BG_CYAN       = 46,
-    ANSI_BG_WHITE      = 47,
-};
-
-struct pango_tag {
-    const char* str;
-    int len;
-};
-
-constexpr int strlen_constexpr(const char* str, int count = 0) {
-    return (*str == '\0') ? count : strlen_constexpr(str + 1, count + 1);
-}
-
-constexpr pango_tag PangoTag(const char* str) {
-    return { str, strlen_constexpr(str) };
-}
-
-constexpr pango_tag FONT_TAGS[] = {
-    PangoTag("<span foreground='black'>"),
-    PangoTag("<span foreground='red'>"),
-    PangoTag("<span foreground='green'>"),
-    PangoTag("<span foreground='yellow'>"),
-    PangoTag("<span foreground='blue'>"),
-    PangoTag("<span foreground='magenta'>"),
-    PangoTag("<span foreground='cyan'>"),
-    PangoTag("<span foreground='white'>")
-};
-
-constexpr pango_tag BG_TAGS[] = {
-    PangoTag("<span background='black'>"),
-    PangoTag("<span background='red'>"),
-    PangoTag("<span background='green'>"),
-    PangoTag("<span background='yellow'>"),
-    PangoTag("<span background='blue'>"),
-    PangoTag("<span background='magenta'>"),
-    PangoTag("<span background='cyan'>"),
-    PangoTag("<span background='white'>")
-};
-
-// Get opening markup tag from ANSI escape sequence
-static const pango_tag GetOpeningTag(ansi_escape_code code) noexcept {
-    if (code == ANSI_BOLD)
-        return PangoTag("<b>");
-    else if (code == ANSI_ITALIC)
-        return PangoTag("<i>");
-    else if (code == ANSI_UNDERLINE)
-        return PangoTag("<u>");
-    else if (code == ANSI_STRIKETHROUGH)
-        return PangoTag("<s>");
-    else if (ANSI_FONT_BLACK <= code && code <= ANSI_FONT_WHITE)
-        return FONT_TAGS[code - ANSI_FONT_BLACK];
-    else if (ANSI_BG_BLACK <= code && code <= ANSI_BG_WHITE)
-        return BG_TAGS[code - ANSI_BG_BLACK];
-    return PangoTag("");
-}
-
-// Get closing markup tag from ANSI escape sequence
-static const pango_tag GetClosingTag(ansi_escape_code code) noexcept {
-    if (code == ANSI_BOLD)
-        return PangoTag("</b>");
-    else if (code == ANSI_ITALIC)
-        return PangoTag("</i>");
-    else if (code == ANSI_UNDERLINE)
-        return PangoTag("</u>");
-    else if (code == ANSI_STRIKETHROUGH)
-        return PangoTag("</s>");
-    else if ((ANSI_FONT_BLACK <= code && code <= ANSI_FONT_WHITE) ||
-            (ANSI_BG_BLACK <= code && code <= ANSI_BG_WHITE))
-        return PangoTag("</span>");
-    return PangoTag("");
-}
-
-#define MAX_STACK_SIZE 64
-
-// Stack for markup tags
-class TagStack {
- private:
-    ansi_escape_code m_tags[MAX_STACK_SIZE];
-    int m_top;
-
- public:
-    TagStack() noexcept : m_tags(), m_top(-1) {}
-
-    void Push(ansi_escape_code code) noexcept {
-        if (m_top < MAX_STACK_SIZE - 1)
-            m_tags[++m_top] = code;
-    }
-
-    int Size() const noexcept { return m_top + 1; }
-
-    void Clear() noexcept { m_top = -1; }
-
-    using GetTagFunc = const pango_tag (*)(ansi_escape_code);
-
-    // Get length of stacked tags
-    int GetTagLength(GetTagFunc GetTag) const noexcept {
-        int len = 0;
-        const ansi_escape_code* max_tag = m_tags + m_top;
-        for (const ansi_escape_code* code = m_tags; code <= max_tag; code++) {
-            len += GetTag(*code).len;
-        }
-        return len;
-    }
-
-    inline int OpeningTagLength() const noexcept {
-        return GetTagLength(GetOpeningTag);
-    }
-
-    inline int ClosingTagLength() const noexcept {
-        return GetTagLength(GetClosingTag);
-    }
-
-    // Copy stacked tags to char*
-    int CopyTag(char* output, GetTagFunc GetTag, bool reverse) const noexcept {
-        char* start = output;
-        for (int i = 0; i <= m_top; i++) {
-            int idx = reverse ? m_top - i : i;
-            const pango_tag opening_tag = GetTag(m_tags[idx]);
-            memcpy(output, opening_tag.str, opening_tag.len);
-            output += opening_tag.len;
-        }
-        return static_cast<int>(output - start);
-    }
-
-    inline int CopyOpeningTag(char* output) const noexcept {
-        return CopyTag(output, GetOpeningTag, false);
-    }
-
-    inline int CopyClosingTag(char* output) const noexcept {
-        return CopyTag(output, GetClosingTag, true);
-    }
-};
-
-// Get string length for ConvertAnsiToPango()
-int ConvertAnsiToPangoLength(TagStack* stack, const char *input) noexcept {
-    const char *p = input;
-    int closing_tag_len = stack->ClosingTagLength();
-    int len = stack->OpeningTagLength();
-
-    while (*p) {
-        if (*p == '\033' && *(p + 1) == '[') {  // Found an ANSI escape sequence
-            p += 2;  // Skip "\033["
-            while (*p) {
-                int code = 0;
-                while (*p >= '0' && *p <= '9') {
-                    code = code * 10 + (*p - '0');
-                    p++;
-                }
-
-                char c = *p;
-                if (c == 'm' || c == ';') {
-                    p++;  // Skip 'm' and ';'
-                    if (code == ANSI_RESET) {
-                        len += closing_tag_len;
-                        closing_tag_len = 0;
-                    } else {
-                        len += GetOpeningTag(code).len;
-                        closing_tag_len += GetClosingTag(code).len;
-                    }
-                    if (c == 'm')
-                        break;
-                }
-            }
-            continue;
-        } else if (*p == '&') {
-            len += 5;  // &amp;
-        } else if (*p == '<') {
-            len += 4;  // &lt;
-        } else if (*p == '>') {
-            len += 4;  // &gt;
-        } else if (*p == '\'') {
-            len += 6;  // &apos;
-        } else if (*p == '"') {
-            len += 6;  // &quot;
-        } else {
-            // Copy regular characters
-            len++;
-        }
-        p++;
-    }
-
-    len += closing_tag_len;
-
-    return len;
-}
-
-// Function to replace ANSI escape sequences with Pango markup
-void ConvertAnsiToPango(TagStack* stack, const char *input, char *output) noexcept {
-    const char *p = input;
-    char *q = output;
-
-    // Add opening tags
-    q += stack->CopyOpeningTag(q);
-
-    while (*p) {
-        if (*p == '\033' && *(p + 1) == '[') {  // Found an ANSI escape sequence
-            p += 2;  // Skip "\033["
-
-            while (*p) {
-                int code = 0;
-                while (*p >= '0' && *p <= '9') {
-                    code = code * 10 + (*p - '0');
-                    p++;
-                }
-
-                char c = *p;
-                if (c == 'm' || c == ';') {
-                    p++;  // Skip 'm' and ';'
-                    if (code == ANSI_RESET) {
-                        q += stack->CopyClosingTag(q);
-                        stack->Clear();
-                    } else {
-                        const pango_tag opening_tag = GetOpeningTag(code);
-                        memcpy(q, opening_tag.str, opening_tag.len);
-                        q += opening_tag.len;
-                        stack->Push(code);
-                    }
-                    if (c == 'm')
-                        break;
-                }
-            }
-            continue;
-        } else if (*p == '&') {
-            memcpy(q, "&amp;", 5);
-            q += 5;
-        } else if (*p == '<') {
-            memcpy(q, "&lt;", 4);
-            q += 4;
-        } else if (*p == '>') {
-            memcpy(q, "&gt;", 4);
-            q += 4;
-        } else if (*p == '\'') {
-            memcpy(q, "&apos;", 6);
-            q += 6;
-        } else if (*p == '"') {
-            memcpy(q, "&quot;", 6);
-            q += 6;
-        } else {
-            // Copy regular characters
-            *q++ = *p;
-        }
-        p++;
-    }
-
-    // Add closing tags
-    q += stack->CopyClosingTag(q);
-
-    // Null-terminate the output
-    *q = '\0';
-}
-
-#define MAX_LOG_BUFFER_SIZE 1024 * 1024
+#include "gtk_ansi.h"
 
 class Logger {
  private:
     uiMultilineEntry* m_log_entry;
     noex::string m_log_buffer;
-    TagStack m_tag_stack;  // stack for markup tags
-    int m_buffer_length;
+    GtkAnsiParser* m_ansi_parser;
 
  public:
     Logger() noexcept : m_log_entry(NULL), m_log_buffer(""),
-                        m_tag_stack(), m_buffer_length(0) {}
-    ~Logger() noexcept {}
+                        m_ansi_parser() {}
+    ~Logger() noexcept {
+        gtk_ansi_free(m_ansi_parser);
+    }
 
     void SetLogEntry(void* log_entry) noexcept {
         m_log_entry = static_cast<uiMultilineEntry*>(log_entry);
+        GtkWidget *scrolled_window =
+            reinterpret_cast<GtkWidget*>(uiControlHandle(uiControl(m_log_entry)));
+        GtkTextView *text_view = GTK_TEXT_VIEW(gtk_bin_get_child(GTK_BIN(scrolled_window)));
+        GtkTextBuffer *buf = gtk_text_view_get_buffer(text_view);
+        m_ansi_parser = gtk_ansi_new(buf);
         if (!m_log_buffer.empty()) {
             Log(m_log_buffer.c_str());
             m_log_buffer = "";
         }
     }
 
-     void Log(const char* str) noexcept {
-        int markup_length = ConvertAnsiToPangoLength(&m_tag_stack, str);
-        noex::string markup_str = noex::string(markup_length);
-        if (noex::get_error_no() != noex::OK) return;  // failed to allocate buffer
-        ConvertAnsiToPango(&m_tag_stack, str, markup_str.data());
+    void Log(const char* str) noexcept {
         if (m_log_entry == NULL) {
-            m_log_buffer += markup_str;
+            m_log_buffer += str;
         } else {
-            if (m_buffer_length + markup_length > MAX_LOG_BUFFER_SIZE) {
-                m_buffer_length = 0;
-                char* text = uiMultilineEntryText(m_log_entry);
-                if (text) {
-                    int text_len = strlen(text);
-                    if (text_len > MAX_LOG_BUFFER_SIZE / 2) {
-                        m_buffer_length = MAX_LOG_BUFFER_SIZE / 2;
-                        uiMultilineEntrySetText(m_log_entry,
-                                                text + text_len - MAX_LOG_BUFFER_SIZE / 2);
-                    } else {
-                        uiMultilineEntrySetText(m_log_entry, "");
-                    }
-                    uiFreeText(text);
-                } else {
-                    uiMultilineEntrySetText(m_log_entry, "");
-                }
-            }
-            m_buffer_length += markup_length;
-            uiUnixMultilineEntryMarkupAppend(m_log_entry, markup_str.data());
+            gtk_ansi_append(m_ansi_parser, str);
             uiUnixMuntilineEntryScrollToEnd(m_log_entry);
         }
     }

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -123,14 +123,18 @@ class Logger {
     GtkAnsiParser* m_ansi_parser;
 
  public:
-    Logger() noexcept : m_log_entry(NULL), m_log_buffer(""),
+    Logger() noexcept : m_log_entry(nullptr), m_log_buffer(""),
                         m_ansi_parser() {}
     ~Logger() noexcept {
         gtk_ansi_free(m_ansi_parser);
     }
 
-    void SetLogEntry(void* log_entry) noexcept {
-        m_log_entry = static_cast<uiMultilineEntry*>(log_entry);
+    void SetLogEntry(uiMultilineEntry* log_entry) noexcept {
+        gtk_ansi_free(m_ansi_parser);
+        m_ansi_parser = nullptr;
+        m_log_entry = log_entry;
+        if (!m_log_entry)
+            return;
         GtkWidget *scrolled_window =
             reinterpret_cast<GtkWidget*>(uiControlHandle(uiControl(m_log_entry)));
         GtkTextView *text_view = GTK_TEXT_VIEW(gtk_bin_get_child(GTK_BIN(scrolled_window)));
@@ -143,7 +147,7 @@ class Logger {
     }
 
     void Log(const char* str) noexcept {
-        if (m_log_entry == NULL) {
+        if (!m_log_entry) {
             m_log_buffer += str;
         } else {
             gtk_ansi_append(m_ansi_parser, str);
@@ -155,7 +159,7 @@ class Logger {
 Logger g_logger = Logger();
 
 void SetLogEntry(void* log_entry) noexcept {
-    g_logger.SetLogEntry(log_entry);
+    g_logger.SetLogEntry(static_cast<uiMultilineEntry*>(log_entry));
 }
 
 void FprintFmt(FILE* out, const char* fmt, ...) noexcept {

--- a/subprojects/gtk_ansi_parser.wrap
+++ b/subprojects/gtk_ansi_parser.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/matyalatte/gtk-ansi-parser.git
-revision = e1e4c40284a3526a5739ce76415ed47dec3d9461
+revision = v0.2.0
 depth = 1
 
 [provide]

--- a/subprojects/gtk_ansi_parser.wrap
+++ b/subprojects/gtk_ansi_parser.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/matyalatte/gtk-ansi-parser.git
-revision = 007cff5deda0fc8987d50b8d1042bdf405f001e1
+revision = b1b3d99cb71e73996b3b3209e1950a3e0be65b90
 depth = 1
 
 [provide]

--- a/subprojects/gtk_ansi_parser.wrap
+++ b/subprojects/gtk_ansi_parser.wrap
@@ -1,0 +1,7 @@
+[wrap-git]
+url = https://github.com/matyalatte/gtk-ansi-parser.git
+revision = 007cff5deda0fc8987d50b8d1042bdf405f001e1
+depth = 1
+
+[provide]
+gtk_ansi_parser = gtkansi_dep

--- a/subprojects/gtk_ansi_parser.wrap
+++ b/subprojects/gtk_ansi_parser.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/matyalatte/gtk-ansi-parser.git
-revision = b1b3d99cb71e73996b3b3209e1950a3e0be65b90
+revision = 41b3467a63d4cbe4ad96d78614574d454c64eead
 depth = 1
 
 [provide]

--- a/subprojects/gtk_ansi_parser.wrap
+++ b/subprojects/gtk_ansi_parser.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/matyalatte/gtk-ansi-parser.git
-revision = 41b3467a63d4cbe4ad96d78614574d454c64eead
+revision = e1e4c40284a3526a5739ce76415ed47dec3d9461
 depth = 1
 
 [provide]

--- a/subprojects/libui.wrap
+++ b/subprojects/libui.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/matyalatte/libui-ng.git
-revision = 4a4f6e0412e91e4cf9a11ed84bc8ecc14d38f0b0
+revision = 46a44d14696e67545434116221f00a1f9e4c2919
 depth = 1
 
 [provide]

--- a/tests/string_test.cpp
+++ b/tests/string_test.cpp
@@ -78,6 +78,12 @@ TEST(StringTest, AssignNull) {
     expect_nullstr(str);
 }
 
+TEST(StringTest, AssignNullToStr) {
+    noex::string str = "aaa";
+    str = nullptr;
+    expect_nullstr(str);
+}
+
 TEST(StringTest, AssignCstr) {
     noex::string str = "test";
     expect_tuwstr("test", str);


### PR DESCRIPTION
Linux build now supports all color codes and carriage returns.

![demo](https://github.com/user-attachments/assets/181dc57b-62c7-41ee-8415-95b15368b0da)

```bash
#!/bin/bash
for y in {0..15}; do
    for x in {0..15}; do
        color=$((y * 16 + x))
        printf "\033[48;5;%dm  \033[0m" "$color"
    done
    echo ""
done

echo -e "\033[1mBold\033[0m\033[3mItalic\033[0m\033[4mUnderline\033[0m"
echo -e "\033[9mStrikethrough\033[0m\033[7mReverse\033[0m\033[8mConceal\033[0m"
echo -e "0123456789abcdefghjklmn\rCarriage returns!"
```

Here is the list of supported escape sequences.
https://matyalatte.github.io/gtk-ansi-parser/md_docs__a_n_s_icodes.html