### PR TITLE
Fix gibberish error messages for CLI features

### DIFF
--- a/include/json_utils.h
+++ b/include/json_utils.h
@@ -35,6 +35,7 @@ FILE* FileOpen(const char* path, const char* mode) noexcept;
 #else
 #define FileOpen(path, mode) fopen(path, mode)
 #endif
+noex::string GetFileError(const noex::string& path) noexcept;
 
 namespace json_utils {
 

--- a/src/exe_container.cpp
+++ b/src/exe_container.cpp
@@ -77,7 +77,7 @@ noex::string ExeContainer::Read(const noex::string& exe_path) noexcept {
     m_exe_path = exe_path;
     FILE* file_io = FileOpen(exe_path.c_str(), "rb");
     if (!file_io)
-        return "Failed to open " + exe_path;
+        return GetFileError(exe_path);
 
     // Read the last 4 bytes
     fseek(file_io, 0, SEEK_END);
@@ -161,12 +161,12 @@ noex::string ExeContainer::Write(const noex::string& exe_path) noexcept {
 
     FILE* old_io = FileOpen(m_exe_path.c_str(), "rb");
     if (!old_io)
-        return "Failed to open " + m_exe_path;
+        return GetFileError(m_exe_path);
 
     FILE* new_io = FileOpen(exe_path.c_str(), "wb");
     if (!new_io) {
         fclose(old_io);
-        return "Failed to open " + exe_path;
+        return GetFileError(exe_path);
     }
     m_exe_path = exe_path;
 

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -96,7 +96,8 @@ class RedirectContext {
 
     noex::string GetLastChars() noexcept {
         noex::string str = m_last_chars.ToString();
-        ReplaceFirstCharsWithDots(&str);
+        if (m_last_chars.IsFull())
+            ReplaceFirstCharsWithDots(&str);
         return str;
     }
 

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -1,4 +1,6 @@
 #include "json_utils.h"
+
+#include <errno.h>
 #include <cstdio>
 #include <cassert>
 
@@ -19,9 +21,16 @@ FILE* FileOpen(const char* path, const char* mode) noexcept {
     noex::wstring wmode = UTF8toUTF16(mode);
     if (wpath.empty() || wmode.empty())
         return nullptr;
+    errno = 0;
     return _wfopen(wpath.c_str(), wmode.c_str());
 }
 #endif
+
+noex::string GetFileError(const noex::string& path) noexcept {
+    if (errno == EACCES)
+        return "Permission denied: " + path;
+    return "Failed to open " + path + " (Errno: " + noex::to_string(errno) + ")";
+}
 
 namespace json_utils {
 
@@ -48,7 +57,7 @@ constexpr auto JSONC_FLAGS =
 noex::string LoadJson(const noex::string& file, rapidjson::Document& json) noexcept {
     FILE* fp = FileOpen(file.c_str(), "rb");
     if (!fp)
-        return "Failed to open " + file;
+        return GetFileError(file);
 
     char readBuffer[JSON_SIZE_MAX];
     rapidjson::FileReadStream is(fp, readBuffer, sizeof(readBuffer));
@@ -70,7 +79,7 @@ noex::string LoadJson(const noex::string& file, rapidjson::Document& json) noexc
 noex::string SaveJson(rapidjson::Document& json, const noex::string& file) noexcept {
     FILE* fp = FileOpen(file.c_str(), "wb");
     if (!fp)
-        return noex::concat_cstr("Failed to open ", file.c_str(), ".");
+        return GetFileError(file);
 
     char writeBuffer[JSON_SIZE_MAX];
     rapidjson::FileWriteStream os(fp, writeBuffer, sizeof(writeBuffer));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -240,7 +240,7 @@ int main(int argc, char* argv[]) noexcept {
     int cmd_int = CmdToInt(cmd_str);
     if (cmd_int == CMD_UNKNOWN) {
         PrintUsage();
-        fprintf(stderr, "Error: Unknown command detected. (%s)", cmd_str);
+        FprintFmt(stderr, "Error: Unknown command detected. (%s)", cmd_str);
         return 1;
     }
 
@@ -254,11 +254,11 @@ int main(int argc, char* argv[]) noexcept {
         int opt_int = OptToInt(opt_str);
         if ((opt_int == OPT_JSON || opt_int == OPT_EXE) && args.size() <= i + 1) {
             PrintUsage();
-            fprintf(stderr, "Error: This option requires a file path. (%s)\n", opt_str);
+            FprintFmt(stderr, "Error: This option requires a file path. (%s)\n", opt_str);
             return 1;
         } else if (opt_int == OPT_UNKNOWN) {
             PrintUsage();
-            fprintf(stderr, "Error: Unknown option detected. (%s)\n", opt_str);
+            FprintFmt(stderr, "Error: Unknown option detected. (%s)\n", opt_str);
             return 1;
         } else if (opt_int == OPT_JSON) {
             i++;
@@ -303,7 +303,7 @@ int main(int argc, char* argv[]) noexcept {
         PrintUsage();
 
     if (!err.empty()) {
-        fprintf(stderr, "Error: %s\n", err.c_str());
+        FprintFmt(stderr, "Error: %s\n", err.c_str());
         return 1;
     }
     return 0;


### PR DESCRIPTION
Related to #105.

- Tuw now applies "UTF8 to UTF16" conversion to error messages for `merge` and `split` commands on Windows.
- Added an error message for the permission error.

![fixed](https://github.com/user-attachments/assets/22e6343e-6d8c-481b-bd8e-32c0584bb85e)
