### PR TITLE
use ring buffer to store outputs

### DIFF
--- a/batch_files/test.bat
+++ b/batch_files/test.bat
@@ -56,7 +56,7 @@ if %ERRORLEVEL% NEQ 0 (
 
     REM Test and get coverage report from tests.
     set MODULES=--modules %cd%\build\%BUILD_TYPE%%~2-Test\
-    set SOURCES=--sources %cd%\src
+    set SOURCES=--sources %cd%\src --sources %cd%\include
     set EXPORT_TYPE=--export_type html:%cd%\coverage-report
     set WORKDIR=--working_dir %cd%
     OpenCppCoverage --cover_children %WORKDIR% %EXPORT_TYPE% %MODULES% %SOURCES% -- meson test -v -C build\%BUILD_TYPE%%~2-Test

--- a/include/exec.h
+++ b/include/exec.h
@@ -45,19 +45,19 @@ class RingStrBuffer {
             return;
 
         if (size >= Size) {
-            memcpy(m_buffer, buf + size - Size, Size);
+            memcpy(m_buffer, buf + (size - Size) * sizeof(char), Size * sizeof(char));
             m_tail = 0;
             m_is_full = true;
             return;
         }
 
         if (m_tail + size >= Size) {
-            size_t first_chunk_size = Size - m_tail;
-            memcpy(m_buffer + m_tail, buf, first_chunk_size);
-            memcpy(m_buffer, buf + first_chunk_size, size - first_chunk_size);
+            size_t first_chunk_size = (Size - m_tail) * sizeof(char);
+            memcpy(m_buffer + m_tail * sizeof(char), buf, first_chunk_size);
+            memcpy(m_buffer, buf + first_chunk_size, size * sizeof(char) - first_chunk_size);
             m_is_full = true;
         } else {
-            memcpy(m_buffer + m_tail, buf, size);
+            memcpy(m_buffer + m_tail * sizeof(char), buf, size * sizeof(char));
         }
         m_tail = (m_tail + size) % Size;
     }
@@ -67,10 +67,11 @@ class RingStrBuffer {
         if (!m_is_full || m_tail == 0)
             return;
         char buf[Size];
-        size_t first_chunk_size = Size - m_tail;
-        memcpy(buf, m_buffer, m_tail);
-        memcpy(m_buffer, m_buffer + m_tail, first_chunk_size);
-        memcpy(m_buffer + first_chunk_size, buf, m_tail);
+        size_t first_chunk_size = (Size - m_tail) * sizeof(char);
+        size_t second_chunk_size = m_tail * sizeof(char);
+        memcpy(buf, m_buffer, second_chunk_size);
+        memmove(m_buffer, m_buffer + second_chunk_size, first_chunk_size);
+        memcpy(m_buffer + first_chunk_size, buf, second_chunk_size);
         m_tail = 0;
     }
 

--- a/include/exec.h
+++ b/include/exec.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstring>
 #include "string_utils.h"
 
 struct ExecuteResult {
@@ -12,3 +13,71 @@ struct ExecuteResult {
 ExecuteResult Execute(const noex::string& cmd,
                       bool use_utf8_on_windows = false) noexcept;
 ExecuteResult LaunchDefaultApp(const noex::string& url) noexcept;
+
+// We use ring buffers to store outputs.
+template <size_t Size>
+class RingStrBuffer {
+ private:
+    char m_buffer[Size];
+    size_t m_tail;
+    bool m_is_full;
+
+ public:
+    RingStrBuffer() noexcept : m_tail(0), m_is_full(false) {}
+
+    bool IsFull() const noexcept {
+        return m_is_full;
+    }
+
+    bool IsEmpty() const noexcept {
+        return (!m_is_full && m_tail == 0);
+    }
+
+    void PushBack(char value) noexcept {
+        m_buffer[m_tail] = value;
+
+        m_tail = (m_tail + 1) % Size;
+        m_is_full = (m_is_full || m_tail == 0);
+    }
+
+    void PushBack(const char* buf, size_t size) noexcept {
+        if (!buf)
+            return;
+
+        if (size >= Size) {
+            memcpy(m_buffer, buf + size - Size, Size);
+            m_tail = 0;
+            m_is_full = true;
+            return;
+        }
+
+        if (m_tail + size >= Size) {
+            size_t first_chunk_size = Size - m_tail;
+            memcpy(m_buffer + m_tail, buf, first_chunk_size);
+            memcpy(m_buffer, buf + first_chunk_size, size - first_chunk_size);
+            m_is_full = true;
+        } else {
+            memcpy(m_buffer + m_tail, buf, size);
+        }
+        m_tail = (m_tail + size) % Size;
+    }
+
+    // Slide tail to 0
+    void SlideToInitialPos() noexcept {
+        if (!m_is_full || m_tail == 0)
+            return;
+        char buf[Size];
+        size_t first_chunk_size = Size - m_tail;
+        memcpy(buf, m_buffer, m_tail);
+        memcpy(m_buffer, m_buffer + m_tail, first_chunk_size);
+        memcpy(m_buffer + first_chunk_size, buf, m_tail);
+        m_tail = 0;
+    }
+
+    noex::string ToString() noexcept {
+        if (!m_is_full)
+            return noex::string(m_buffer, m_tail);
+        SlideToInitialPos();
+        return noex::string(m_buffer, Size);
+    }
+};

--- a/src/noex/string.cpp
+++ b/src/noex/string.cpp
@@ -154,7 +154,7 @@ void basic_string<charT>::append(const charT* str, size_t size) noexcept {
     if (!m_str || !str)
         return;
 
-    memcpy(m_str + m_size, str, size * sizeof(charT));
+    memcpy(m_str + m_size * sizeof(charT), str, size * sizeof(charT));
     m_str[new_size] = 0;
     m_size = new_size;
 }
@@ -297,7 +297,9 @@ void basic_string<charT>::erase(size_t pos, size_t n) noexcept {
         set_error_no(STR_BOUNDARY_ERROR);
         return;
     }
-    memcpy(m_str + pos, m_str + pos + n, m_size - pos - n);
+    memmove(m_str + pos * sizeof(charT),
+            m_str + (pos + n) * sizeof(charT),
+            (m_size - pos - n) * sizeof(charT));
     m_size -= n;
     m_str[m_size] = 0;
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -11,6 +11,7 @@ test_sources = [
     'string_test.cpp',
     'vector_test.cpp',
     'process_utils.cpp',
+    'ring_buffer_test.cpp',
 ]
 
 # build tests

--- a/tests/ring_buffer_test.cpp
+++ b/tests/ring_buffer_test.cpp
@@ -1,0 +1,73 @@
+// Tests for string utils
+// Todo: Write more tests
+
+#include "test_utils.h"
+
+// Test RingStrBuffer
+TEST(RingStrBufferTest, Construct) {
+    RingStrBuffer<10> buf;
+    EXPECT_TRUE(buf.IsEmpty());
+    EXPECT_FALSE(buf.IsFull());
+    EXPECT_STREQ("", buf.ToString().c_str());
+}
+
+TEST(RingStrBufferTest, PushBackChar) {
+    RingStrBuffer<10> buf;
+    buf.PushBack('c');
+    EXPECT_FALSE(buf.IsEmpty());
+    EXPECT_FALSE(buf.IsFull());
+    EXPECT_STREQ("c", buf.ToString().c_str());
+}
+
+TEST(RingStrBufferTest, PushBackStr) {
+    RingStrBuffer<10> buf;
+    buf.PushBack("test", 4);
+    EXPECT_FALSE(buf.IsEmpty());
+    EXPECT_FALSE(buf.IsFull());
+    EXPECT_STREQ("test", buf.ToString().c_str());
+}
+
+TEST(RingStrBufferTest, PushBackLongStr) {
+    RingStrBuffer<10> buf;
+    buf.PushBack("0123456789test", 14);
+    EXPECT_FALSE(buf.IsEmpty());
+    EXPECT_TRUE(buf.IsFull());
+    EXPECT_STREQ("456789test", buf.ToString().c_str());
+}
+
+TEST(RingStrBufferTest, PushBackTwoStr) {
+    RingStrBuffer<10> buf;
+    buf.PushBack("0123456", 7);
+    buf.PushBack("789test", 7);
+    EXPECT_FALSE(buf.IsEmpty());
+    EXPECT_TRUE(buf.IsFull());
+    EXPECT_STREQ("456789test", buf.ToString().c_str());
+}
+
+TEST(RingStrBufferTest, PushBackStrAndChar) {
+    RingStrBuffer<10> buf;
+    buf.PushBack("0123456789", 10);
+    EXPECT_FALSE(buf.IsEmpty());
+    EXPECT_TRUE(buf.IsFull());
+    buf.PushBack('c');
+    EXPECT_STREQ("123456789c", buf.ToString().c_str());
+}
+
+TEST(RingStrBufferTest, PushBackStrAndLongStr) {
+    RingStrBuffer<10> buf;
+    buf.PushBack("0123456", 7);
+    const char* str = "abcdefghijklmnopqrstuvwxyz0123456789";
+    buf.PushBack(str, strlen(str));
+    EXPECT_FALSE(buf.IsEmpty());
+    EXPECT_TRUE(buf.IsFull());
+    EXPECT_STREQ("0123456789", buf.ToString().c_str());
+}
+
+TEST(RingStrBufferTest, PushBackNull) {
+    RingStrBuffer<10> buf;
+    const char* null = nullptr;
+    buf.PushBack(null, 4);
+    EXPECT_TRUE(buf.IsEmpty());
+    EXPECT_FALSE(buf.IsFull());
+    EXPECT_STREQ("", buf.ToString().c_str());
+}

--- a/tests/string_test.cpp
+++ b/tests/string_test.cpp
@@ -336,10 +336,10 @@ TEST(StringTest, IterForNull) {
 
 // Test erase()
 TEST(StringTest, Erase) {
-    noex::string str = "testfoobar";
-    expect_tuwstr("testfoobar", str);
+    noex::string str = "testfoobar!!!";
+    expect_tuwstr("testfoobar!!!", str);
     str.erase(4, 3);
-    expect_tuwstr("testbar", str);
+    expect_tuwstr("testbar!!!", str);
     str.erase(4, noex::string::npos);
     expect_tuwstr("test", str);
     EXPECT_EQ(noex::OK, noex::get_error_no());


### PR DESCRIPTION
Tuw now uses ring buffers to store the last characters of outputs. It makes redirection a little bit faster.