### PR TITLE
Improve the performance of redirection

### DIFF
--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -24,11 +24,10 @@ void FprintFmt(FILE* out, const char* fmt, ...) noexcept;
 void EnableCSI() noexcept;
 #elif defined(__TUW_UNIX__)
 void SetLogEntry(void* log_entry) noexcept;
+void Log(const char* str) noexcept;
 void FprintFmt(FILE* out, const char* fmt, ...) noexcept;
-void Fwrite(FILE* out, const char* buf, size_t buf_size) noexcept;
 #else
 #define FprintFmt(...) fprintf(__VA_ARGS__)
-#define Fwrite(out, buf, buf_size) fwrite(buf, sizeof(char), buf_size, out)
 #endif
 
 // Note: PrintFmt() and FprintFmt() only support UTF-8 strings.

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -25,8 +25,10 @@ void EnableCSI() noexcept;
 #elif defined(__TUW_UNIX__)
 void SetLogEntry(void* log_entry) noexcept;
 void FprintFmt(FILE* out, const char* fmt, ...) noexcept;
+void Fwrite(FILE* out, const char* buf, size_t buf_size) noexcept;
 #else
 #define FprintFmt(...) fprintf(__VA_ARGS__)
+#define Fwrite(out, buf, buf_size) fwrite(buf, sizeof(char), buf_size, out)
 #endif
 
 // Note: PrintFmt() and FprintFmt() only support UTF-8 strings.

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -59,7 +59,7 @@ void RedirectOutput(FILE* out, const char* buf,
         WriteFile(file, buf, read_size, &written, NULL);
     }
 #else
