### PR TITLE
Update gtk console while running commands on linux

### DIFF
--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -1,6 +1,9 @@
 #include "exec.h"
 #include "subprocess.h"
 #include "string_utils.h"
+#ifdef __TUW_UNIX__
+#include <gtk/gtk.h>
+#endif
 #ifdef _WIN32
 #include "windows.h"
 #else
@@ -172,6 +175,11 @@ ExecuteResult Execute(const noex::string& cmd,
     do {
         stdout_context.RedirectOutput(process);
         stderr_context.RedirectOutput(process);
+#ifdef __TUW_UNIX__
+        // Update the console window
+        while (gtk_events_pending())
+            gtk_main_iteration_do(FALSE);
+#endif
 #ifdef _WIN32
         Sleep(10);  // wait 10ms
 #else

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -517,7 +517,7 @@ void MainFrame::RunCommand() noexcept {
 
 #ifdef __TUW_UNIX__
     // Disable the main window on Unix
-    // since we calls the main loop while running commands
+    // since we call the main loop while running commands
     GtkWidget* widget = reinterpret_cast<GtkWidget*>(uiControlHandle(uiControl(m_mainwin)));
     gtk_widget_set_sensitive(widget, FALSE);
 #endif

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -5,6 +5,9 @@
 #include "exec.h"
 #include "string_utils.h"
 #include "tuw_constants.h"
+#ifdef __TUW_UNIX__
+#include <gtk/gtk.h>
+#endif
 
 noex::string GetDefaultJsonPath() {
     noex::string def_name = "gui_definition.";
@@ -512,7 +515,16 @@ void MainFrame::RunCommand() noexcept {
     const char* codepage = json_utils::GetString(sub_definition, "codepage", "");
     bool use_utf8_on_windows = strcmp(codepage, "utf8") == 0 || strcmp(codepage, "utf-8") == 0;
 
+#ifdef __TUW_UNIX__
+    // Disable the main window on Unix
+    // since we calls the main loop while running commands
+    GtkWidget* widget = reinterpret_cast<GtkWidget*>(uiControlHandle(uiControl(m_mainwin)));
+    gtk_widget_set_sensitive(widget, FALSE);
+#endif
     ExecuteResult result = Execute(cmd, use_utf8_on_windows);
+#ifdef __TUW_UNIX__
+    gtk_widget_set_sensitive(widget, TRUE);
+#endif
     uiButtonSetText(m_run_button, text);
 
     bool check_exit_code = json_utils::GetBool(sub_definition, "check_exit_code", false);


### PR DESCRIPTION
Related to #89
Tuw can now update the gtk console while running commands on Linux.
The following script can show a line per 0.1 sec.

```bash
#!/bin/bash
last_time=""
for i in {1..10}; do
  current_time=$(date +%s%3N)  # Get current time in milliseconds  
  if [[ "$current_time" != "$last_time" ]]; then
    printf "Current time in milliseconds: %s\n" "$current_time"
    last_time="$current_time"
    sleep 0.1
  fi
done
```