### PR TITLE
Add deprecation warning for undefined ids

### DIFF
--- a/examples/comp_options/id/README.md
+++ b/examples/comp_options/id/README.md
@@ -24,6 +24,9 @@ You can use the defined ids as variable names in commands.
 
 ## Undefined IDs
 
+> [!warning]
+> Undifined ids are deprecated. Please define an id for each component.
+
 When you put an undefined id in `%*%`, it'll use one of the components that have no id.
 
 ```json

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -368,6 +368,13 @@ void MainFrame::UpdatePanel(unsigned definition_id) noexcept {
     Component* new_comp = nullptr;
     if (sub_definition["components"].Size() > 0) {
         for (rapidjson::Value& c : sub_definition["components"].GetArray()) {
+            if (c["type_int"].GetInt() != COMP_STATIC_TEXT && !c.HasMember("id")) {
+                PrintFmt(
+                    "[UpdatePanel] DeprecationWarning: "
+                    "\"id\" is missing in [\"components\"][%d]. "
+                    "Support for components without \"id\" will be removed in a future version.\n",
+                    m_components.size());
+            }
             uiBox* priv_box = uiNewVerticalBox();
             uiBoxSetSpacing(priv_box, tuw_constants::BOX_SUB_SPACE);
             new_comp = Component::PutComponent(priv_box, c);


### PR DESCRIPTION
Related to #96.

Tuw now shows warnings if components don't have ids.

```
[UpdatePanel] DeprecationWarning: "id" is missing in ["components"][1]. Support for components without "id" will be removed in a future version.
```