### PR TITLE
Improve JSON parser and validator

### DIFF
--- a/include/component.h
+++ b/include/component.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "rapidjson/document.h"
+#include "json.h"
 #include "ui.h"
 #include "string_utils.h"
 #include "noex/vector.hpp"
@@ -25,14 +25,14 @@ class Component {
     bool m_add_quotes;
 
  public:
-    explicit Component(const rapidjson::Value& j) noexcept;
+    explicit Component(const tuwjson::Value& j) noexcept;
     virtual ~Component() noexcept {}
     virtual noex::string GetRawString() noexcept { return "";}
     noex::string GetString() noexcept;
     const noex::string& GetID() const noexcept { return m_id; }
 
-    virtual void SetConfig(const rapidjson::Value& config) noexcept { UNUSED(config); }
-    virtual void GetConfig(rapidjson::Document& config) noexcept { UNUSED(config); }
+    virtual void SetConfig(const tuwjson::Value& config) noexcept { UNUSED(config); }
+    virtual void GetConfig(tuwjson::Value& config) noexcept { UNUSED(config); }
 
     bool HasString() const noexcept { return m_has_string; }
     bool IsWide() const noexcept { return m_is_wide; }
@@ -41,7 +41,7 @@ class Component {
     const noex::string& GetValidationError() const noexcept;
     void PutErrorWidget(uiBox* box) noexcept;
 
-    static Component* PutComponent(uiBox* box, const rapidjson::Value& j) noexcept;
+    static Component* PutComponent(uiBox* box, const tuwjson::Value& j) noexcept;
 };
 
 // containers for Combo and CheckArray
@@ -57,19 +57,19 @@ class MultipleValuesContainer {
 
 class EmptyComponent : public Component {
  public:
-    EmptyComponent(uiBox* box, const rapidjson::Value& j) noexcept
+    EmptyComponent(uiBox* box, const tuwjson::Value& j) noexcept
         : Component(j) { UNUSED(box); }
 };
 
 class StaticText : public Component {
  public:
-    StaticText(uiBox* box, const rapidjson::Value& j) noexcept;
+    StaticText(uiBox* box, const tuwjson::Value& j) noexcept;
 };
 
 class StringComponentBase : public Component {
  public:
-    StringComponentBase(uiBox* box, const rapidjson::Value& j) noexcept;
-    void GetConfig(rapidjson::Document& config) noexcept override;
+    StringComponentBase(uiBox* box, const tuwjson::Value& j) noexcept;
+    void GetConfig(tuwjson::Value& config) noexcept override;
 };
 
 class FilePicker : public StringComponentBase {
@@ -77,33 +77,33 @@ class FilePicker : public StringComponentBase {
     noex::string m_ext;
  public:
     noex::string GetRawString() noexcept override;
-    FilePicker(uiBox* box, const rapidjson::Value& j) noexcept;
-    void SetConfig(const rapidjson::Value& config) noexcept override;
+    FilePicker(uiBox* box, const tuwjson::Value& j) noexcept;
+    void SetConfig(const tuwjson::Value& config) noexcept override;
     void OpenFile() noexcept;
 };
 
 class DirPicker : public StringComponentBase {
  public:
     noex::string GetRawString() noexcept override;
-    DirPicker(uiBox* box, const rapidjson::Value& j) noexcept;
-    void SetConfig(const rapidjson::Value& config) noexcept override;
+    DirPicker(uiBox* box, const tuwjson::Value& j) noexcept;
+    void SetConfig(const tuwjson::Value& config) noexcept override;
     void OpenFolder() noexcept;
 };
 
 class ComboBox : public StringComponentBase, MultipleValuesContainer {
  public:
     noex::string GetRawString() noexcept override;
-    ComboBox(uiBox* box, const rapidjson::Value& j) noexcept;
-    void GetConfig(rapidjson::Document& config) noexcept override;
-    void SetConfig(const rapidjson::Value& config) noexcept override;
+    ComboBox(uiBox* box, const tuwjson::Value& j) noexcept;
+    void GetConfig(tuwjson::Value& config) noexcept override;
+    void SetConfig(const tuwjson::Value& config) noexcept override;
 };
 
 class RadioButtons : public StringComponentBase, MultipleValuesContainer {
  public:
     noex::string GetRawString() noexcept override;
-    RadioButtons(uiBox* box, const rapidjson::Value& j) noexcept;
-    void GetConfig(rapidjson::Document& config) noexcept override;
-    void SetConfig(const rapidjson::Value& config) noexcept override;
+    RadioButtons(uiBox* box, const tuwjson::Value& j) noexcept;
+    void GetConfig(tuwjson::Value& config) noexcept override;
+    void SetConfig(const tuwjson::Value& config) noexcept override;
 };
 
 class CheckBox : public Component {
@@ -111,9 +111,9 @@ class CheckBox : public Component {
     noex::string m_value;
  public:
     noex::string GetRawString() noexcept override;
-    CheckBox(uiBox* box, const rapidjson::Value& j) noexcept;
-    void GetConfig(rapidjson::Document& config) noexcept override;
-    void SetConfig(const rapidjson::Value& config) noexcept override;
+    CheckBox(uiBox* box, const tuwjson::Value& j) noexcept;
+    void GetConfig(tuwjson::Value& config) noexcept override;
+    void SetConfig(const tuwjson::Value& config) noexcept override;
 };
 
 class CheckArray : public StringComponentBase, MultipleValuesContainer {
@@ -121,31 +121,31 @@ class CheckArray : public StringComponentBase, MultipleValuesContainer {
     noex::vector<uiCheckbox*> m_checks;
  public:
     noex::string GetRawString() noexcept override;
-    CheckArray(uiBox* box, const rapidjson::Value& j) noexcept;
-    void GetConfig(rapidjson::Document& config) noexcept override;
-    void SetConfig(const rapidjson::Value& config) noexcept override;
+    CheckArray(uiBox* box, const tuwjson::Value& j) noexcept;
+    void GetConfig(tuwjson::Value& config) noexcept override;
+    void SetConfig(const tuwjson::Value& config) noexcept override;
 };
 
 class TextBox : public StringComponentBase {
  public:
     noex::string GetRawString() noexcept override;
-    TextBox(uiBox* box, const rapidjson::Value& j) noexcept;
-    void SetConfig(const rapidjson::Value& config) noexcept override;
+    TextBox(uiBox* box, const tuwjson::Value& j) noexcept;
+    void SetConfig(const tuwjson::Value& config) noexcept override;
 };
 
 class IntPicker : public StringComponentBase {
  public:
-    IntPicker(uiBox* box, const rapidjson::Value& j) noexcept;
+    IntPicker(uiBox* box, const tuwjson::Value& j) noexcept;
     noex::string GetRawString() noexcept override;
-    void GetConfig(rapidjson::Document& config) noexcept override;
-    void SetConfig(const rapidjson::Value& config) noexcept override;
+    void GetConfig(tuwjson::Value& config) noexcept override;
+    void SetConfig(const tuwjson::Value& config) noexcept override;
 };
 
 // This is the same as IntPicker cause uiSpinboxDouble is not supported yet.
 class FloatPicker : public StringComponentBase {
  public:
-    FloatPicker(uiBox* box, const rapidjson::Value& j) noexcept;
+    FloatPicker(uiBox* box, const tuwjson::Value& j) noexcept;
     noex::string GetRawString() noexcept override;
-    void GetConfig(rapidjson::Document& config) noexcept override;
-    void SetConfig(const rapidjson::Value& config) noexcept override;
+    void GetConfig(tuwjson::Value& config) noexcept override;
+    void SetConfig(const tuwjson::Value& config) noexcept override;
 };

--- a/include/exe_container.h
+++ b/include/exe_container.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "rapidjson/document.h"
+#include "json.h"
 #include "json_utils.h"
 #include "string_utils.h"
 
@@ -7,7 +7,7 @@ class ExeContainer {
  private:
     noex::string m_exe_path;
     uint32_t m_exe_size;
-    rapidjson::Document m_json;
+    tuwjson::Value m_json;
 
  public:
     ExeContainer(): m_exe_path(""),
@@ -21,19 +21,19 @@ class ExeContainer {
     noex::string Write(const noex::string& exe_path) noexcept;
 
     bool HasJson() noexcept {
-        return m_json.IsObject() && !m_json.ObjectEmpty();
+        return m_json.IsObject() && !m_json.IsEmpty();
     }
 
-    void GetJson(rapidjson::Document& json) noexcept {
-        json.CopyFrom(m_json, json.GetAllocator());
+    void GetJson(tuwjson::Value& json) noexcept {
+        json.CopyFrom(m_json);
     }
 
-    void SetJson(rapidjson::Document& json) noexcept {
-        m_json.CopyFrom(json, m_json.GetAllocator());
+    void SetJson(tuwjson::Value& json) noexcept {
+        m_json.CopyFrom(json);
     }
 
     void RemoveJson() noexcept {
-        rapidjson::Document doc;
+        tuwjson::Value doc;
         doc.SetObject();
         SetJson(doc);
     }

--- a/include/json.h
+++ b/include/json.h
@@ -1,0 +1,392 @@
+#pragma once
+
+#include <assert.h>
+#include "noex/string.hpp"
+#include "noex/vector.hpp"
+#include "noex/new.hpp"
+
+namespace tuwjson {
+
+/*
+ * JSON module which supports RFC8259 (https://datatracker.ietf.org/doc/html/rfc8259)
+ * without unicode escape (\uXXXX).
+ * It also supports C style comments and trailing commas.
+ * Note that this module focuses on parsing small data with small code.
+ * You should use another JSON library if the performance is a consideration for you.
+ */
+
+enum Type : int {
+    JSON_TYPE_NULL = 0,
+    JSON_TYPE_OBJECT,
+    JSON_TYPE_ARRAY,
+    JSON_TYPE_STRING,
+    JSON_TYPE_INT,
+    JSON_TYPE_DOUBLE,
+    JSON_TYPE_BOOL,  // true or false
+    JSON_TYPE_END,  // null terminator
+    JSON_TYPE_UNKNOWN,  // unsupported type
+    JSON_TYPE_MAX,
+};
+
+class Value;
+
+class Item {
+ public:
+    noex::string key;
+    Value* val;
+
+    Item() noexcept : key(), val() {
+        val = noex::new_ref<Value>();
+    }
+    Item(Item&& item) noexcept :
+            key(static_cast<noex::string&&>(item.key)), val(item.val) {
+        item.val = nullptr;
+    }
+
+    ~Item() noexcept {
+        noex::del_ref(val);
+    }
+};
+
+typedef noex::vector<Item> Object;
+typedef noex::vector<Value> Array;
+
+class Value {
+ private:
+    Type m_type;
+    union {
+        Object* m_object;
+        Array* m_array;
+        noex::string* m_string;
+        int m_int;
+        double m_double;
+        bool m_bool;
+    } u;
+
+ public:
+    Value() noexcept : m_type(JSON_TYPE_NULL) {}
+    Value(Value&& val) noexcept : m_type(val.m_type), u(val.u) {
+        val.m_type = JSON_TYPE_NULL;
+    }
+    Value& MoveFrom(Value& val) noexcept {
+        FreeValue();
+        m_type = val.m_type;
+        u = val.u;
+        val.m_type = JSON_TYPE_NULL;
+        return *this;
+    }
+    Value& operator=(Value&& val) noexcept {
+        return MoveFrom(val);
+    }
+    ~Value() noexcept {
+        FreeValue();
+    }
+
+    Type GetType() const noexcept {
+        return m_type;
+    }
+
+    void FreeValue() noexcept;
+    void CopyFrom(const Value& val) noexcept;
+    void Swap(Value& val) noexcept;
+
+    bool operator==(const Value& val) const noexcept;
+    inline bool operator!=(const Value& val) const noexcept {
+        return !(*this == val);
+    }
+
+    // object
+    inline bool IsObject() const noexcept {
+        return m_type == JSON_TYPE_OBJECT;
+    }
+    void SetObject() noexcept;
+    Object* GetObject() const noexcept {
+        assert(IsObject());
+        return u.m_object;
+    }
+    bool HasMember(const char* key) const noexcept;
+    inline bool HasMember(const noex::string& key) const noexcept {
+        return HasMember(key.c_str());
+    }
+    Value& At(const char* key) const noexcept;
+    inline Value& At(const noex::string& key) const noexcept {
+        return At(key.c_str());
+    }
+    inline Value& operator[](const char* key) const noexcept {
+        return At(key);
+    }
+    inline Value& operator[](const noex::string& key) const noexcept {
+        return At(key.c_str());
+    }
+    void ReplaceKey(const char* key, const char* new_key) noexcept;
+    void ConvertToObject(const char* key) noexcept;
+
+    // array
+    inline bool IsArray() const noexcept {
+        return m_type == JSON_TYPE_ARRAY;
+    }
+    void SetArray() noexcept;
+    Array* GetArray() const noexcept {
+        assert(IsArray());
+        return u.m_array;
+    }
+    Value& At(size_t id) const noexcept {
+        assert(IsArray());
+        assert(u.m_array->size() > id);
+        return u.m_array->at(id);
+    }
+    inline Value& At(int id) const noexcept {
+        return At(static_cast<size_t>(id));
+    }
+    inline Value& operator[](size_t id) const noexcept {
+        return At(id);
+    }
+    inline Value& operator[](int id) const noexcept {
+        return At(id);
+    }
+    Value* begin() const noexcept {
+        assert(IsArray());
+        return u.m_array->begin();
+    }
+    Value* end() const noexcept {
+        assert(IsArray());
+        return u.m_array->end();
+    }
+    size_t Size() const noexcept;
+    inline bool IsEmpty() const noexcept {
+        return Size() == 0;
+    }
+    void ConvertToArray() noexcept;
+    inline void MoveAndPush(Value& val) noexcept {
+        assert(IsArray());
+        u.m_array->push_back(static_cast<Value&&>(val));
+    }
+
+    // string
+    inline bool IsString() const noexcept {
+        return m_type == JSON_TYPE_STRING;
+    }
+    void SetString() noexcept;
+    void SetString(char* val) noexcept {
+        SetString();
+        if (u.m_string)
+            *u.m_string = val;
+    }
+    void SetString(const noex::string& str) noexcept {
+        SetString();
+        if (u.m_string)
+            *u.m_string = str;
+    }
+    void SetString(noex::string&& str) noexcept {
+        SetString();
+        if (u.m_string)
+            *u.m_string = str;
+    }
+    const char* GetString() const noexcept {
+        assert(m_type == JSON_TYPE_STRING);
+        return u.m_string->c_str();
+    }
+
+    // int
+    inline bool IsInt() const noexcept {
+        return m_type == JSON_TYPE_INT;
+    }
+    void SetInt(int val) noexcept {
+        FreeValue();
+        m_type = JSON_TYPE_INT;
+        u.m_int = val;
+    }
+    int GetInt() const noexcept {
+        assert(IsInt());
+        return u.m_int;
+    }
+
+    // double
+    inline bool IsDouble() const noexcept {
+        return m_type == JSON_TYPE_INT || m_type == JSON_TYPE_DOUBLE;
+    }
+    void SetDouble(double val) noexcept {
+        FreeValue();
+        m_type = JSON_TYPE_DOUBLE;
+        u.m_double = val;
+    }
+    double GetDouble() const noexcept {
+        assert(IsDouble());
+        if (IsInt())
+            return static_cast<double>(u.m_int);
+        return u.m_double;
+    }
+
+    // bool
+    inline bool IsBool() const noexcept {
+        return m_type == JSON_TYPE_BOOL;
+    }
+    void SetBool(bool val) noexcept {
+        FreeValue();
+        m_type = JSON_TYPE_BOOL;
+        u.m_bool = val;
+    }
+    bool GetBool() const noexcept {
+        assert(IsBool());
+        return u.m_bool;
+    }
+
+    // null
+    inline bool IsNull() const noexcept {
+        return m_type == JSON_TYPE_NULL;
+    }
+    void SetNull() noexcept {
+        FreeValue();
+        m_type = JSON_TYPE_NULL;
+    }
+};
+
+enum Error : int {
+    JSON_OK = 0,
+    JSON_ERR_ALLOC,  // Allocation error
+    JSON_ERR_UNKNOWN_LITERAL,  // Unknown literal value detected.
+    JSON_ERR_INVALID_UTF,  // Invalid UTF8 character detected.
+    JSON_ERR_INVALID_INT,  // Failed to parse an integer.
+    JSON_ERR_INVALID_DOUBLE,  // Failed to parse a double.
+    JSON_ERR_INVALID_COMMA,  // There is a comma in the wrong position.
+    JSON_ERR_INVALID_ESCAPE,  // Invalid escaped character. \c
+    JSON_ERR_UNICODE_ESCAPE,  // Unicode escape is not supported. \uxxxx
+    JSON_ERR_UNCLOSED_STR,  // " is missing.
+    JSON_ERR_UNCLOSED_COMMENT,  // */ is missing.
+    JSON_ERR_UNCLOSED_ARRAY,  // , or ] is missing.
+    JSON_ERR_EXPECTED_COLON,  // : is missing.
+    JSON_ERR_INVALID_KEY,  // String key is missing.
+    JSON_ERR_DUPLICATED_KEY,  // There is a duplicated key.
+    JSON_ERR_UNCLOSED_OBJECT,  // , or } is missing.
+    JSON_ERR_MAX,
+};
+
+class Parser {
+ private:
+    const char* m_ptr;
+    const char* m_line_ptr;
+    int m_line_count;
+    Error m_err;
+    noex::string m_err_msg;
+
+    inline char Peek(size_t pos = 0) const noexcept {
+        return *(m_ptr + pos);
+    }
+
+    void Consume() noexcept {
+        if (Peek() == '\n') {
+            m_line_count++;
+            m_line_ptr = m_ptr;
+        }
+        m_ptr++;
+    }
+
+    static inline bool IsSpace(char c) noexcept {
+        return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+    }
+
+    static inline bool IsLiteralEnd(char c) noexcept {
+        return !c || IsSpace(c) || c == ',' || c == ']' || c == '}';
+    }
+
+    static bool IsLiteral(const char* actual, const char* expected) noexcept {
+        while (*actual && *expected) {
+            if (*actual != *expected)
+                return false;
+            actual++;
+            expected++;
+        }
+        return IsLiteralEnd(*actual) && !*expected;
+    }
+
+    inline void ConsumeNonSpace(size_t len = 1) noexcept {
+        m_ptr += len;
+    }
+
+    void SkipSpaces() noexcept {
+        while (IsSpace(Peek()))
+            Consume();
+    }
+
+    void SkipToValue() noexcept;
+    Type PeekValueType() const noexcept;
+    noex::string ParseString() noexcept;
+    int ParseInt() noexcept;
+    double ParseDouble() noexcept;
+    void ParseArray(Array* array) noexcept;
+    void ParseObject(Object* object) noexcept;
+    void ParseValue(Value* value) noexcept;
+    bool ValidateUTF8(const char* str) noexcept;
+
+ public:
+    Parser() noexcept {
+        Init(nullptr);
+    }
+
+    void Init(const char* str) noexcept {
+        m_ptr = str;
+        m_line_ptr = str;
+        m_line_count = 1;
+        m_err = JSON_OK;
+        m_err_msg = "";
+    }
+
+    inline bool HasError() const noexcept {
+        return m_err != JSON_OK;
+    }
+    inline void SetError(Error error) noexcept {
+        assert(m_err == JSON_OK);
+        m_err = error;
+    }
+    inline Error GetError() const noexcept {
+        return m_err;
+    }
+
+    Error ParseJson(const char* json, Value* root) noexcept;
+    inline Error ParseJson(const noex::string& json, Value* root) noexcept {
+        return ParseJson(json.c_str(), root);
+    }
+
+    const char* GetErrMsg() noexcept;
+};
+
+class Writer {
+ private:
+    const char* m_indent_ptr;
+    size_t m_indent_size;
+    bool m_use_linefeed;
+    size_t m_depth;
+
+    char* m_buf;
+    size_t m_buf_size;
+
+    void WriteChar(char c) noexcept;
+    void WriteBytes(const char* bytes, size_t size) noexcept;
+    void WriteIndent() noexcept;
+    void WriteLinefeed() noexcept;
+    void WriteString(const char* str) noexcept;
+    void WriteObject(const Object* obj) noexcept;
+    void WriteArray(const Array* ary) noexcept;
+    void WriteValue(const Value* val) noexcept;
+
+ public:
+    Writer() noexcept {
+        Init(nullptr, 0, false);
+    }
+    Writer(const char* indent_ptr, size_t indent_size, bool use_linefeed) noexcept {
+        Init(indent_ptr, indent_size, use_linefeed);
+    }
+
+    void Init(const char* indent_ptr, size_t indent_size, bool use_linefeed) noexcept {
+        m_indent_ptr = indent_ptr;
+        m_indent_size = indent_size;
+        m_use_linefeed = use_linefeed;
+        m_depth = 0;
+        m_buf = nullptr;
+        m_buf_size = 0;
+    }
+
+    char* WriteJson(const Value* root, char* buf, size_t buf_size) noexcept;
+};
+
+}  // namespace tuwjson

--- a/include/json.h
+++ b/include/json.h
@@ -167,7 +167,7 @@ class Value {
         return m_type == JSON_TYPE_STRING;
     }
     void SetString() noexcept;
-    void SetString(char* val) noexcept {
+    void SetString(const char* val) noexcept {
         SetString();
         if (u.m_string)
             *u.m_string = val;

--- a/include/json_utils.h
+++ b/include/json_utils.h
@@ -1,7 +1,7 @@
 // Functions related to json.
 
 #pragma once
-#include "rapidjson/document.h"
+#include "json.h"
 #include "string_utils.h"
 
 enum ComponentType: int {
@@ -50,22 +50,19 @@ struct JsonResult {
 #define JSON_SIZE_MAX 128 * 1024
 
 // Returns an empty string if succeed. An error message otherwise.
-noex::string LoadJson(const noex::string& file, rapidjson::Document& json) noexcept;
-noex::string SaveJson(rapidjson::Document& json, const noex::string& file) noexcept;
+noex::string LoadJson(const noex::string& file, tuwjson::Value& json) noexcept;
+noex::string SaveJson(tuwjson::Value& json, const noex::string& file) noexcept;
 
-noex::string JsonToString(rapidjson::Document& json) noexcept;
+const char* GetString(const tuwjson::Value& json, const char* key, const char* def) noexcept;
+bool GetBool(const tuwjson::Value& json, const char* key, bool def) noexcept;
+int GetInt(const tuwjson::Value& json, const char* key, int def) noexcept;
+double GetDouble(const tuwjson::Value& json, const char* key, double def) noexcept;
 
-const char* GetString(const rapidjson::Value& json, const char* key, const char* def) noexcept;
-bool GetBool(const rapidjson::Value& json, const char* key, bool def) noexcept;
-int GetInt(const rapidjson::Value& json, const char* key, int def) noexcept;
-double GetDouble(const rapidjson::Value& json, const char* key, double def) noexcept;
-
-void GetDefaultDefinition(rapidjson::Document& definition) noexcept;
-void CheckVersion(JsonResult& result, rapidjson::Document& definition) noexcept;
-void CheckDefinition(JsonResult& result, rapidjson::Document& definition) noexcept;
-void CheckSubDefinition(JsonResult& result, rapidjson::Value& sub_definition,
-                        int index,
-                        rapidjson::Document::AllocatorType& alloc) noexcept;
-void CheckHelpURLs(JsonResult& result, rapidjson::Document& definition) noexcept;
+void GetDefaultDefinition(tuwjson::Value& definition) noexcept;
+void CheckVersion(JsonResult& result, tuwjson::Value& definition) noexcept;
+void CheckDefinition(JsonResult& result, tuwjson::Value& definition) noexcept;
+void CheckSubDefinition(JsonResult& result, tuwjson::Value& sub_definition,
+                        int index) noexcept;
+void CheckHelpURLs(JsonResult& result, tuwjson::Value& definition) noexcept;
 
 }  // namespace json_utils

--- a/include/main_frame.h
+++ b/include/main_frame.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "rapidjson/document.h"
+#include "json.h"
 #include "component.h"
 #include "json_utils.h"
 #include "string_utils.h"
@@ -13,7 +13,7 @@ struct MenuData {
     int menu_id;
 };
 
-#define EMPTY_DOCUMENT rapidjson::Document(rapidjson::kObjectType)
+#define EMPTY_JSON tuwjson::Value()
 
 // Get "gui_definition.*"
 const char* GetDefaultJsonPath() noexcept;
@@ -21,9 +21,9 @@ const char* GetDefaultJsonPath() noexcept;
 // Main window
 class MainFrame {
  private:
-    rapidjson::Document m_definition;
-    unsigned m_definition_id;
-    rapidjson::Document m_config;
+    tuwjson::Value m_definition;
+    size_t m_definition_id;
+    tuwjson::Value m_config;
     uiWindow* m_mainwin;
 #ifdef __TUW_UNIX__
     uiWindow* m_logwin;
@@ -37,7 +37,7 @@ class MainFrame {
 
     void CreateFrame() noexcept;
     void CreateMenu() noexcept;
-    json_utils::JsonResult CheckDefinition(rapidjson::Document& definition) noexcept;
+    json_utils::JsonResult CheckDefinition(tuwjson::Value& definition) noexcept;
     void UpdateConfig() noexcept;
     void ShowSuccessDialog(const char* msg, const char* title = "Success") noexcept;
     void ShowErrorDialog(const char* msg, const char* title = "Error") noexcept;
@@ -73,27 +73,27 @@ class MainFrame {
     }
 
  public:
-    explicit MainFrame(const rapidjson::Document& definition = EMPTY_DOCUMENT,
-                       const rapidjson::Document& config = EMPTY_DOCUMENT,
+    explicit MainFrame(const tuwjson::Value& definition = EMPTY_JSON,
+                       const tuwjson::Value& config = EMPTY_JSON,
                        const char* json_path = nullptr) noexcept {
         Initialize(definition, config, json_path);
     }
 
     explicit MainFrame(const char* json_path) noexcept {
-        Initialize(EMPTY_DOCUMENT, EMPTY_DOCUMENT, json_path);
+        Initialize(EMPTY_JSON, EMPTY_JSON, json_path);
     }
 
-    void Initialize(const rapidjson::Document& definition,
-                    const rapidjson::Document& config,
+    void Initialize(const tuwjson::Value& definition,
+                    const tuwjson::Value& config,
                     noex::string json_path) noexcept;
 
-    void UpdatePanel(unsigned definition_id) noexcept;
+    void UpdatePanel(size_t definition_id) noexcept;
     noex::string OpenURLBase(int id) noexcept;
     void OpenURL(int id) noexcept;
     bool Validate() noexcept;
     noex::string GetCommand() noexcept;
     void RunCommand() noexcept;
-    void GetDefinition(rapidjson::Document& json) noexcept;
+    void GetDefinition(tuwjson::Value& json) noexcept;
     void SaveConfig() noexcept;
     void Fit(bool keep_width = false) noexcept;
     void Close() noexcept {

--- a/include/noex/error.hpp
+++ b/include/noex/error.hpp
@@ -4,6 +4,7 @@ namespace noex {
 
 enum ErrorNo : int {
     OK = 0,
+    NEW_ALLOCATION_ERROR,  // Failed to call noex::new() oeperator.
     STR_ALLOCATION_ERROR,  // Failed to allocate memory for string.
     STR_BOUNDARY_ERROR,  // Accessed out-of-bounds with substr or [].
     STR_FORMAT_ERROR,  // Failed to convert a number to string.

--- a/include/noex/new.hpp
+++ b/include/noex/new.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+namespace noex {
+
+template <typename T>
+T* new_ref() {
+    T* obj = reinterpret_cast<T*>(calloc(1, sizeof(T)));
+    if (obj) {
+        if (std::is_trivial<T>::value)
+            new (obj) T();
+    } else {
+        set_error_no(NEW_ALLOCATION_ERROR);
+    }
+    return obj;
+}
+
+template <typename T>
+void del_ref(T* obj) {
+    if (!obj)
+        return;
+    if (std::is_trivial<T>::value)
+        obj->~T();
+    free(obj);
+}
+
+}  // namespace noex

--- a/include/noex/string.hpp
+++ b/include/noex/string.hpp
@@ -66,10 +66,12 @@ class basic_string {
     basic_string operator+(int num) const noexcept;
     basic_string operator+(size_t num) const noexcept;
     basic_string operator+(uint32_t num) const noexcept;
+    basic_string operator+(double num) const noexcept;
 
     static basic_string to_string(int num) noexcept;
     static basic_string to_string(size_t num) noexcept;
     static basic_string to_string(uint32_t num) noexcept;
+    static basic_string to_string(double num) noexcept;
 
     bool operator==(const charT* str) const noexcept;
     bool operator==(const basic_string& str) const noexcept;

--- a/include/noex/vector.hpp
+++ b/include/noex/vector.hpp
@@ -65,7 +65,7 @@ class non_trivial_vector {
 
         // Move or copy existing elements to the new memory
         for (size_t i = 0; i < m_size; ++i) {
-            new (data + i) T(std::move(m_data[i]));
+            new (data + i) T(static_cast<T&&>(m_data[i]));
             m_data[i].~T();
         }
 
@@ -155,6 +155,13 @@ class non_trivial_vector {
         return at(m_size - 1);
     }
 
+    void pop_back() noexcept {
+        if (empty())
+            return;
+        back().~T();
+        m_size--;
+    }
+
     void push_back(const T& val) noexcept {
         reserve(m_size + 1);
         if (m_capacity < m_size + 1) return;
@@ -190,7 +197,7 @@ class non_trivial_vector {
 
         // Move or copy existing elements to the new memory
         for (size_t i = 0; i < m_size; ++i) {
-            new (data + i) T(std::move(m_data[i]));
+            new (data + i) T(static_cast<T&&>(m_data[i]));
             m_data[i].~T();
         }
 
@@ -235,6 +242,12 @@ class trivial_vector_base {
     }
 
     void shrink_to_fit() noexcept;
+
+    void pop_back() noexcept {
+        if (empty())
+            return;
+        m_size--;
+    }
 };
 
 // base class for trivial classes

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -9,7 +9,10 @@ noex::string GetLastLine(const noex::string& str) noexcept;
 // Convert allocated string with env_utils.h into noex::string
 noex::string envuStr(char *cstr) noexcept;
 
-uint32_t Fnv1Hash32(const noex::string& str) noexcept;
+uint32_t Fnv1Hash32(const char* str) noexcept;
+inline uint32_t Fnv1Hash32(const noex::string& str) noexcept {
+    return Fnv1Hash32(str.c_str());
+}
 
 #ifdef _WIN32
 noex::string ANSItoUTF8(const noex::string& str) noexcept;

--- a/include/validator.h
+++ b/include/validator.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "rapidjson/document.h"
+#include "json.h"
 
 #include "string_utils.h"
 
@@ -20,7 +20,7 @@ class Validator {
                   m_not_empty(false), m_exist(false),
                   m_error_msg("") {}
     ~Validator() {}
-    void Initialize(const rapidjson::Value& j) noexcept;
+    void Initialize(const tuwjson::Value& j) noexcept;
     bool Validate(const noex::string& str) noexcept;
     const noex::string& GetError() const noexcept { return m_error_msg; }
 };

--- a/meson.build
+++ b/meson.build
@@ -123,12 +123,11 @@ if tuw_OS != 'windows'
 endif
 
 libui_dep = dependency('libui', fallback : ['libui', 'libui_dep'])
-rapidjson_dep = dependency('rapidjson', fallback : ['rapidjson', 'rapidjson_dep'])
 subprocess_dep = dependency('subprocess', fallback : ['subprocess', 'subprocess_dep'])
 env_utils_dep = dependency('env_utils', fallback : ['env_utils', 'env_utils_dep'])
 tiny_str_match_dep = dependency('tiny_str_match', fallback : ['tiny_str_match', 'tiny_str_match_dep'])
 
-tuw_dependencies += [libui_dep, rapidjson_dep, subprocess_dep, env_utils_dep, tiny_str_match_dep]
+tuw_dependencies += [libui_dep, subprocess_dep, env_utils_dep, tiny_str_match_dep]
 if tuw_OS != 'windows' and tuw_OS != 'darwin'
     gtkansi_dep = dependency('gtk_ansi_parser', fallback : ['gtk_ansi_parser', 'gtkansi_dep'])
     tuw_dependencies += [gtkansi_dep]

--- a/meson.build
+++ b/meson.build
@@ -142,6 +142,7 @@ tuw_sources += [
     'src/exec.cpp',
     'src/string_utils.cpp',
     'src/validator.cpp',
+    'src/json.cpp',
     'src/noex/string.cpp',
     'src/noex/vector.cpp',
 ]

--- a/src/exe_container.cpp
+++ b/src/exe_container.cpp
@@ -151,7 +151,7 @@ noex::string ExeContainer::Write(const noex::string& exe_path) noexcept {
         if (end)
             json_size = static_cast<uint32_t>(end - json_buffer);
         else
-            return "Failed to convert JSON to string.";
+            return writer.GetErrMsg();
     }
 
     if (JSON_SIZE_MAX <= json_size)

--- a/src/exe_container.cpp
+++ b/src/exe_container.cpp
@@ -1,10 +1,7 @@
 #include "exe_container.h"
 #include <cassert>
 
-#include "rapidjson/stringbuffer.h"
-#include "rapidjson/writer.h"
-#include "rapidjson/error/en.h"
-
+#include "json.h"
 #include "string_utils.h"
 
 static uint32_t ReadUint32(FILE* io) noexcept {

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -460,7 +460,7 @@ bool Parser::ValidateUTF8(const char* str) noexcept {
     size_t multibyte_seq = 0;
     bool valid = true;
     while (*ptr) {
-        char c = *ptr;
+        uint8_t c = static_cast<uint8_t>(*ptr);
         if (multibyte_seq <= 0) {
             if (c <= ASCII_MAX) {
             } else if (c < TWO_BYTE_MIN) {
@@ -579,7 +579,7 @@ void Writer::WriteBytes(const char* bytes, size_t size) noexcept {
 }
 
 void Writer::WriteIndent() noexcept {
-    for (int i = 0; i < m_depth; i++)
+    for (size_t i = 0; i < m_depth; i++)
         WriteBytes(m_indent_ptr, m_indent_size);
 }
 

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -1,0 +1,697 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
+#include "json.h"
+#include "noex/error.hpp"
+#include "noex/new.hpp"
+
+namespace tuwjson {
+
+// Value
+
+bool Value::operator==(const Value& val) const noexcept {
+    if (m_type != val.m_type)
+        return false;
+    if (m_type == JSON_TYPE_OBJECT) {
+        if (val.Size() != Size())
+            return false;
+        for (const Item& item : *val.u.m_object) {
+            if (!HasMember(item.key))
+                return false;
+            if (*item.val != At(item.key))
+                return false;
+        }
+    } else if (m_type == JSON_TYPE_ARRAY) {
+        if (val.Size() != Size())
+            return false;
+        for (size_t i = 0; i < Size(); i++) {
+            if (At(i) != val[i])
+                return false;
+        }
+    } else if (m_type == JSON_TYPE_STRING) {
+        return *u.m_string == *val.u.m_string;
+    } else if (m_type == JSON_TYPE_INT) {
+        return GetInt() == val.GetInt();
+    } else if (m_type == JSON_TYPE_DOUBLE) {
+        double diff = GetDouble() - val.GetDouble();
+        if (diff < 0)
+            diff = -diff;
+        return diff < 0.00001;
+    } else if (m_type == JSON_TYPE_BOOL) {
+        return GetBool() == val.GetBool();
+    }
+    return true;
+}
+
+void Value::FreeValue() noexcept {
+    if (m_type == JSON_TYPE_OBJECT && u.m_object) {
+        noex::del_ref(u.m_object);
+    } else if (m_type == JSON_TYPE_ARRAY && u.m_array) {
+        noex::del_ref(u.m_array);
+    } else if (m_type == JSON_TYPE_STRING && u.m_string) {
+        noex::del_ref(u.m_string);
+    }
+}
+
+void Value::CopyFrom(const Value& val) noexcept {
+    Type type = val.m_type;
+    if (type == JSON_TYPE_OBJECT) {
+        SetObject();
+        for (const Item& item : *val.u.m_object) {
+            Value& new_v = At(item.key);
+            new_v.CopyFrom(*item.val);
+        }
+    } else if (type == JSON_TYPE_ARRAY) {
+        SetArray();
+        for (const Value& v : val) {
+            Value new_v;
+            new_v.CopyFrom(v);
+            u.m_array->push_back(static_cast<Value&&>(new_v));
+        }
+    } else if (type == JSON_TYPE_STRING) {
+        SetString(*val.u.m_string);
+    } else if (type == JSON_TYPE_INT) {
+        SetInt(val.u.m_int);
+    } else if (type == JSON_TYPE_DOUBLE) {
+        SetDouble(val.u.m_double);
+    } else if (type == JSON_TYPE_BOOL) {
+        SetBool(val.u.m_bool);
+    }
+    return;
+}
+
+void Value::Swap(Value& val) noexcept {
+    Value tmp;
+    tmp.MoveFrom(val);
+    val.MoveFrom(*this);
+    MoveFrom(tmp);
+}
+
+void Value::SetObject() noexcept {
+    FreeValue();
+    m_type = JSON_TYPE_OBJECT;
+    u.m_object = noex::new_ref<Object>();
+}
+
+static bool object_has_member(const Object* obj, const char* key) {
+    for (const Item& item : *obj) {
+        if (item.key == key)
+            return true;
+    }
+    return false;
+}
+
+bool Value::HasMember(const char* key) const noexcept {
+    assert(m_type == JSON_TYPE_OBJECT);
+    return object_has_member(u.m_object, key);
+}
+
+Value& Value::At(const char* key) const noexcept {
+    assert(m_type == JSON_TYPE_OBJECT);
+    static Value dummy{};
+    for (Item& item : *u.m_object) {
+        if (item.key == key) {
+            if (item.val)
+                return *item.val;
+            break;
+        }
+    }
+    Item item;
+    item.key = key;
+    u.m_object->push_back(static_cast<Item&&>(item));
+    return *u.m_object->back().val;
+}
+
+void Value::ReplaceKey(const char* key, const char* new_key) noexcept {
+    assert(m_type == JSON_TYPE_OBJECT);
+    for (Item& item : *u.m_object) {
+        if (item.key == key) {
+            item.key = new_key;
+            break;
+        }
+    }
+}
+
+void Value::ConvertToObject(const char* key) noexcept {
+    Object* object = u.m_object;
+    Type type = m_type;
+    u.m_object = nullptr;
+    m_type = JSON_TYPE_NULL;
+    SetObject();
+    Item item;
+    item.key = key;
+    item.val->u.m_object = object;
+    item.val->m_type = type;
+    u.m_object->push_back(static_cast<Item&&>(item));
+}
+
+size_t Value::Size() const noexcept {
+    assert(m_type == JSON_TYPE_OBJECT || m_type == JSON_TYPE_ARRAY);
+    if (m_type == JSON_TYPE_OBJECT)
+        return u.m_object->size();
+    if (m_type == JSON_TYPE_ARRAY)
+        return u.m_array->size();
+    return 0;
+}
+
+void Value::SetArray() noexcept {
+    FreeValue();
+    m_type = JSON_TYPE_ARRAY;
+    u.m_array = noex::new_ref<Array>();
+}
+
+void Value::ConvertToArray() noexcept {
+    Array* array = u.m_array;
+    Type type = m_type;
+    u.m_array = nullptr;
+    m_type = JSON_TYPE_NULL;
+    SetArray();
+    Value val;
+    val.u.m_array = array;
+    val.m_type = type;
+    u.m_array->push_back(static_cast<Value&&>(val));
+}
+
+void Value::SetString() noexcept {
+    FreeValue();
+    m_type = JSON_TYPE_STRING;
+    u.m_string = noex::new_ref<noex::string>();
+}
+
+// Parser
+void Parser::SkipToValue() noexcept {
+    while (true) {
+        SkipSpaces();
+        if (Peek() == '/' && Peek(1) == '/') {
+            while (Peek() && Peek() != '\n')
+                ConsumeNonSpace();
+        } else if (Peek() == '/' && Peek(1) == '*') {
+            ConsumeNonSpace(2);
+            while (Peek() && !(Peek() == '*' && Peek(1) == '/')) {
+                Consume();
+            }
+            if (Peek()) {
+                ConsumeNonSpace(2);
+            } else {
+                m_err = JSON_ERR_UNCLOSED_COMMENT;
+            }
+        } else {
+            break;
+        }
+    }
+}
+
+Type Parser::PeekValueType() const noexcept {
+    char c = Peek();
+    if (c == '{')
+        return JSON_TYPE_OBJECT;
+    if (c == '[')
+        return JSON_TYPE_ARRAY;
+    if (c == '"')
+        return JSON_TYPE_STRING;
+    if (c == '-' || ('0' <= c && c <= '9')) {
+        const char* s = m_ptr + 1;
+        while ('0' <= *s && *s <= '9')
+            s++;
+        if (*s != '.' && *s != 'e' && *s != 'E')
+            return JSON_TYPE_INT;
+        if (*s == '.') {
+            s++;
+            while ('0' <= *s && *s <= '9')
+                s++;
+        }
+        if (*s == 'e' || *s == 'E') {
+            s++;
+            if (*s == '-')
+                s++;
+            while ('0' <= *s && *s <= '9')
+                s++;
+        }
+        if (IsLiteralEnd(*s))
+            return JSON_TYPE_DOUBLE;
+        return JSON_TYPE_UNKNOWN;
+    }
+    if (IsLiteral(m_ptr, "null")) {
+        return JSON_TYPE_NULL;
+    }
+    if (IsLiteral(m_ptr, "true") || IsLiteral(m_ptr, "false")) {
+        return JSON_TYPE_BOOL;
+    }
+    return JSON_TYPE_UNKNOWN;
+}
+
+noex::string Parser::ParseString() noexcept {
+    const char* s = m_ptr + 1;
+    size_t len = 0;
+    while (*s && *s != '\n' && *s != '"') {
+        if (*s == '\\' && s[1]) {
+            s++;
+        }
+        len++;
+        s++;
+    }
+    if (!*s || *s == '\n') {
+        m_err = JSON_ERR_UNCLOSED_STR;
+        return "";
+    }
+    noex::string buf(len);
+    char* cstr = buf.data();
+    if (!cstr) {
+        m_err = JSON_ERR_ALLOC;
+        return "";
+    }
+    ConsumeNonSpace();
+    while (Peek() != '"') {
+        char c = Peek();
+        if (c == '\\') {
+            ConsumeNonSpace();
+            c = Peek();
+            if (c == '"' || c == '\\' || c == '/') {
+                *cstr = c;
+            } else if (c == 'b') {
+                *cstr = '\b';
+            } else if (c == 'f') {
+                *cstr = '\f';
+            } else if (c == 'n') {
+                *cstr = '\n';
+            } else if (c == 'r') {
+                *cstr = '\r';
+            } else if (c == 't') {
+                *cstr = '\t';
+            } else if (c == 'u') {
+                m_err = JSON_ERR_UNICODE_ESCAPE;
+                return "";
+            } else {
+                m_err = JSON_ERR_INVALID_ESCAPE;
+                return "";
+            }
+        } else {
+            *cstr = c;
+        }
+        cstr++;
+        ConsumeNonSpace();
+    }
+    ConsumeNonSpace();
+    return buf;
+}
+
+int Parser::ParseInt() noexcept {
+    char* endptr;
+    errno = 0;
+    int value = static_cast<int>(strtol(m_ptr, &endptr, 10));
+    if (errno) {
+        m_err = JSON_ERR_INVALID_INT;
+        return 0;
+    }
+    ConsumeNonSpace(static_cast<size_t>(endptr - m_ptr));
+    return value;
+}
+
+double Parser::ParseDouble() noexcept {
+    char* endptr;
+    errno = 0;
+    double value = strtod(m_ptr, &endptr);
+    if (errno) {
+        m_err = JSON_ERR_INVALID_DOUBLE;
+        return 0.0;
+    }
+    ConsumeNonSpace(static_cast<size_t>(endptr - m_ptr));
+    return value;
+}
+
+void Parser::ParseArray(Array* array) noexcept {
+    bool comma_exists = true;
+    while (true) {
+        SkipToValue();
+        if (!Peek()) {
+            m_err = JSON_ERR_UNCLOSED_ARRAY;
+            return;
+        }
+        if (Peek() == ']') {
+            ConsumeNonSpace();
+            break;
+        }
+        if (!comma_exists) {
+            m_err = JSON_ERR_UNCLOSED_ARRAY;
+            return;
+        }
+        Value val;
+        ParseValue(&val);
+        array->push_back(static_cast<Value&&>(val));
+        if (noex::get_error_no() != noex::OK)
+            m_err = JSON_ERR_ALLOC;
+        if (HasError())
+            return;
+        SkipToValue();
+        comma_exists = Peek() == ',';
+        if (comma_exists)
+            ConsumeNonSpace();
+    }
+}
+
+void Parser::ParseObject(Object* object) noexcept {
+    bool comma_exists = true;
+    while (true) {
+        SkipToValue();
+        if (!Peek()) {
+            m_err = JSON_ERR_UNCLOSED_OBJECT;
+            return;
+        }
+        if (Peek() == '}') {
+            ConsumeNonSpace();
+            break;
+        }
+        if (!comma_exists) {
+            m_err = JSON_ERR_UNCLOSED_OBJECT;
+            return;
+        }
+        if (PeekValueType() != JSON_TYPE_STRING) {
+            m_err = JSON_ERR_INVALID_KEY;
+            return;
+        }
+        Item item;
+        item.key = ParseString();
+        if (HasError())
+            return;
+        if (object_has_member(object, item.key.c_str())) {
+            m_err = JSON_ERR_DUPLICATED_KEY;
+            return;
+        }
+        SkipToValue();
+        if (Peek() != ':') {
+            m_err = JSON_ERR_EXPECTED_COLON;
+            return;
+        }
+        ConsumeNonSpace();
+
+        ParseValue(item.val);
+        object->push_back(static_cast<Item&&>(item));
+        if (noex::get_error_no() != noex::OK)
+            m_err = JSON_ERR_ALLOC;
+        if (HasError())
+            return;
+        SkipToValue();
+        comma_exists = Peek() == ',';
+        if (comma_exists)
+            ConsumeNonSpace();
+    }
+}
+
+void Parser::ParseValue(Value* value) noexcept {
+    if (!value)
+        return;
+    SkipToValue();
+    if (HasError())
+        return;
+    Type type = PeekValueType();
+    if (type == JSON_TYPE_OBJECT) {
+        ConsumeNonSpace();
+        value->SetObject();
+        Object* object = value->GetObject();
+        if (!object) {
+            m_err = JSON_ERR_ALLOC;
+            return;
+        }
+        ParseObject(object);
+    } else if (type == JSON_TYPE_ARRAY) {
+        ConsumeNonSpace();
+        value->SetArray();
+        Array* array = value->GetArray();
+        if (!array) {
+            m_err = JSON_ERR_ALLOC;
+            return;
+        }
+        ParseArray(array);
+    } else if (type == JSON_TYPE_STRING) {
+        value->SetString(ParseString());
+    } else if (type == JSON_TYPE_INT) {
+        value->SetInt(ParseInt());
+    } else if (type == JSON_TYPE_DOUBLE) {
+        value->SetDouble(ParseDouble());
+    } else if (type == JSON_TYPE_BOOL) {
+        bool val = Peek() == 't';
+        value->SetBool(val);
+        ConsumeNonSpace(val ? 4 : 5);
+    } else if (type == JSON_TYPE_NULL) {
+        ConsumeNonSpace(4);
+    } else if (type == JSON_TYPE_UNKNOWN) {
+        char c = Peek();
+        if (c == ',')
+            m_err = JSON_ERR_INVALID_COMMA;
+        else if (c)
+            m_err = JSON_ERR_UNKNOWN_LITERAL;
+    }
+}
+
+#define ASCII_MAX 0x7F  // ascii 0x00 ~ 0x7F
+#define MULTIBYTE_SEQ_MAX 0xBF  // sequences for multibyte characters 0x80 ~ 0xBF
+#define TWO_BYTE_MIN 0xC2  // two-byte characters 0xC2 ~
+#define TWO_BYTE_MAX 0xDF  // two-byte characters ~ 0xDF
+#define THREE_BYTE_MAX 0xEF  // three-byte characters 0xE0 ~ 0xEF
+#define FOUR_BYTE_MAX 0xF4  // four-byte characters 0xF0 ~ 0xF4
+// unused codes 0xF5 ~ 0xFF
+
+#define is_multibyte_seq(c) ((ASCII_MAX < (c)) && ((c) <= MULTIBYTE_SEQ_MAX))
+
+bool Parser::ValidateUTF8(const char* str) noexcept {
+    size_t line_count = 1;
+    const char* ptr = str;
+    const char* line_ptr = str;
+    size_t multibyte_seq = 0;
+    bool valid = true;
+    while (*ptr) {
+        char c = *ptr;
+        if (multibyte_seq <= 0) {
+            if (c <= ASCII_MAX) {
+            } else if (c < TWO_BYTE_MIN) {
+                valid = false;
+                break;
+            } else if (c <= TWO_BYTE_MAX) {
+                multibyte_seq = 1;
+            } else if (c <= THREE_BYTE_MAX) {
+                multibyte_seq = 2;
+            } else if (c <= FOUR_BYTE_MAX) {
+                multibyte_seq = 3;
+            } else {
+                valid = false;
+                break;
+            }
+        } else {
+            if (!is_multibyte_seq(c)) {
+                valid = false;
+                break;
+            }
+            multibyte_seq--;
+        }
+        if (c == '\n') {
+            line_count++;
+            line_ptr = ptr;
+        }
+        ptr++;
+    }
+    if (!valid) {
+        m_line_count = line_count;
+        m_line_ptr = line_ptr;
+        m_ptr = ptr;
+        m_err = JSON_ERR_INVALID_UTF;
+    }
+    return valid;
+}
+
+Error Parser::ParseJson(const char* json, Value* root) noexcept {
+    Init(json);
+    if (!ValidateUTF8(json))
+        return m_err;
+    ParseValue(root);
+    return m_err;
+}
+
+static const char* get_def_err_msg(Error err) noexcept {
+    if (err == JSON_ERR_UNKNOWN_LITERAL)
+        return "unknown literal detected";
+    if (err == JSON_ERR_INVALID_UTF)
+        return "invalid UTF8 character detected";
+    if (err == JSON_ERR_INVALID_INT)
+        return "failed to parse a double number";
+    if (err == JSON_ERR_INVALID_DOUBLE)
+        return "failed to parse an integer";
+    if (err == JSON_ERR_INVALID_COMMA)
+        return "there is a comma in the wrong position";
+    if (err == JSON_ERR_INVALID_ESCAPE)
+        return "invalid escaped character: \\";
+    if (err == JSON_ERR_UNICODE_ESCAPE)
+        return "unicode escape (\\uXXXX) is not supported. use UTF-8 characters instead";
+    if (err == JSON_ERR_UNCLOSED_STR)
+        return "quotation mark '\"' is missing";
+    if (err == JSON_ERR_UNCLOSED_COMMENT)
+        return "multiline comment is not closed";
+    if (err == JSON_ERR_UNCLOSED_ARRAY)
+        return "comma ',' or closing bracket ']' is missing";
+    if (err == JSON_ERR_UNCLOSED_OBJECT)
+        return "comma ',' or closing brace '}' is missing";
+    if (err == JSON_ERR_EXPECTED_COLON)
+        return "colon ':' is missing";
+    if (err == JSON_ERR_INVALID_KEY)
+        return "string key is missing";
+    if (err == JSON_ERR_DUPLICATED_KEY)
+        return "there is a duplicated key";
+    return "";
+}
+
+const char* Parser::GetErrMsg() noexcept {
+    if (m_err == JSON_OK || m_err >= JSON_ERR_MAX)
+        return "";
+    if (m_err == JSON_ERR_ALLOC)
+        return "Memory allocation error.";
+
+    m_err_msg = get_def_err_msg(m_err);
+    if (m_err == JSON_ERR_INVALID_ESCAPE)
+        m_err_msg.push_back(*m_ptr);
+
+    size_t offSet = static_cast<size_t>(m_ptr - m_line_ptr);
+    m_err_msg += " (line: " + noex::to_string(m_line_count) +
+                    ", offset: " + noex::to_string(offSet) + ")";
+    return m_err_msg.c_str();
+}
+
+void Writer::WriteChar(char c) noexcept {
+    if (!m_buf)
+        return;
+    if (m_buf_size <= 1) {
+        m_buf = nullptr;
+        return;
+    }
+    *m_buf = c;
+    m_buf++;
+    m_buf_size--;
+}
+
+void Writer::WriteBytes(const char* bytes, size_t size) noexcept {
+    if (!m_buf)
+        return;
+    if (m_buf_size <= size) {
+        m_buf = nullptr;
+        return;
+    }
+    memcpy(m_buf, bytes, size);
+    m_buf += size;
+    m_buf_size -= size;
+}
+
+void Writer::WriteIndent() noexcept {
+    for (int i = 0; i < m_depth; i++)
+        WriteBytes(m_indent_ptr, m_indent_size);
+}
+
+void Writer::WriteLinefeed() noexcept {
+    if (m_use_linefeed)
+        WriteChar('\n');
+}
+
+static bool need_escape(char c) noexcept {
+    return c == '"' || c == '\\' || c == '\b' ||
+            c == '\f' || c == '\n' || c == '\r' || c == '\t';
+}
+
+void Writer::WriteString(const char* str) noexcept {
+    WriteChar('"');
+    while (*str && m_buf) {
+        char c = *str;
+        if (need_escape(c))
+            WriteChar('\\');
+        if (c == '\b') {
+            WriteChar('b');
+        } else if (c == '\f') {
+            WriteChar('f');
+        } else if (c == '\n') {
+            WriteChar('n');
+        } else if (c == '\r') {
+            WriteChar('r');
+        } else if (c == '\t') {
+            WriteChar('t');
+        } else {
+            WriteChar(c);
+        }
+        str++;
+    }
+    WriteChar('"');
+}
+
+void Writer::WriteObject(const Object* obj) noexcept {
+    WriteChar('{');
+    WriteLinefeed();
+    m_depth++;
+    WriteIndent();
+    size_t object_size = obj->size();
+    for (size_t i = 0; i < object_size; i++) {
+        Item& item = obj->at(i);
+        WriteString(item.key.c_str());
+        WriteBytes(": ", 2);
+        WriteValue(item.val);
+        if (i + 1 < object_size) {
+            WriteChar(',');
+            WriteLinefeed();
+            WriteIndent();
+        }
+    }
+    m_depth--;
+    WriteLinefeed();
+    WriteIndent();
+    WriteChar('}');
+}
+
+void Writer::WriteArray(const Array* ary) noexcept {
+    WriteChar('[');
+    WriteLinefeed();
+    m_depth++;
+    WriteIndent();
+    size_t array_size = ary->size();
+    for (size_t i = 0; i < array_size; i++) {
+        WriteValue(&ary->at(i));
+        if (i + 1 < array_size) {
+            WriteChar(',');
+            WriteLinefeed();
+            WriteIndent();
+        }
+    }
+    m_depth--;
+    WriteLinefeed();
+    WriteIndent();
+    WriteChar(']');
+}
+
+void Writer::WriteValue(const Value* val) noexcept {
+    Type type = val->GetType();
+    if (type == JSON_TYPE_OBJECT) {
+        WriteObject(val->GetObject());
+    } else if (type == JSON_TYPE_ARRAY) {
+        WriteArray(val->GetArray());
+    } else if (type == JSON_TYPE_STRING) {
+        WriteString(val->GetString());
+    } else if (type == JSON_TYPE_INT) {
+        noex::string str = noex::to_string(val->GetInt());
+        WriteBytes(str.c_str(), str.size());
+    } else if (type == JSON_TYPE_DOUBLE) {
+        noex::string str = noex::to_string(val->GetDouble());
+        WriteBytes(str.c_str(), str.size());
+    } else if (type == JSON_TYPE_BOOL) {
+        if (val->GetBool())
+            WriteBytes("true", 4);
+        else
+            WriteBytes("false", 5);
+    } else if (type == JSON_TYPE_NULL) {
+        WriteBytes("null", 4);
+    }
+}
+
+char* Writer::WriteJson(const Value* root, char* buf, size_t buf_size) noexcept {
+    m_buf = buf;
+    m_buf_size = buf_size;
+    WriteValue(root);
+    WriteLinefeed();
+    if (m_buf)
+        *m_buf = '\0';
+    return m_buf;
+}
+
+}  // namespace tuwjson

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -52,71 +52,66 @@ enum ComponentType: int {
     COMP_MAX
 };
 
-// JSON parser allows c style comments and trailing commas.
-constexpr auto JSONC_FLAGS =
-    rapidjson::kParseCommentsFlag | rapidjson::kParseTrailingCommasFlag;
-
-noex::string LoadJson(const noex::string& file, rapidjson::Document& json) noexcept {
+noex::string LoadJson(const noex::string& file, tuwjson::Value& json) noexcept {
     FILE* fp = FileOpen(file.c_str(), "rb");
     if (!fp)
         return GetFileError(file);
 
-    char readBuffer[JSON_SIZE_MAX];
-    rapidjson::FileReadStream is(fp, readBuffer, sizeof(readBuffer));
-
-    rapidjson::ParseResult ok = json.ParseStream<JSONC_FLAGS>(is);
+    char buffer[JSON_SIZE_MAX];
+    size_t size = fread(buffer, sizeof(char), JSON_SIZE_MAX - 1, fp);
     fclose(fp);
+    if (size > 0)
+        buffer[size] = 0;
+    else
+        buffer[0] = 0;
 
-    if (!ok) {
-        return noex::concat_cstr("Failed to parse JSON: ",
-                rapidjson::GetParseError_En(ok.Code()),
-                " (offset: ") + ok.Offset() + ")";
-    }
+    tuwjson::Parser parser;
+    parser.ParseJson(buffer, &json);
+    if (parser.HasError())
+        return noex::concat_cstr("Failed to parse JSON: ", parser.GetErrMsg());
     if (!json.IsObject())
         json.SetObject();
 
     return "";
 }
 
-noex::string SaveJson(rapidjson::Document& json, const noex::string& file) noexcept {
+noex::string SaveJson(tuwjson::Value& json, const noex::string& file) noexcept {
     FILE* fp = FileOpen(file.c_str(), "wb");
     if (!fp)
         return GetFileError(file);
 
-    char writeBuffer[JSON_SIZE_MAX];
-    rapidjson::FileWriteStream os(fp, writeBuffer, sizeof(writeBuffer));
-    rapidjson::PrettyWriter<rapidjson::FileWriteStream> writer(os);
-    json.Accept(writer);
+    char buffer[JSON_SIZE_MAX];
+    tuwjson::Writer writer("    ", 4, true);
+    char* end = writer.WriteJson(&json, buffer, JSON_SIZE_MAX);
+    if (end)
+        fwrite(buffer, sizeof(char), end - buffer, fp);
+
     fclose(fp);
+
+    if (!end)
+        return "Failed to write JSON: " + file;
     return "";
 }
 
-noex::string JsonToString(rapidjson::Document& json) noexcept {
-    rapidjson::StringBuffer buffer;
-    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-    json.Accept(writer);
-    return buffer.GetString();
-}
-
-const char* GetString(const rapidjson::Value& json, const char* key, const char* def) noexcept {
+const char* GetString(const tuwjson::Value& json, const char* key, const char* def) noexcept {
     if (json.HasMember(key))
         return json[key].GetString();
     return def;
 }
 
-bool GetBool(const rapidjson::Value& json, const char* key, bool def) noexcept {
+bool GetBool(const tuwjson::Value& json, const char* key, bool def) noexcept {
     if (json.HasMember(key))
         return json[key].GetBool();
     return def;
 }
 
-int GetInt(const rapidjson::Value& json, const char* key, int def) noexcept {
+int GetInt(const tuwjson::Value& json, const char* key, int def) noexcept {
     if (json.HasMember(key))
         return json[key].GetInt();
     return def;
 }
 
-double GetDouble(const rapidjson::Value& json, const char* key, double def) noexcept {
+double GetDouble(const tuwjson::Value& json, const char* key, double def) noexcept {
     if (json.HasMember(key))
         return json[key].GetDouble();
     return def;
@@ -142,7 +137,7 @@ enum class JsonType {
 
 static const bool OPTIONAL = true;
 
-static void CheckJsonType(JsonResult& result, const rapidjson::Value& j, const char* key,
+static void CheckJsonType(JsonResult& result, const tuwjson::Value& j, const char* key,
         const JsonType& type, const char* label = "", const bool& optional = false) noexcept {
     if (!j.HasMember(key)) {
         if (optional) return;
@@ -152,25 +147,26 @@ static void CheckJsonType(JsonResult& result, const rapidjson::Value& j, const c
     }
     bool valid = false;
     const char* type_name = nullptr;
+    const tuwjson::Value& v = j[key];
     switch (type) {
     case JsonType::BOOLEAN:
-        valid = j[key].IsBool();
+        valid = v.IsBool();
         type_name = "a boolean";
         break;
     case JsonType::INTEGER:
-        valid = j[key].IsInt();
+        valid = v.IsInt();
         type_name = "an int";
         break;
     case JsonType::FLOAT:
-        valid = j[key].IsDouble() || j[key].IsInt();
+        valid = v.IsDouble();
         type_name = "a float";
         break;
     case JsonType::STRING:
-        valid = j[key].IsString();
+        valid = v.IsString();
         type_name = "a string";
         break;
     case JsonType::JSON:
-        valid = j[key].IsObject();
+        valid = v.IsObject();
         type_name = "a json object";
         break;
     default:
@@ -184,40 +180,36 @@ static void CheckJsonType(JsonResult& result, const rapidjson::Value& j, const c
     }
 }
 
-static bool IsJsonArray(rapidjson::Value& j, const char* key,
-                        rapidjson::Document::AllocatorType& alloc) noexcept {
-    if (!j[key].IsArray()) {
-        if (!j[key].IsObject())
+static bool IsJsonArray(tuwjson::Value& j, const char* key) noexcept {
+    tuwjson::Value& val = j[key];
+    if (!val.IsArray()) {
+        if (!val.IsObject())
             return false;
-        rapidjson::Value array(rapidjson::kArrayType);
-        array.PushBack(j[key].Move(), alloc);
-        j[key] = array;
+        val.ConvertToArray();
     }
-    for (const rapidjson::Value& el : j[key].GetArray()) {
+    for (const tuwjson::Value& el : val) {
         if (!el.IsObject())
             return false;
     }
     return true;
 }
 
-static bool IsStringArray(rapidjson::Value& j, const char* key,
-                            rapidjson::Document::AllocatorType& alloc) noexcept {
-    if (!j[key].IsArray()) {
-        if (!j[key].IsString())
+static bool IsStringArray(tuwjson::Value& j, const char* key) noexcept {
+    tuwjson::Value& val = j[key];
+    if (!val.IsArray()) {
+        if (!val.IsString())
             return false;
-        rapidjson::Value array(rapidjson::kArrayType);
-        array.PushBack(j[key].Move(), alloc);
-        j[key] = array;
+        val.ConvertToArray();
     }
-    for (const rapidjson::Value& el : j[key].GetArray()) {
+    for (const tuwjson::Value& el : val) {
         if (!el.IsString())
             return false;
     }
     return true;
 }
 
-static void CheckJsonArrayType(JsonResult& result, rapidjson::Value& j, const char* key,
-        const JsonType& type, rapidjson::Document::AllocatorType& alloc,
+static void CheckJsonArrayType(JsonResult& result, tuwjson::Value& j, const char* key,
+        const JsonType& type,
         const char* label = "", const bool& optional = false) noexcept {
     if (!j.HasMember(key)) {
         if (optional) return;
@@ -229,11 +221,11 @@ static void CheckJsonArrayType(JsonResult& result, rapidjson::Value& j, const ch
     const char* type_name = nullptr;
     switch (type) {
     case JsonType::STRING:
-        valid = IsStringArray(j, key, alloc);
+        valid = IsStringArray(j, key);
         type_name = "an array of strings";
         break;
     case JsonType::JSON:
-        valid = IsJsonArray(j, key, alloc);
+        valid = IsJsonArray(j, key);
         type_name = "an array of json objects";
         break;
     default:
@@ -248,7 +240,7 @@ static void CheckJsonArrayType(JsonResult& result, rapidjson::Value& j, const ch
 }
 
 // get default definition of gui
-void GetDefaultDefinition(rapidjson::Document& definition) noexcept {
+void GetDefaultDefinition(tuwjson::Value& definition) noexcept {
     static const char* def_str = "{"
 #ifdef _WIN32
         "\"command\":\"dir\","
@@ -259,8 +251,9 @@ void GetDefaultDefinition(rapidjson::Document& definition) noexcept {
 #endif
         "\"components\":[]"
         "}";
-    rapidjson::ParseResult ok = definition.Parse(def_str);
-    assert(ok);
+    tuwjson::Parser parser;
+    tuwjson::Error ok = parser.ParseJson(def_str, &definition);
+    assert(ok == tuwjson::JSON_OK);
     (void) ok;  // GCC says it's unused even if you use it for assertion.
     JsonResult result = JSON_RESULT_OK;
     CheckDefinition(result, definition);
@@ -268,14 +261,10 @@ void GetDefaultDefinition(rapidjson::Document& definition) noexcept {
 }
 
 static void CorrectKey(
-        rapidjson::Value& j,
-        const char* false_key, const char* true_key,
-        rapidjson::Document::AllocatorType& alloc) noexcept {
-    if (!j.HasMember(true_key) && j.HasMember(false_key)) {
-        rapidjson::Value n(true_key, alloc);
-        j.AddMember(n, j[false_key], alloc);
-        j.RemoveMember(false_key);
-    }
+        tuwjson::Value& j,
+        const char* false_key, const char* true_key) noexcept {
+    if (!j.HasMember(true_key) && j.HasMember(false_key))
+        j.ReplaceKey(false_key, true_key);
 }
 
 static noex::vector<noex::string>
@@ -321,15 +310,14 @@ static void CheckIndexDuplication(
 
 // split command by "%" symbol, and calculate which component should be inserted there.
 static void CompileCommand(JsonResult& result,
-                            rapidjson::Value& sub_definition,
-                            const noex::vector<noex::string>& comp_ids,
-                            rapidjson::Document::AllocatorType& alloc) noexcept {
+                            tuwjson::Value& sub_definition,
+                            const noex::vector<noex::string>& comp_ids) noexcept {
     noex::vector<noex::string> cmd = SplitString(sub_definition["command"].GetString(), '%');
     noex::vector<noex::string> cmd_ids;
     noex::vector<noex::string> splitted_cmd;
-    if (sub_definition.HasMember("command_splitted"))
-        sub_definition.RemoveMember("command_splitted");
-    rapidjson::Value splitted_cmd_json(rapidjson::kArrayType);
+
+    tuwjson::Value splitted_cmd_json;
+    splitted_cmd_json.SetArray();
 
     bool store_ids = false;
     for (const noex::string& token : cmd) {
@@ -337,15 +325,17 @@ static void CompileCommand(JsonResult& result,
             cmd_ids.emplace_back(token);
         } else {
             splitted_cmd.emplace_back(token);
-            rapidjson::Value n(token.c_str(), alloc);
-            splitted_cmd_json.PushBack(n, alloc);
+            tuwjson::Value n;
+            n.SetString(token);
+            splitted_cmd_json.MoveAndPush(n);
         }
         store_ids = !store_ids;
     }
-    sub_definition.AddMember("command_splitted", splitted_cmd_json, alloc);
+    sub_definition["command_splitted"].MoveFrom(splitted_cmd_json);
 
-    rapidjson::Value& components = sub_definition["components"];;
-    rapidjson::Value cmd_int_ids(rapidjson::kArrayType);
+    tuwjson::Value& components = sub_definition["components"];;
+    tuwjson::Value cmd_int_ids;
+    cmd_int_ids.SetArray();
     noex::string cmd_str;
     int comp_size = static_cast<int>(comp_ids.size());
     int non_id_comp = 0;
@@ -367,17 +357,20 @@ static void CompileCommand(JsonResult& result,
                 if (id == comp_ids[j]) break;
             if (j == comp_size) {
                 while (non_id_comp < comp_size
-                    && (components[non_id_comp]["type_int"] == COMP_STATIC_TEXT
+                    && (components[non_id_comp]["type_int"].GetInt() == COMP_STATIC_TEXT
                         || !comp_ids[non_id_comp].empty()
-                        || components[non_id_comp]["type_int"] == COMP_EMPTY)) {
+                        || components[non_id_comp]["type_int"].GetInt() == COMP_EMPTY)) {
                     non_id_comp++;
                 }
                 j = non_id_comp;
                 non_id_comp++;
             }
         }
-        if (j < comp_size)
-            cmd_int_ids.PushBack(j, alloc);
+        if (j < comp_size) {
+            tuwjson::Value n;
+            n.SetInt(j);
+            cmd_int_ids.MoveAndPush(n);
+        }
         if (j >= comp_size)
             cmd_str += "__comp???__";
         else if (j >= 0)
@@ -392,7 +385,7 @@ static void CompileCommand(JsonResult& result,
         if (type_int == COMP_STATIC_TEXT || type_int == COMP_EMPTY)
             continue;
         bool found = false;
-        for (rapidjson::Value& id : cmd_int_ids.GetArray())
+        for (tuwjson::Value& id : cmd_int_ids)
             if (id.GetInt() == j) {
                 found = true;
                 break;
@@ -412,13 +405,10 @@ static void CompileCommand(JsonResult& result,
             "The command requires more components for arguments; " + cmd_str;
         return;
     }
-    if (sub_definition.HasMember("command_str"))
-        sub_definition.RemoveMember("command_str");
-    rapidjson::Value v(cmd_str.c_str(), alloc);
-    sub_definition.AddMember("command_str", v, alloc);
-    if (sub_definition.HasMember("command_ids"))
-        sub_definition.RemoveMember("command_ids");
-    sub_definition.AddMember("command_ids", cmd_int_ids, alloc);
+    tuwjson::Value v;
+    v.SetString(cmd_str);
+    sub_definition["command_str"].MoveFrom(v);
+    sub_definition["command_ids"].MoveFrom(cmd_int_ids);
 }
 
 // don't use map. it will make exe larger.
@@ -456,7 +446,7 @@ int ComptypeToInt(const char* comptype) noexcept {
     return COMP_UNKNOWN;
 }
 
-void CheckValidator(JsonResult& result, rapidjson::Value& validator,
+void CheckValidator(JsonResult& result, tuwjson::Value& validator,
                     const char* label) noexcept {
     CheckJsonType(result, validator, "regex", JsonType::STRING, label, OPTIONAL);
     CheckJsonType(result, validator, "regex_error", JsonType::STRING, label, OPTIONAL);
@@ -469,18 +459,16 @@ void CheckValidator(JsonResult& result, rapidjson::Value& validator,
 }
 
 // validate one of definitions (["gui"][i]) and store parsed info
-void CheckSubDefinition(JsonResult& result, rapidjson::Value& sub_definition,
-                        int index,
-                        rapidjson::Document::AllocatorType& alloc) noexcept {
-    CorrectKey(sub_definition, "window_title", "window_name", alloc);
-    CorrectKey(sub_definition, "title", "window_name", alloc);
+void CheckSubDefinition(JsonResult& result, tuwjson::Value& sub_definition,
+                        int index) noexcept {
+    CorrectKey(sub_definition, "window_title", "window_name");
+    CorrectKey(sub_definition, "title", "window_name");
     CheckJsonType(result, sub_definition, "window_name", JsonType::STRING, "", OPTIONAL);
 
     if (!sub_definition.HasMember("label")) {
         noex::string default_label = noex::string("GUI ") + index;
         const char* label = GetString(sub_definition, "window_name", default_label.c_str());
-        rapidjson::Value n(label, alloc);
-        sub_definition.AddMember("label", n, alloc);
+        sub_definition["label"].SetString(label);
     }
     CheckJsonType(result, sub_definition, "label", JsonType::STRING);
 
@@ -502,15 +490,15 @@ void CheckSubDefinition(JsonResult& result, rapidjson::Value& sub_definition,
         }
     }
 
-    CorrectKey(sub_definition, "component", "components", alloc);
-    CorrectKey(sub_definition, "component_array", "components", alloc);
-    CheckJsonArrayType(result, sub_definition, "components", JsonType::JSON, alloc);
+    CorrectKey(sub_definition, "component", "components");
+    CorrectKey(sub_definition, "component_array", "components");
+    CheckJsonArrayType(result, sub_definition, "components", JsonType::JSON);
 
     if (!result.ok) return;
 
     // check components
     noex::vector<noex::string> comp_ids;
-    for (rapidjson::Value& c : sub_definition["components"].GetArray()) {
+    for (tuwjson::Value& c : sub_definition["components"]) {
         // check if type and label exist
         CheckJsonType(result, c, "label", JsonType::STRING, "components");
         if (!result.ok) return;
@@ -521,11 +509,9 @@ void CheckSubDefinition(JsonResult& result, rapidjson::Value& sub_definition,
         if (!result.ok) return;
         const char* type_str = c["type"].GetString();
         int type = ComptypeToInt(type_str);
-        if (c.HasMember("type_int"))
-            c.RemoveMember("type_int");
-        c.AddMember("type_int", type, alloc);
-        CorrectKey(c, "item", "items", alloc);
-        CorrectKey(c, "item_array", "items", alloc);
+        c["type_int"].SetInt(type);
+        CorrectKey(c, "item", "items");
+        CorrectKey(c, "item_array", "items");
         switch (type) {
             case COMP_FILE:
                 CheckJsonType(result, c, "extension", JsonType::STRING, label, OPTIONAL);
@@ -538,9 +524,9 @@ void CheckSubDefinition(JsonResult& result, rapidjson::Value& sub_definition,
                 break;
             case COMP_COMBO:
             case COMP_RADIO:
-                CheckJsonArrayType(result, c, "items", JsonType::JSON, alloc, label);
+                CheckJsonArrayType(result, c, "items", JsonType::JSON, label);
                 if (!result.ok) return;
-                for (rapidjson::Value& i : c["items"].GetArray()) {
+                for (tuwjson::Value& i : c["items"]) {
                     CheckJsonType(result, i, "label", JsonType::STRING, "items");
                     CheckJsonType(result, i, "value", JsonType::STRING, "items", OPTIONAL);
                 }
@@ -551,9 +537,9 @@ void CheckSubDefinition(JsonResult& result, rapidjson::Value& sub_definition,
                 CheckJsonType(result, c, "default", JsonType::BOOLEAN, label, OPTIONAL);
                 break;
             case COMP_CHECK_ARRAY:
-                CheckJsonArrayType(result, c, "items", JsonType::JSON, alloc, label);
+                CheckJsonArrayType(result, c, "items", JsonType::JSON, label);
                 if (!result.ok) return;
-                for (rapidjson::Value& i : c["items"].GetArray()) {
+                for (tuwjson::Value& i : c["items"]) {
                     CheckJsonType(result, i, "label", JsonType::STRING, "items");
                     CheckJsonType(result, i, "value", JsonType::STRING, "items", OPTIONAL);
                     CheckJsonType(result, i, "default", JsonType::BOOLEAN, "items", OPTIONAL);
@@ -599,9 +585,9 @@ void CheckSubDefinition(JsonResult& result, rapidjson::Value& sub_definition,
             if (!result.ok) return;
         }
 
-        CorrectKey(c, "add_quote", "add_quotes", alloc);
+        CorrectKey(c, "add_quote", "add_quotes");
         CheckJsonType(result, c, "add_quotes", JsonType::BOOLEAN, label, OPTIONAL);
-        CorrectKey(c, "empty_message", "placeholder", alloc);
+        CorrectKey(c, "empty_message", "placeholder");
         CheckJsonType(result, c, "placeholder", JsonType::STRING, label, OPTIONAL);
         CheckJsonType(result, c, "id", JsonType::STRING, label, OPTIONAL);
         CheckJsonType(result, c, "tooltip", JsonType::STRING, label, OPTIONAL);
@@ -611,13 +597,13 @@ void CheckSubDefinition(JsonResult& result, rapidjson::Value& sub_definition,
         CheckJsonType(result, c, "suffix", JsonType::STRING, label, OPTIONAL);
 
         bool ignore = false;
-        CorrectKey(c, "platform", "platforms", alloc);
-        CorrectKey(c, "platform_array", "platforms", alloc);
-        CheckJsonArrayType(result, c, "platforms", JsonType::STRING, alloc, label, OPTIONAL);
+        CorrectKey(c, "platform", "platforms");
+        CorrectKey(c, "platform_array", "platforms");
+        CheckJsonArrayType(result, c, "platforms", JsonType::STRING, label, OPTIONAL);
         if (!result.ok) return;
         if (c.HasMember("platforms")) {
             ignore = true;
-            for (rapidjson::Value& v : c["platforms"].GetArray()) {
+            for (tuwjson::Value& v : c["platforms"]) {
                 if (strcmp(v.GetString(), TUW_CONSTANTS_OS) == 0) {
                     ignore = false;
                     break;
@@ -655,16 +641,13 @@ void CheckSubDefinition(JsonResult& result, rapidjson::Value& sub_definition,
         CheckJsonType(result, sub_definition, command_os_key, JsonType::STRING);
         if (!result.ok) return;
         const char* command_os = sub_definition[command_os_key].GetString();
-        if (sub_definition.HasMember("command"))
-            sub_definition.RemoveMember("command");
-        rapidjson::Value v(command_os, alloc);
-        sub_definition.AddMember("command", v, alloc);
+        sub_definition["command"].SetString(command_os);
     }
 
     // check sub_definition["command"] and convert it to more useful format.
     CheckJsonType(result, sub_definition, "command", JsonType::STRING);
     if (!result.ok) return;
-    CompileCommand(result, sub_definition, comp_ids, alloc);
+    CompileCommand(result, sub_definition, comp_ids);
 }
 
 // vX.Y.Z -> 10000*X + 100 * Y + Z
@@ -692,19 +675,15 @@ static int VersionStringToInt(JsonResult& result, const char* string) noexcept {
     return version_int;
 }
 
-void CheckVersion(JsonResult& result, rapidjson::Document& definition) noexcept {
-    CorrectKey(definition, "recommended_version", "recommended", definition.GetAllocator());
+void CheckVersion(JsonResult& result, tuwjson::Value& definition) noexcept {
+    CorrectKey(definition, "recommended_version", "recommended");
     if (definition.HasMember("recommended")) {
         CheckJsonType(result, definition, "recommended", JsonType::STRING);
         if (!result.ok) return;
         int recom_int = VersionStringToInt(result, definition["recommended"].GetString());
-        if (definition.HasMember("not_recommended")) definition.RemoveMember("not_recommended");
-        definition.AddMember("not_recommended",
-                                tuw_constants::VERSION_INT != recom_int,
-                                definition.GetAllocator());
+        definition["not_recommended"].SetBool(tuw_constants::VERSION_INT != recom_int);
     }
-    CorrectKey(definition, "minimum_required_version",
-                "minimum_required", definition.GetAllocator());
+    CorrectKey(definition, "minimum_required_version", "minimum_required");
     if (definition.HasMember("minimum_required")) {
         CheckJsonType(result, definition, "minimum_required", JsonType::STRING);
         if (!result.ok) return;
@@ -717,15 +696,12 @@ void CheckVersion(JsonResult& result, rapidjson::Document& definition) noexcept 
     }
 }
 
-void CheckDefinition(JsonResult& result, rapidjson::Document& definition) noexcept {
-    rapidjson::Document::AllocatorType& alloc = definition.GetAllocator();
+void CheckDefinition(JsonResult& result, tuwjson::Value& definition) noexcept {
     if (!definition.HasMember("gui")) {
         // definition["gui"] = definition
-        rapidjson::Value n(rapidjson::kObjectType);
-        n.CopyFrom(definition, alloc);
-        definition.AddMember("gui", n, alloc);
+        definition.ConvertToObject("gui");
     }
-    CheckJsonArrayType(result, definition, "gui", JsonType::JSON, alloc);
+    CheckJsonArrayType(result, definition, "gui", JsonType::JSON);
     if (!result.ok) return;
     if (definition["gui"].Size() == 0) {
         result.ok = false;
@@ -733,18 +709,18 @@ void CheckDefinition(JsonResult& result, rapidjson::Document& definition) noexce
     }
 
     int i = 0;
-    for (rapidjson::Value& sub_d : definition["gui"].GetArray()) {
+    for (tuwjson::Value& sub_d : definition["gui"]) {
         if (!result.ok) return;
-        CheckSubDefinition(result, sub_d, i, alloc);
+        CheckSubDefinition(result, sub_d, i);
         i++;
     }
 }
 
-void CheckHelpURLs(JsonResult& result, rapidjson::Document& definition) noexcept {
+void CheckHelpURLs(JsonResult& result, tuwjson::Value& definition) noexcept {
     if (!definition.HasMember("help")) return;
-    CheckJsonArrayType(result, definition, "help", JsonType::JSON, definition.GetAllocator());
+    CheckJsonArrayType(result, definition, "help", JsonType::JSON);
     if (!result.ok) return;
-    for (const rapidjson::Value& h : definition["help"].GetArray()) {
+    for (const tuwjson::Value& h : definition["help"]) {
         CheckJsonType(result, h, "type", JsonType::STRING);
         CheckJsonType(result, h, "label", JsonType::STRING);
         if (!result.ok) return;

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -4,12 +4,7 @@
 #include <cstdio>
 #include <cassert>
 
-#include "rapidjson/filereadstream.h"
-#include "rapidjson/filewritestream.h"
-#include "rapidjson/stringbuffer.h"
-#include "rapidjson/prettywriter.h"
-#include "rapidjson/error/en.h"
-
+#include "json.h"
 #include "tuw_constants.h"
 #include "string_utils.h"
 #include "noex/vector.hpp"

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -84,7 +84,7 @@ noex::string SaveJson(tuwjson::Value& json, const noex::string& file) noexcept {
     fclose(fp);
 
     if (!end)
-        return "Failed to write JSON: " + file;
+        return writer.GetErrMsg();
     return "";
 }
 

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -495,13 +495,22 @@ void CheckSubDefinition(JsonResult& result, tuwjson::Value& sub_definition,
     for (tuwjson::Value& c : sub_definition["components"]) {
         // check if type and label exist
         CheckJsonType(result, c, "label", JsonType::STRING, "component", REQUIRED);
+        CheckJsonType(result, c, "type", JsonType::STRING, "component", REQUIRED);
         if (!result.ok) return;
 
         // convert ["type"] from string to enum.
-        CheckJsonType(result, c, "type", JsonType::STRING, "component", REQUIRED);
-        if (!result.ok) return;
         const char* type_str = c["type"].GetString();
         int type = ComptypeToInt(type_str);
+
+        // TODO: throw an error for missing ids.
+        if (type != COMP_STATIC_TEXT && !c.HasMember("id")) {
+            PrintFmt(
+                "[CheckDefinition] DeprecationWarning: "
+                "\"id\" is missing in [\"components\"][%d]%s."
+                " Support for components without \"id\" will be removed in a future version.\n",
+                comp_ids.size(), c.GetLineColumnStr().c_str());
+        }
+
         c["type_int"].SetInt(type);
         CorrectKey(c, "item", "items");
         CorrectKey(c, "item_array", "items");

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -137,7 +137,7 @@ static void CheckJsonType(JsonResult& result, const tuwjson::Value& j, const cha
     if (!j.HasMember(key)) {
         if (optional) return;
         result.ok = false;
-        result.msg = GetLabel(label, key) + " not found.";
+        result.msg = GetLabel(label, key) + " not found." + j.GetLineColumnStr();
         return;
     }
     bool valid = false;
@@ -171,7 +171,9 @@ static void CheckJsonType(JsonResult& result, const tuwjson::Value& j, const cha
     }
     if (!valid) {
         result.ok = false;
-        result.msg = GetLabel(label, key) + noex::concat_cstr(" should be ", type_name, ".");
+        result.msg = GetLabel(label, key)
+            + noex::concat_cstr(" should be ", type_name, ".")
+            + v.GetLineColumnStr();
     }
 }
 
@@ -209,7 +211,7 @@ static void CheckJsonArrayType(JsonResult& result, tuwjson::Value& j, const char
     if (!j.HasMember(key)) {
         if (optional) return;
         result.ok = false;
-        result.msg = GetLabel(label, key) + " not found.";
+        result.msg = GetLabel(label, key) + " not found." + j.GetLineColumnStr();
         return;
     }
     bool valid = false;
@@ -230,7 +232,9 @@ static void CheckJsonArrayType(JsonResult& result, tuwjson::Value& j, const char
     }
     if (!valid) {
         result.ok = false;
-        result.msg = GetLabel(label, key) + noex::concat_cstr(" should be ", type_name, ".");
+        result.msg = GetLabel(label, key) +
+            noex::concat_cstr(" should be ", type_name, ".") +
+            j[key].GetLineColumnStr();
     }
 }
 
@@ -553,7 +557,8 @@ void CheckSubDefinition(JsonResult& result, tuwjson::Value& sub_definition,
                     if (c.HasMember("digits") && c["digits"].GetInt() < 0) {
                         result.ok = false;
                         result.msg = GetLabel(label, "digits")
-                                        + " should be a non-negative integer.";
+                                        + " should be a non-negative integer."
+                                        + c["digits"].GetLineColumnStr();
                     }
                 }
                 CheckJsonType(result, c, "default", jtype, label, OPTIONAL);
@@ -564,7 +569,8 @@ void CheckSubDefinition(JsonResult& result, tuwjson::Value& sub_definition,
                 break;
             case COMP_UNKNOWN:
                 result.ok = false;
-                result.msg = noex::string("Unknown component type: ") + type_str;
+                result.msg = noex::string("Unknown component type: ")
+                    + type_str + c["type"].GetLineColumnStr();
                 break;
         }
         if (!result.ok) return;
@@ -572,7 +578,8 @@ void CheckSubDefinition(JsonResult& result, tuwjson::Value& sub_definition,
         if (c.HasMember("validator")) {
             if (type == COMP_STATIC_TEXT) {
                 result.ok = false;
-                result.msg = "Static text does not support validator.";
+                result.msg = "Static text does not support validator."
+                    + c["validator"].GetLineColumnStr();
                 return;
             }
             CheckJsonType(result, c, "validator", JsonType::JSON, label);
@@ -611,11 +618,13 @@ void CheckSubDefinition(JsonResult& result, tuwjson::Value& sub_definition,
             if (id[0] == '\0') {
                 result.ok = false;
                 result.msg = GetLabel(label, "id")
-                                + " should NOT be an empty string.";
+                                + " should NOT be an empty string."
+                                + c["id"].GetLineColumnStr();
             } else if (id[0] == '_') {
                 result.ok = false;
                 result.msg = GetLabel(label, "id")
-                                + " should NOT start with '_'.";
+                                + " should NOT start with '_'."
+                                + c["id"].GetLineColumnStr();
             }
         }
         if (!result.ok) return;
@@ -700,7 +709,8 @@ void CheckDefinition(JsonResult& result, tuwjson::Value& definition) noexcept {
     if (!result.ok) return;
     if (definition["gui"].Size() == 0) {
         result.ok = false;
-        result.msg = "The size of [\"gui\"] should NOT be zero.";
+        result.msg = "The size of [\"gui\"] should NOT be zero."
+            + definition["gui"].GetLineColumnStr();;
     }
 
     int i = 0;
@@ -726,7 +736,8 @@ void CheckHelpURLs(JsonResult& result, tuwjson::Value& definition) noexcept {
             CheckJsonType(result, h, "path", JsonType::STRING);
         } else {
             result.ok = false;
-            result.msg = noex::concat_cstr("Unsupported help type: ", type);
+            result.msg = noex::concat_cstr("Unsupported help type: ", type)
+                + h["type"].GetLineColumnStr();;
             return;
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,12 +50,12 @@ bool AskOverwrite(const char *path) noexcept {
 
 noex::string Merge(const noex::string& exe_path, const noex::string& json_path,
                     const noex::string& new_path, const bool force) noexcept {
-    rapidjson::Document json;
+    tuwjson::Value json;
     noex::string err;
     err = json_utils::LoadJson(json_path, json);
     if (!err.empty()) return err;
 
-    if (!json.IsObject() || json.ObjectEmpty()) {
+    if (!json.IsObject() || json.IsEmpty()) {
         PrintFmt("JSON file loaded but it has no data.\n");
         return "";
     }
@@ -92,7 +92,7 @@ noex::string Split(const noex::string& exe_path, const noex::string& json_path,
         return "";
     }
     PrintFmt("Extracting JSON data from the executable...\n");
-    rapidjson::Document json;
+    tuwjson::Value json;
     exe.GetJson(json);
     exe.RemoveJson();
     if (!force && (!AskOverwrite(new_path.c_str()) || !AskOverwrite(json_path.c_str()))) {
@@ -290,7 +290,6 @@ int main(int argc, char* argv[]) noexcept {
         return 1;
     }
 
-    rapidjson::Document json(rapidjson::kObjectType);
     noex::string err;
 
     if (cmd_int == CMD_MERGE)

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -1,5 +1,5 @@
 #include "main_frame.h"
-#include "rapidjson/error/en.h"
+#include "json.h"
 #include "exe_container.h"
 #include "env_utils.h"
 #include "exec.h"

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -368,13 +368,6 @@ void MainFrame::UpdatePanel(size_t definition_id) noexcept {
     Component* new_comp = nullptr;
     if (sub_definition["components"].Size() > 0) {
         for (tuwjson::Value& c : sub_definition["components"]) {
-            if (c["type_int"].GetInt() != COMP_STATIC_TEXT && !c.HasMember("id")) {
-                PrintFmt(
-                    "[UpdatePanel] DeprecationWarning: "
-                    "\"id\" is missing in [\"components\"][%d]. "
-                    "Support for components without \"id\" will be removed in a future version.\n",
-                    m_components.size());
-            }
             uiBox* priv_box = uiNewVerticalBox();
             uiBoxSetSpacing(priv_box, tuw_constants::BOX_SUB_SPACE);
             new_comp = Component::PutComponent(priv_box, c);

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -300,7 +300,7 @@ noex::string MainFrame::OpenURLBase(int id) noexcept {
     }
 
     if (IsSafeMode()) {
-        noex::string msg = "The URL was not opened because the safe mode is enabled.\n"
+        noex::string msg = "The URL was not opened since the safe mode is enabled.\n"
                             "You can disable it from the menu bar (Debug > Safe Mode.)\n"
                             "\n"
                             "URL: " + url;
@@ -309,8 +309,8 @@ noex::string MainFrame::OpenURLBase(int id) noexcept {
         if (noex::get_error_no() != noex::OK) {
             // Reject the URL as it might have an unexpected value.
             return "The URL was not opened "
-                    "because a fatal error has occurred while editing strings or vectors. "
-                    "Please reboot the application.";
+                    "since a fatal error has occurred while editing strings or vectors. "
+                    "Please reboot the GUI application.";
         } else {
             ExecuteResult result = LaunchDefaultApp(url);
             if (result.exit_code != 0) {
@@ -494,7 +494,7 @@ void MainFrame::RunCommand() noexcept {
     Log("RunCommad", "Command", cmd);
 
     if (IsSafeMode()) {
-        noex::string msg = "The command was not executed because the safe mode is enabled.\n"
+        noex::string msg = "The command was not executed since the safe mode is enabled.\n"
                           "You can disable it from the menu bar (Debug > Safe Mode.)\n"
                           "\n"
                           "Command: " + cmd;
@@ -532,8 +532,9 @@ void MainFrame::RunCommand() noexcept {
     bool show_success_dialog = json_utils::GetBool(sub_definition, "show_success_dialog", true);
 
     if (noex::get_error_no() != noex::OK) {
-        const char* msg = "Fatal error has occurred while editing strings or vectors. "
-                          "Please reboot the application.";
+        const char* msg = "The command was not executed "
+            "since a fatal error has occurred while editing strings or vectors. "
+            "Please reboot the GUI application.";
         ShowErrorDialogWithLog("RunCommand", msg);
         return;
     }

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -19,8 +19,8 @@ const char* GetDefaultJsonPath() noexcept {
 }
 
 // Main window
-void MainFrame::Initialize(const rapidjson::Document& definition,
-                           const rapidjson::Document& config,
+void MainFrame::Initialize(const tuwjson::Value& definition,
+                           const tuwjson::Value& config,
                            noex::string json_path) noexcept {
     PrintFmt("%s v%s by %s\n", tuw_constants::TOOL_NAME,
               tuw_constants::VERSION, tuw_constants::AUTHOR);
@@ -30,8 +30,8 @@ void MainFrame::Initialize(const rapidjson::Document& definition,
     m_menu_item = NULL;
     noex::string exe_path = envuStr(envuGetExecutablePath());
 
-    m_definition.CopyFrom(definition, m_definition.GetAllocator());
-    m_config.CopyFrom(config, m_config.GetAllocator());
+    m_definition.CopyFrom(definition);
+    m_config.CopyFrom(config);
 
     noex::string workdir;
     if (json_path.empty()) {
@@ -60,7 +60,7 @@ void MainFrame::Initialize(const rapidjson::Document& definition,
 
     bool ignore_external_json = false;
     bool exists_external_json = envuFileExists(json_path.c_str());
-    bool loaded = m_definition.IsObject() && !m_definition.ObjectEmpty();
+    bool loaded = m_definition.IsObject() && !m_definition.IsEmpty();
     noex::string err;
 
     if (!loaded) {
@@ -91,7 +91,7 @@ void MainFrame::Initialize(const rapidjson::Document& definition,
         }
     }
 
-    if (!config.IsObject() || config.ObjectEmpty()) {
+    if (!config.IsObject() || config.IsEmpty()) {
         noex::string cfg_err =
             json_utils::LoadJson("gui_config.json", m_config);
         if (!cfg_err.empty()) {
@@ -188,7 +188,7 @@ void MainFrame::CreateFrame() noexcept {
 
 static void OnUpdatePanel(uiMenuItem *item, uiWindow *w, void *data) noexcept {
     MenuData* menu_data = static_cast<MenuData*>(data);
-    menu_data->main_frame->UpdatePanel(menu_data->menu_id);
+    menu_data->main_frame->UpdatePanel(static_cast<size_t>(menu_data->menu_id));
     menu_data->main_frame->Fit();
     UNUSED(item);
     UNUSED(w);
@@ -221,7 +221,7 @@ void MainFrame::CreateMenu() noexcept {
     if (m_definition["gui"].Size() > 1) {
 #endif  // __APPLE__
         int i = 0;
-        for (const rapidjson::Value& j : m_definition["gui"].GetArray()) {
+        for (const tuwjson::Value& j : m_definition["gui"]) {
             item = uiMenuAppendItem(menu, j["label"].GetString());
             m_menu_data_vec.push_back({ this, i });
             MenuData* m = &m_menu_data_vec.back();
@@ -236,7 +236,7 @@ void MainFrame::CreateMenu() noexcept {
         menu = uiNewMenu("Help");
 
         int i = 0;
-        for (const rapidjson::Value& j : m_definition["help"].GetArray()) {
+        for (const tuwjson::Value& j : m_definition["help"]) {
             item = uiMenuAppendItem(menu, j["label"].GetString());
             m_menu_data_vec.push_back({ this, i });
             MenuData* m = &m_menu_data_vec.back();
@@ -257,7 +257,7 @@ static bool IsValidURL(const noex::string &url) noexcept {
 }
 
 noex::string MainFrame::OpenURLBase(int id) noexcept {
-    rapidjson::Value& help = m_definition["help"].GetArray()[id];
+    tuwjson::Value& help = m_definition["help"][id];
     const char* type = help["type"].GetString();
     noex::string url;
 
@@ -338,9 +338,9 @@ static void OnClicked(uiButton *sender, void *data) noexcept {
     UNUSED(sender);
 }
 
-void MainFrame::UpdatePanel(unsigned definition_id) noexcept {
+void MainFrame::UpdatePanel(size_t definition_id) noexcept {
     m_definition_id = definition_id;
-    rapidjson::Value& sub_definition = m_definition["gui"][m_definition_id];
+    tuwjson::Value& sub_definition = m_definition["gui"][m_definition_id];
     if (m_definition["gui"].Size() > 1) {
         const char* label = sub_definition["label"].GetString();
         Log("UpdatePanel", "Label", label);
@@ -367,7 +367,7 @@ void MainFrame::UpdatePanel(unsigned definition_id) noexcept {
     // Put new components
     Component* new_comp = nullptr;
     if (sub_definition["components"].Size() > 0) {
-        for (rapidjson::Value& c : sub_definition["components"].GetArray()) {
+        for (tuwjson::Value& c : sub_definition["components"]) {
             if (c["type_int"].GetInt() != COMP_STATIC_TEXT && !c.HasMember("id")) {
                 PrintFmt(
                     "[UpdatePanel] DeprecationWarning: "
@@ -451,11 +451,11 @@ bool MainFrame::Validate() noexcept {
 // Make command string
 noex::string MainFrame::GetCommand() noexcept {
     noex::vector<noex::string> cmd_ary;
-    rapidjson::Value& sub_definition = m_definition["gui"][m_definition_id];
-    for (rapidjson::Value& c : sub_definition["command_splitted"].GetArray())
+    tuwjson::Value& sub_definition = m_definition["gui"][m_definition_id];
+    for (tuwjson::Value& c : sub_definition["command_splitted"])
         cmd_ary.emplace_back(c.GetString());
     noex::vector<int> cmd_ids;
-    for (rapidjson::Value& c : sub_definition["command_ids"].GetArray())
+    for (tuwjson::Value& c : sub_definition["command_ids"])
         cmd_ids.emplace_back(c.GetInt());
 
     noex::vector<noex::string> comp_strings;
@@ -509,7 +509,7 @@ void MainFrame::RunCommand() noexcept {
 #elif defined(__TUW_UNIX__)
     uiUnixWaitEvents();
 #endif
-    rapidjson::Value& sub_definition = m_definition["gui"][m_definition_id];
+    tuwjson::Value& sub_definition = m_definition["gui"][m_definition_id];
 
     const char* codepage = json_utils::GetString(sub_definition, "codepage", "");
     bool use_utf8_on_windows = strcmp(codepage, "utf8") == 0 || strcmp(codepage, "utf-8") == 0;
@@ -567,7 +567,7 @@ void MainFrame::RunCommand() noexcept {
 }
 
 // read gui_definition.json
-json_utils::JsonResult MainFrame::CheckDefinition(rapidjson::Document& definition) noexcept {
+json_utils::JsonResult MainFrame::CheckDefinition(tuwjson::Value& definition) noexcept {
     json_utils::JsonResult result = JSON_RESULT_OK;
     json_utils::CheckVersion(result, definition);
     if (!result.ok) return result;
@@ -589,9 +589,7 @@ json_utils::JsonResult MainFrame::CheckDefinition(rapidjson::Document& definitio
 void MainFrame::UpdateConfig() noexcept {
     for (Component *c : m_components)
         c->GetConfig(m_config);
-    if (m_config.HasMember("_mode"))
-        m_config.RemoveMember("_mode");
-    m_config.AddMember("_mode", m_definition_id, m_config.GetAllocator());
+    m_config["_mode"].SetInt(static_cast<int>(m_definition_id));
 }
 
 void MainFrame::SaveConfig() noexcept {
@@ -625,6 +623,6 @@ void MainFrameDisableDialog() noexcept {
     g_no_dialog = true;
 }
 
-void MainFrame::GetDefinition(rapidjson::Document& json) noexcept {
-    json.CopyFrom(m_definition, json.GetAllocator());
+void MainFrame::GetDefinition(tuwjson::Value& json) noexcept {
+    json.CopyFrom(m_definition);
 }

--- a/src/noex/string.cpp
+++ b/src/noex/string.cpp
@@ -199,10 +199,11 @@ inline int snprintf_wrap(wchar_t* buf, size_t size, const char* fmt, \
 } \
 template <typename charT> \
 basic_string<charT> basic_string<charT>::to_string(num_type num) noexcept { \
-    charT buf[21]; /* assume that the max value of num has 20 digits (2^64). */ \
-    buf[20] = 0; \
-    int num_size = snprintf_wrap(buf, 21, "%" num_fmt, L"%" num_fmt, num); \
-    if (num_size <= 0 || num_size > 20) { \
+    /* assume that the max value of num has 24 characters (e.g. -1.7976931348623157e+308). */ \
+    charT buf[25]; \
+    buf[24] = 0; \
+    int num_size = snprintf_wrap(buf, 25, "%" num_fmt, L"%" num_fmt, num); \
+    if (num_size <= 0 || num_size > 24) { \
         set_error_no(STR_FORMAT_ERROR); \
         return basic_string<charT>(); \
     } \
@@ -217,6 +218,7 @@ basic_string<charT> basic_string<charT>::operator+(num_type num) const noexcept 
 DEFINE_TO_STRING(int, "d")
 DEFINE_TO_STRING(size_t, "zu")
 DEFINE_TO_STRING(uint32_t, PRIu32)
+DEFINE_TO_STRING(double, "lf")
 
 inline bool streq(const char* str1, const char* str2) noexcept {
     return strcmp(str1, str2) == 0;

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -37,9 +37,12 @@ noex::string envuStr(char *cstr) noexcept {
 static const uint32_t FNV_OFFSET_BASIS_32 = 2166136261U;
 static const uint32_t FNV_PRIME_32 = 16777619U;
 
-uint32_t Fnv1Hash32(const noex::string& str) noexcept {
+uint32_t Fnv1Hash32(const char* str) noexcept {
     uint32_t hash = FNV_OFFSET_BASIS_32;
-    for (const char c : str) hash = (FNV_PRIME_32 * hash) ^ c;
+    while (*str) {
+        hash = (FNV_PRIME_32 * hash) ^ *str;
+        str++;
+    }
     return hash;
 }
 

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -4,7 +4,7 @@
 #include "env_utils.h"
 #include "string_utils.h"
 
-void Validator::Initialize(const rapidjson::Value& j) noexcept {
+void Validator::Initialize(const tuwjson::Value& j) noexcept {
     m_regex = json_utils::GetString(j, "regex", "");
     m_regex_error = json_utils::GetString(j, "regex_error", "");
     m_wildcard = json_utils::GetString(j, "wildcard", "");

--- a/subprojects/packagefiles/rapidjson/meson.build
+++ b/subprojects/packagefiles/rapidjson/meson.build
@@ -1,4 +1,0 @@
-project('rapidjson', 'cpp', version: '1.1.0', license: 'MIT')
-
-rapidjson_inc = include_directories('include')
-rapidjson_dep = declare_dependency(include_directories: rapidjson_inc)

--- a/subprojects/rapidjson.wrap
+++ b/subprojects/rapidjson.wrap
@@ -1,8 +1,0 @@
-[wrap-git]
-url = https://github.com/Tencent/rapidjson.git
-revision = 476ffa2fd272243275a74c36952f210267dc3088
-depth=1
-patch_directory = rapidjson
-
-[provide]
-rapidjson = rapidjson_dep

--- a/tests/exe_container_test.cpp
+++ b/tests/exe_container_test.cpp
@@ -5,7 +5,7 @@
 
 TEST(JsonEmbeddingTest, Embed) {
     {
-        rapidjson::Document test_json;
+        tuwjson::Value test_json;
         test_json.SetObject();
         GetTestJson(test_json);
         ExeContainer exe;
@@ -16,10 +16,10 @@ TEST(JsonEmbeddingTest, Embed) {
         EXPECT_STREQ("", result.c_str());
     }
     {
-        rapidjson::Document test_json;
+        tuwjson::Value test_json;
         test_json.SetObject();
         GetTestJson(test_json);
-        rapidjson::Document embedded_json;
+        tuwjson::Value embedded_json;
         embedded_json.SetObject();
         ExeContainer exe;
         noex::string result = exe.Read("embedded.json");

--- a/tests/json_check_test.cpp
+++ b/tests/json_check_test.cpp
@@ -15,7 +15,7 @@ TEST(JsonCheckTest, LoadJsonFail2) {
     noex::string err = json_utils::LoadJson(JSON_BROKEN, test_json);
     const char* expected =
         "Failed to parse JSON: comma ',' or closing brace '}' is missing"
-        " (line: 7, offset: 5)";
+        " (line: 7, column: 5)";
     EXPECT_STREQ(expected, err.c_str());
 }
 
@@ -94,28 +94,28 @@ TEST(JsonCheckTest, checkGUIFail2) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"][0]["components"][6].ReplaceKey("items", "notitems");
-    CheckGUIError(test_json, "['options']['items'] not found.");
+    CheckGUIError(test_json, "['options']['items'] not found. (line: 60, column: 17)");
 }
 
 TEST(JsonCheckTest, checkGUIFail3) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"].SetInt(1);
-    CheckGUIError(test_json, "['gui'] should be an array of json objects.");
+    CheckGUIError(test_json, "['gui'] should be an array of json objects. (line: 4, column: 12)");
 }
 
 TEST(JsonCheckTest, checkGUIFail4) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"][0]["components"][0]["label"].SetInt(1);
-    CheckGUIError(test_json, "['components']['label'] should be a string.");
+    CheckGUIError(test_json, "['components']['label'] should be a string. (line: 11, column: 30)");
 }
 
 TEST(JsonCheckTest, checkGUIFail5) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"][2]["show_last_line"].SetString("test");
-    CheckGUIError(test_json, "['show_last_line'] should be a boolean.");
+    CheckGUIError(test_json, "['show_last_line'] should be a boolean. (line: 267, column: 31)");
 }
 
 TEST(JsonCheckTest, checkGUIFail6) {
@@ -167,14 +167,14 @@ TEST(JsonCheckTest, checkHelpFail) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["help"][0].ReplaceKey("label", "notlabel");
-    CheckHelpError(test_json, "['label'] not found.");
+    CheckHelpError(test_json, "['label'] not found. (line: 280, column: 9)");
 }
 
 TEST(JsonCheckTest, checkHelpFail2) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["help"][0]["label"].SetInt(3);
-    CheckHelpError(test_json, "['label'] should be a string.");
+    CheckHelpError(test_json, "['label'] should be a string. (line: 282, column: 22)");
 }
 
 TEST(JsonCheckTest, checkVersionSuccess) {

--- a/tests/json_check_test.cpp
+++ b/tests/json_check_test.cpp
@@ -87,35 +87,35 @@ TEST(JsonCheckTest, checkGUIFail) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json.ReplaceKey("gui", "g");
-    CheckGUIError(test_json, "['components'] not found.");
+    CheckGUIError(test_json, "gui definition requires \"components\"");
 }
 
 TEST(JsonCheckTest, checkGUIFail2) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"][0]["components"][6].ReplaceKey("items", "notitems");
-    CheckGUIError(test_json, "['options']['items'] not found. (line: 60, column: 17)");
+    CheckGUIError(test_json, "check array requires \"items\" (line: 60, column: 17)");
 }
 
 TEST(JsonCheckTest, checkGUIFail3) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"].SetInt(1);
-    CheckGUIError(test_json, "['gui'] should be an array of json objects. (line: 4, column: 12)");
+    CheckGUIError(test_json, "\"gui\" should be an array of json objects (line: 4, column: 12)");
 }
 
 TEST(JsonCheckTest, checkGUIFail4) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"][0]["components"][0]["label"].SetInt(1);
-    CheckGUIError(test_json, "['components']['label'] should be a string. (line: 11, column: 30)");
+    CheckGUIError(test_json, "\"label\" should be a string (line: 11, column: 30)");
 }
 
 TEST(JsonCheckTest, checkGUIFail5) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"][2]["show_last_line"].SetString("test");
-    CheckGUIError(test_json, "['show_last_line'] should be a boolean. (line: 267, column: 31)");
+    CheckGUIError(test_json, "\"show_last_line\" should be a boolean (line: 267, column: 31)");
 }
 
 TEST(JsonCheckTest, checkGUIFail6) {
@@ -134,7 +134,7 @@ TEST(JsonCheckTest, checkGUIFail7) {
     GetTestJson(test_json);
     test_json["gui"][0]["components"][1]["id"].SetString("aaa");
     CheckGUIError(test_json,
-        "The ID of [\"components\"][1] is unused in the command;"
+        "component id \"aaa\" (line: 15, column: 27) is unused in the command;"
         " echo file: __comp???__ & echo folder: __comp2__ & echo combo: __comp3__"
         " & echo radio: __comp4__ & echo check: __comp5__ & echo check_array: __comp6__"
         " & echo textbox: __comp7__ & echo int: __comp8__ & echo float: __comp9__");
@@ -145,7 +145,7 @@ TEST(JsonCheckTest, checkGUIFailRelaxed) {
     noex::string err = json_utils::LoadJson(JSON_RELAXED, test_json);
     EXPECT_TRUE(err.empty());
     test_json["exit_success"].SetString("a");
-    CheckGUIError(test_json, "['exit_success'] should be an int.");
+    CheckGUIError(test_json, "\"exit_success\" should be an int");
 }
 
 TEST(JsonCheckTest, checkHelpSuccess) {
@@ -167,14 +167,14 @@ TEST(JsonCheckTest, checkHelpFail) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["help"][0].ReplaceKey("label", "notlabel");
-    CheckHelpError(test_json, "['label'] not found. (line: 280, column: 9)");
+    CheckHelpError(test_json, "help document requires \"label\" (line: 280, column: 9)");
 }
 
 TEST(JsonCheckTest, checkHelpFail2) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["help"][0]["label"].SetInt(3);
-    CheckHelpError(test_json, "['label'] should be a string. (line: 282, column: 22)");
+    CheckHelpError(test_json, "\"label\" should be a string (line: 282, column: 22)");
 }
 
 TEST(JsonCheckTest, checkVersionSuccess) {

--- a/tests/json_test.cpp
+++ b/tests/json_test.cpp
@@ -1,0 +1,121 @@
+#include "test_utils.h"
+
+class JsonTest : public ::testing::Test {
+ protected:
+    tuwjson::Value root;
+    tuwjson::Parser parser;
+};
+
+static double eps = 0.00001;
+
+// Test tuwjson::string()
+TEST_F(JsonTest, ParseEmpty) {
+    tuwjson::Error err = parser.ParseJson("  ", &root);
+    EXPECT_EQ(err, tuwjson::JSON_OK);
+    EXPECT_TRUE(root.IsNull());
+}
+
+TEST_F(JsonTest, ParseNull) {
+    tuwjson::Error err = parser.ParseJson("  null  ", &root);
+    EXPECT_EQ(err, tuwjson::JSON_OK);
+    EXPECT_TRUE(root.IsNull());
+}
+
+TEST_F(JsonTest, ParseTrue) {
+    tuwjson::Error err = parser.ParseJson("  true  ", &root);
+    EXPECT_EQ(err, tuwjson::JSON_OK);
+    EXPECT_TRUE(root.IsBool());
+    EXPECT_TRUE(root.GetBool());
+}
+
+TEST_F(JsonTest, ParseFalse) {
+    tuwjson::Error err = parser.ParseJson("  false  ", &root);
+    EXPECT_EQ(err, tuwjson::JSON_OK);
+    EXPECT_TRUE(root.IsBool());
+    EXPECT_FALSE(root.GetBool());
+}
+
+TEST_F(JsonTest, ParseInt) {
+    tuwjson::Error err = parser.ParseJson("  123  ", &root);
+    EXPECT_EQ(err, tuwjson::JSON_OK);
+    EXPECT_TRUE(root.IsInt());
+    EXPECT_EQ(root.GetInt(), 123);
+    EXPECT_TRUE(root.IsDouble());
+    EXPECT_NEAR(root.GetDouble(), 123.0, eps);
+}
+
+TEST_F(JsonTest, ParseFloat) {
+    tuwjson::Error err = parser.ParseJson("  -12.3e-1  ", &root);
+    EXPECT_EQ(err, tuwjson::JSON_OK);
+    EXPECT_TRUE(root.IsDouble());
+    EXPECT_NEAR(root.GetDouble(), -1.23, eps);
+}
+
+TEST_F(JsonTest, ParseString) {
+    tuwjson::Error err = parser.ParseJson("  \"abcdefg\"  ", &root);
+    EXPECT_EQ(err, tuwjson::JSON_OK);
+    EXPECT_TRUE(root.IsString());
+    EXPECT_STREQ(root.GetString(), "abcdefg");
+}
+
+TEST_F(JsonTest, ParseArray) {
+    tuwjson::Error err = parser.ParseJson("  [\"abcdefg\", 1,true,]  ", &root);
+    EXPECT_EQ(err, tuwjson::JSON_OK);
+    EXPECT_TRUE(root.IsArray());
+    EXPECT_FALSE(root.IsEmpty());
+    EXPECT_EQ(root.Size(), 3);
+    EXPECT_TRUE(root[0].IsString());
+    EXPECT_STREQ(root[0].GetString(), "abcdefg");
+    EXPECT_TRUE(root[1].IsInt());
+    EXPECT_EQ(root[1].GetInt(), 1);
+    EXPECT_TRUE(root[2].IsBool());
+    EXPECT_TRUE(root[2].GetBool());
+}
+
+TEST_F(JsonTest, ParseObject) {
+    tuwjson::Error err = parser.ParseJson(" { \"key\" : \"val\",\"key2\":2.3} ", &root);
+    EXPECT_EQ(err, tuwjson::JSON_OK);
+    EXPECT_TRUE(root.IsObject());
+    EXPECT_FALSE(root.IsEmpty());
+    EXPECT_EQ(root.Size(), 2);
+    EXPECT_TRUE(root["key"].IsString());
+    EXPECT_STREQ(root["key"].GetString(), "val");
+    EXPECT_TRUE(root["key2"].IsDouble());
+    EXPECT_NEAR(root["key2"].GetDouble(), 2.3, eps);
+}
+
+struct ParseFailCase {
+    const char* json;
+    tuwjson::Error err;
+    const char* err_msg;
+};
+
+class ParseFailTest : public ::testing::TestWithParam<ParseFailCase> {
+ protected:
+    tuwjson::Value root;
+    tuwjson::Parser parser;
+};
+
+const ParseFailCase parse_fail_cases[] = {
+    {
+        "{\"a\": [{\"key\": true]}",
+        tuwjson::JSON_ERR_UNCLOSED_OBJECT,
+        "comma ',' or closing brace '}' is missing (line: 1, offset: 19)"
+    },
+};
+
+INSTANTIATE_TEST_SUITE_P(ParseFailTestInstantiation,
+    ParseFailTest,
+    ::testing::ValuesIn(parse_fail_cases));
+
+TEST_P(ParseFailTest, ParseFail) {
+    const ParseFailCase test_case = GetParam();
+    tuwjson::Error err = parser.ParseJson(test_case.json, &root);
+    noex::string json_str = test_case.json;
+    if (json_str.size() > 20)
+        json_str = json_str.substr(0, 20) + "...";
+    EXPECT_EQ(err, test_case.err)  <<
+        "  json: " << json_str.c_str();
+    EXPECT_STREQ(parser.GetErrMsg(), test_case.err_msg) <<
+        "  json: " << json_str.c_str();
+}

--- a/tests/main_frame_test.cpp
+++ b/tests/main_frame_test.cpp
@@ -33,12 +33,12 @@ class MainFrameTest : public ::testing::Test {
     void TestConfig(tuwjson::Value& test_json, noex::string config) {
         tuwjson::Value test_config;
         noex::string err = json_utils::LoadJson(config, test_config);
-        EXPECT_TRUE(err.empty());
+        EXPECT_TRUE(err.empty()) << ("err: " + err).c_str();
         main_frame = new MainFrame(test_json, test_config);
         main_frame->SaveConfig();
         tuwjson::Value saved_config;
         err = json_utils::LoadJson("gui_config.json", saved_config);
-        EXPECT_TRUE(err.empty());
+        EXPECT_TRUE(err.empty()) << ("err: " + err).c_str();
         EXPECT_EQ(test_config, saved_config);
     }
 };

--- a/tests/main_frame_test.cpp
+++ b/tests/main_frame_test.cpp
@@ -30,13 +30,13 @@ class MainFrameTest : public ::testing::Test {
         EXPECT_EQ(noex::OK, noex::get_error_no());
     }
 
-    void TestConfig(rapidjson::Document& test_json, noex::string config) {
-        rapidjson::Document test_config;
+    void TestConfig(tuwjson::Value& test_json, noex::string config) {
+        tuwjson::Value test_config;
         noex::string err = json_utils::LoadJson(config, test_config);
         EXPECT_TRUE(err.empty());
         main_frame = new MainFrame(test_json, test_config);
         main_frame->SaveConfig();
-        rapidjson::Document saved_config;
+        tuwjson::Value saved_config;
         err = json_utils::LoadJson("gui_config.json", saved_config);
         EXPECT_TRUE(err.empty());
         EXPECT_EQ(test_config, saved_config);
@@ -45,36 +45,36 @@ class MainFrameTest : public ::testing::Test {
 
 TEST_F(MainFrameTest, MakeDefaultMainFrame) {
     main_frame = new MainFrame();
-    rapidjson::Document json1;
-    rapidjson::Document json2;
+    tuwjson::Value json1;
+    tuwjson::Value json2;
     json_utils::GetDefaultDefinition(json1);
     main_frame->GetDefinition(json2);
     EXPECT_EQ(json1, json2);
 }
 
-void GetDummyConfig(rapidjson::Document& dummy_config) {
+void GetDummyConfig(tuwjson::Value& dummy_config) {
     dummy_config.SetObject();
-    dummy_config.AddMember("test", 0, dummy_config.GetAllocator());
+    dummy_config["test"].SetInt(0);
 }
 
 TEST_F(MainFrameTest, InvalidDefinition) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"][1]["components"][4]["default"].SetString("number");
-    rapidjson::Document dummy_config;
+    tuwjson::Value dummy_config;
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
     json_utils::GetDefaultDefinition(test_json);
-    rapidjson::Document actual_json;
+    tuwjson::Value actual_json;
     main_frame->GetDefinition(actual_json);
     EXPECT_EQ(test_json, actual_json);
 }
 
 TEST_F(MainFrameTest, InvalidHelp) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["help"][0]["url"].SetInt(1);
-    rapidjson::Document dummy_config;
+    tuwjson::Value dummy_config;
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
     main_frame->GetDefinition(test_json);
@@ -82,21 +82,21 @@ TEST_F(MainFrameTest, InvalidHelp) {
 }
 
 TEST_F(MainFrameTest, GetCommand1) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     json_utils::GetDefaultDefinition(test_json);
     test_json["gui"][0]["command"].SetString("command!");
-    rapidjson::Document dummy_config;
+    tuwjson::Value dummy_config;
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
     EXPECT_STREQ("command!", main_frame->GetCommand().c_str());
 }
 
 TEST_F(MainFrameTest, GetCommand2) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"][0].Swap(test_json["gui"][1]);
-    rapidjson::Document dummy_config;
+    tuwjson::Value dummy_config;
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
     noex::string expected = "echo file: \"test.txt\" & echo folder: \"testdir\"";
@@ -107,9 +107,9 @@ TEST_F(MainFrameTest, GetCommand2) {
 }
 
 TEST_F(MainFrameTest, GetCommand3) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
-    rapidjson::Document dummy_config;
+    tuwjson::Value dummy_config;
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
     noex::string expected = "echo file:  & echo folder:  & echo combo: value1 & echo radio: value1";
@@ -119,13 +119,13 @@ TEST_F(MainFrameTest, GetCommand3) {
 }
 
 TEST_F(MainFrameTest, RunCommandSuccess) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
-    rapidjson::Document dummy_config;
+    tuwjson::Value dummy_config;
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
 
-    rapidjson::Document actual_json;
+    tuwjson::Value actual_json;
     main_frame->GetDefinition(actual_json);
     ASSERT_EQ(test_json["help"], actual_json["help"]);
 
@@ -136,11 +136,11 @@ TEST_F(MainFrameTest, RunCommandSuccess) {
 }
 
 TEST_F(MainFrameTest, RunCommandFail) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     json_utils::GetDefaultDefinition(test_json);
     test_json["gui"][0]["command"].SetString("I'll fail");
-    rapidjson::Document dummy_config;
+    tuwjson::Value dummy_config;
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
 
@@ -151,9 +151,9 @@ TEST_F(MainFrameTest, RunCommandFail) {
 }
 
 TEST_F(MainFrameTest, UpdateFrame) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
-    rapidjson::Document dummy_config;
+    tuwjson::Value dummy_config;
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
     main_frame->UpdatePanel(1);
@@ -163,9 +163,9 @@ TEST_F(MainFrameTest, UpdateFrame) {
 }
 
 TEST_F(MainFrameTest, RunCommandShowLast) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
-    rapidjson::Document dummy_config;
+    tuwjson::Value dummy_config;
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
     main_frame->UpdatePanel(2);
@@ -178,27 +178,27 @@ TEST_F(MainFrameTest, RunCommandShowLast) {
 }
 
 TEST_F(MainFrameTest, LoadSaveConfigAscii) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"][0].Swap(test_json["gui"][1]);
     TestConfig(test_json, JSON_CONFIG_ASCII);
 }
 
 TEST_F(MainFrameTest, LoadSaveConfigUTF) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"][0].Swap(test_json["gui"][1]);
     noex::string cmd = test_json["gui"][0]["command"].GetString();
     memcpy(cmd.data() + 12, "ファイル", 4);
-    test_json["gui"][0]["command"].SetString(rapidjson::StringRef(cmd.c_str()));
+    test_json["gui"][0]["command"].SetString(cmd);
     test_json["gui"][0]["components"][1]["id"].SetString("ファイル");
     TestConfig(test_json, JSON_CONFIG_UTF);
 }
 
 TEST_F(MainFrameTest, CrossPlatform) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json, JSON_CROSS_PLATFORM);
-    rapidjson::Document dummy_config;
+    tuwjson::Value dummy_config;
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
     main_frame->UpdatePanel(1);
@@ -206,8 +206,8 @@ TEST_F(MainFrameTest, CrossPlatform) {
 
 class OpenURLTest : public MainFrameTest {
  protected:
-    rapidjson::Document definition;
-    rapidjson::Document config;
+    tuwjson::Value definition;
+    tuwjson::Value config;
 
     void SetUp() override {
         MainFrameTest::SetUp();
@@ -216,10 +216,7 @@ class OpenURLTest : public MainFrameTest {
     }
 
     void ReplaceURL(const char* url) {
-        definition["help"][0].RemoveMember("url");
-        rapidjson::Value urlValue;
-        urlValue.SetString(url, definition.GetAllocator());
-        definition["help"][0].AddMember("url", urlValue, definition.GetAllocator());
+        definition["help"][0]["url"].SetString(url);
     }
 };
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -10,6 +10,7 @@ test_sources = [
     'validator_test.cpp',
     'string_test.cpp',
     'vector_test.cpp',
+    'json_test.cpp',
     'process_utils.cpp',
     'ring_buffer_test.cpp',
 ]

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -10,6 +10,7 @@
 #include "validator.h"
 #include "env_utils.h"
 #include "noex/vector.hpp"
+#include "json.h"
 
 // you need to copy it from examples/all_keys to the json folder
 constexpr char JSON_ALL_KEYS[] = "./json/gui_definition.json";
@@ -21,14 +22,14 @@ constexpr char JSON_CONFIG_UTF[] = "./json/config_utf.json";
 constexpr char JSON_RELAXED[] = "./json/relaxed.jsonc";
 constexpr char JSON_CROSS_PLATFORM[] = "./json/platform.json";
 
-inline void GetTestJson(rapidjson::Document& json) {
+inline void GetTestJson(tuwjson::Value& json) {
     noex::string err = json_utils::LoadJson(JSON_ALL_KEYS, json);
     EXPECT_TRUE(err.empty());
-    EXPECT_FALSE(json.ObjectEmpty());
+    EXPECT_FALSE(json.IsEmpty());
 }
 
-inline void GetTestJson(rapidjson::Document& json, const char* file) {
+inline void GetTestJson(tuwjson::Value& json, const char* file) {
     noex::string err = json_utils::LoadJson(file, json);
     EXPECT_TRUE(err.empty());
-    EXPECT_FALSE(json.ObjectEmpty());
+    EXPECT_FALSE(json.IsEmpty());
 }

--- a/tests/validator_test.cpp
+++ b/tests/validator_test.cpp
@@ -4,8 +4,9 @@
 #include "test_utils.h"
 
 Validator GetValidator(const char* config_str) {
-    rapidjson::Document config(rapidjson::kObjectType);
-    config.Parse(config_str);
+    tuwjson::Value config;
+    tuwjson::Parser parser;
+    parser.ParseJson(config_str, &config);
     Validator validator;
     validator.Initialize(config);
     return validator;


### PR DESCRIPTION
I reworked on the JSON utilities.

- Replaced rapidjson with a custom JSON libraray. (Tuw.exe for Windows10 became 16% smaller.)
- JSON parser and validator now show error messages with line and column of a JSON file. e.g. `"id" should be a string (line: 4, column: 5)`
- Revised some error messages.

The new JSON library has lower performance than rapidjson but it's sufficient for parsing a small file.