### PR TITLE
use windows-11-arm runners for Github Actions

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -52,30 +52,35 @@ jobs:
           - os: windows-2022
             exe_ext: .exe
             zip_ext: zip
-            arch: ""
+            ucrt: ""
             arch_suffix: -x64
-          - os: windows-2022
+          - os: windows-11-arm
             exe_ext: .exe
             zip_ext: zip
-            arch: ARM
+            ucrt: ""
             arch_suffix: -arm64
           - os: windows-2022
             exe_ext: .exe
             zip_ext: zip
-            arch: UCRT
+            ucrt: UCRT
             arch_suffix: 10-x64
+          - os: windows-11-arm
+            exe_ext: .exe
+            zip_ext: zip
+            ucrt: UCRT
+            arch_suffix: 10-arm64
           - os: macos-14
             exe_ext: ""
             zip_ext: tar.xz
-            arch: ""
+            ucrt: ""
             arch_suffix: "-arm64"
           - os: macos-14
             exe_ext: ""
             zip_ext: tar.xz
-            arch: ""
+            ucrt: ""
             arch_suffix: "-universal"
 
-    name: build-${{ matrix.os }}${{ matrix.arch_suffix }}
+    name: build (${{ matrix.os }}, ${{ matrix.arch_suffix }})
     runs-on: ${{ matrix.os }}
     needs: setup
     steps:
@@ -100,7 +105,7 @@ jobs:
 
       - name: Build exe for Windows
         if: runner.os == 'Windows'
-        run: batch_files/build.bat Release ${{ matrix.arch }}
+        run: batch_files/build.bat Release ${{ matrix.ucrt }}
 
       - name: Build exe for Unix
         if: (runner.os != 'Windows') && (matrix.arch_suffix != '-universal')
@@ -111,13 +116,13 @@ jobs:
         run: ./shell_scripts/build_universal.sh Release
 
       - name: Show info about exe
-        run: ./shell_scripts/exe_info.sh build/Release${{ matrix.arch }}/${{ env.TOOL_NAME }}${{ matrix.exe_ext }}
+        run: ./shell_scripts/exe_info.sh build/Release${{ matrix.ucrt }}/${{ env.TOOL_NAME }}${{ matrix.exe_ext }}
         shell: bash
 
       - name: Copy files
         run: |
           mkdir -p archive/${{ env.TOOL_NAME }}
-          cp build/Release${{ matrix.arch }}/${{ env.TOOL_NAME }}${{ matrix.exe_ext }} archive/${{ env.TOOL_NAME }}
+          cp build/Release${{ matrix.ucrt }}/${{ env.TOOL_NAME }}${{ matrix.exe_ext }} archive/${{ env.TOOL_NAME }}
           cp examples/other_features/help/gui_definition.json archive/${{ env.TOOL_NAME }}
           cp docs/changelog.txt archive/${{ env.TOOL_NAME }}
           cp license.txt archive/${{ env.TOOL_NAME }}
@@ -142,7 +147,7 @@ jobs:
           gh release upload ${{ needs.setup.outputs.tag }} archive/${{ env.TOOL_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}${{ matrix.arch_suffix }}.${{ matrix.zip_ext }}
 
   build-ubuntu:
-    name: build-ubuntu-${{ matrix.arch }}
+    name: build (${{ matrix.host }})
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
             buildtype: Release
           - os: windows-2022
             buildtype: Debug
+          - os: windows-11-arm
+            buildtype: Release
           - os: macos-14
             buildtype: Release
     runs-on: ${{ matrix.os }}
@@ -81,55 +83,3 @@ jobs:
       - name: Test with docker
         run: |
           docker build --build-arg TEST=true -t tuw_test -f docker/${{ matrix.os }}.dockerfile ./
-
-  build_tests_windows_arm64:
-    runs-on: windows-2022
-    needs: lint
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-
-      - name: Install Meson
-        run: pip install meson
-
-      - name: Prepare MSVC
-        uses: bus1/cabuild/action/msdevshell@v1
-        with:
-          architecture: x64
-
-      - name: build tests
-        run: |
-          cd batch_files
-          ./test_arm.bat
-
-      - name: copy test files to ./workspace
-        run: |
-          mkdir workspace
-          cp build/ReleaseARM-Test/tests/unit_test.exe workspace
-          mkdir workspace/json
-          cp build/ReleaseARM-Test/tests/json/*.json* workspace/json
-        shell: bash
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: tests-windows-arm64
-          path: workspace
-
-  run_tests_windows_arm64:
-    runs-on: ubuntu-latest
-    needs: [lint, build_tests_windows_arm64]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          name: tests-windows-arm64
-          path: workspace
-
-      - name: Run tests with wine-arm64
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static xvfb
-          docker run --rm --init -i -v $(pwd)/workspace/:/workspace docker.io/linaro/wine-arm64 xvfb-run wine-arm64 cmd.exe /c '/workspace/unit_test.exe'


### PR DESCRIPTION
No need wine-arm64 anymore. We can use windows arm64 runners.

[Windows arm64 hosted runners now available in public preview - GitHub Changelog](https://github.blog/changelog/2025-04-14-windows-arm64-hosted-runners-now-available-in-public-preview/)

I also added `windows10-arm64.zip` to release packages.