-    FprintFmt(out, "%s", buf);
+    Fwrite(out, buf, read_size);
 #endif
 }
 

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -66,9 +66,17 @@ class RedirectContext {
                 break;
 
             // Store last characters
-            m_last_chars += m_buf;
-            if (m_last_chars.length() > LAST_CHARS_MAX_LEN * 2)
-                m_last_chars.erase(0, m_last_chars.length() - LAST_CHARS_MAX_LEN);
+            // TODO: Use a ring buffer to remove string.erase()
+            // Note: We use LAST_CHARS_MAX_LEN * 2 to avoid shifting memory
+            //       with string.erase()
+            if (m_last_chars.length() + read_size <= LAST_CHARS_MAX_LEN * 2) {
+                m_last_chars += m_buf;
+            } else if (read_size >= LAST_CHARS_MAX_LEN) {
+                m_last_chars = m_buf + read_size - LAST_CHARS_MAX_LEN;
+            } else {
+                m_last_chars.erase(0, m_last_chars.length() + read_size - LAST_CHARS_MAX_LEN);
+                m_last_chars += m_buf;
+            }
 
             // Redirect to console
         #ifdef _WIN32

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -104,9 +104,9 @@ ExecuteResult Execute(const noex::string& cmd,
     if (0 != result)
         return { -1, "Failed to create a subprocess.\n", ""};
 
-    const unsigned BUF_SIZE = 1024;
-    const size_t LAST_LINE_MAX_LEN = BUF_SIZE;
-    const size_t ERR_MSG_MAX_LEN = BUF_SIZE * 2;
+    const unsigned BUF_SIZE = 65536;  // 64KB
+    const size_t LAST_LINE_MAX_LEN = 1024;
+    const size_t ERR_MSG_MAX_LEN = 2048;
     char out_buf[BUF_SIZE + 1];
     char err_buf[BUF_SIZE + 1];
     noex::string last_line;

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -27,10 +27,15 @@ class RedirectContext {
     char m_buf[BUF_SIZE + 1];
     noex::string m_last_chars;  // Stores the last characters
 
-    noex::string TruncateStr(const noex::string& str, size_t size) noexcept {
-        if (str.size() > size)
-            return "..." + str.substr(str.size() - size, size);
-        return str;
+    noex::string TruncateStr(noex::string* str) noexcept {
+        if (str->size() < LAST_CHARS_MAX_LEN)
+            return *str;
+        char* buf = str->data();
+        char* new_buf = buf + str->size() - LAST_CHARS_MAX_LEN;
+        *new_buf = '.';
+        *(new_buf + 1) = '.';
+        *(new_buf + 2) = '.';
+        return new_buf;
     }
 
  public:
@@ -99,12 +104,12 @@ class RedirectContext {
     }
 
     noex::string GetLastChars() noexcept {
-        return TruncateStr(m_last_chars, LAST_CHARS_MAX_LEN);
+        return TruncateStr(&m_last_chars);
     }
 
     noex::string GetLine() noexcept {
         noex::string last_line = GetLastLine(m_last_chars);
-        last_line = TruncateStr(last_line, LAST_CHARS_MAX_LEN);
+        last_line = TruncateStr(&last_line);
         return last_line;
     }
 };

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -19,13 +19,13 @@ class RedirectContext {
  private:
 #ifdef _WIN32
     HANDLE m_file;
+    bool m_use_utf8_on_windows;
 #else
     FILE* m_file;
 #endif
     int m_io_type;
     char m_buf[BUF_SIZE + 1];
     noex::string m_last_chars;  // Stores the last characters
-    bool m_use_utf8_on_windows;
 
     noex::string TruncateStr(const noex::string& str, size_t size) noexcept {
         if (str.size() > size)
@@ -35,7 +35,9 @@ class RedirectContext {
 
  public:
     explicit RedirectContext(int read_io_type, int use_utf8_on_windows) noexcept :
+    #ifdef _WIN32
             m_use_utf8_on_windows(use_utf8_on_windows),
+    #endif
             m_io_type(read_io_type), m_last_chars() {
     #ifdef _WIN32
         if (read_io_type == READ_STDOUT)
@@ -73,7 +75,9 @@ class RedirectContext {
             DWORD written;
             if (m_use_utf8_on_windows) {
                 noex::wstring wout = UTF8toUTF16(m_buf);
-                WriteConsoleW(m_file, wout.c_str(), static_cast<DWORD>(wout.size()), &written, NULL);
+                WriteConsoleW(m_file,
+                    wout.c_str(), static_cast<DWORD>(wout.size()),
+                    &written, NULL);
             } else {
                 WriteFile(m_file, m_buf, static_cast<DWORD>(read_size), &written, NULL);
             }

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -191,6 +191,10 @@ void SetLogEntry(void* log_entry) noexcept {
     g_logger.SetLogEntry(static_cast<uiMultilineEntry*>(log_entry));
 }
 
+void Log(const char* str) noexcept {
+    g_logger.Log(str);
+}
+
 void FprintFmt(FILE* out, const char* fmt, ...) noexcept {
     va_list va;
     va_start(va, fmt);
@@ -203,11 +207,6 @@ void FprintFmt(FILE* out, const char* fmt, ...) noexcept {
     g_logger.Log(buf.c_str());
     fprintf(out, "%s", buf.c_str());
     va_end(va);
-}
-
-void Fwrite(FILE* out, const char* buf, size_t buf_size) noexcept {
-    g_logger.Log(buf);
-    fwrite(buf, sizeof(char), buf_size, out);
 }
 #endif
 

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -204,5 +204,10 @@ void FprintFmt(FILE* out, const char* fmt, ...) noexcept {
     fprintf(out, "%s", buf.c_str());
     va_end(va);
 }
+
+void Fwrite(FILE* out, const char* buf, size_t buf_size) noexcept {
+    g_logger.Log(buf);
+    fwrite(buf, sizeof(char), buf_size, out);
+}
 #endif
 


### PR DESCRIPTION
Related to #90

- Replaced `fprintf` with `WriteFile` or `fwrite`.
- Enlarged the buffer size from 1KB to 64KB.
- Tuw sleeps 10ms when subprocess outputs nothing.
- a few more changes for tiny improvements.

Replacing `fprintf` with `WriteFile` greatly improved the performance of redirection on Windows. You can see the improvement if your command outputs tons of lines (like 1k lines per sec.)

For example, [cpplint-cpp](https://github.com/matyalatte/cpplint-cpp) outputs 1500 lines in 0.05 sec when linting tuw (with subprojects) on my Windows machine.
It takes 3 sec when running it via Tuw v0.9.1 but this patch takes only 0.1 sec.