### PR TITLE
use 0.1 as the default value of `inc` for float pickers

### DIFF
--- a/src/component.cpp
+++ b/src/component.cpp
@@ -639,7 +639,7 @@ FloatPicker::FloatPicker(uiBox* box, const rapidjson::Value& j) noexcept
         min = max;
         max = x;
     }
-    double inc = json_utils::GetDouble(j, "inc", 1.0);
+    double inc = json_utils::GetDouble(j, "inc", 0.1);
     if (inc < 0)
         inc = -inc;
     else if (inc == 0)


### PR DESCRIPTION
[The document](https://github.com/matyalatte/tuw/tree/main/examples/components/num_pickers) says the default value of `inc` is 0.1. But it actually uses 1.

> The default value is 1 for int pickers, and 0.1 for float pickers.

So, I replaced 1 with 0.1 in the source code.