### PR TITLE
v0.10.0 release

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -104,14 +104,14 @@ jobs:
 
       - name: Build exe for Unix
         if: (runner.os != 'Windows') && (matrix.arch_suffix != '-universal')
-        run: bash shell_scripts/build.sh Release
+        run: ./shell_scripts/build.sh Release
 
       - name: Build universal binary for Unix
         if: (runner.os != 'Windows') && (matrix.arch_suffix == '-universal')
-        run: bash shell_scripts/build_universal.sh Release
+        run: ./shell_scripts/build_universal.sh Release
 
       - name: Show info about exe
-        run: bash shell_scripts/exe_info.sh build/Release${{ matrix.arch }}/${{ env.TOOL_NAME }}${{ matrix.exe_ext }}
+        run: ./shell_scripts/exe_info.sh build/Release${{ matrix.arch }}/${{ env.TOOL_NAME }}${{ matrix.exe_ext }}
         shell: bash
 
       - name: Copy files
@@ -174,7 +174,9 @@ jobs:
         shell: bash
 
       - name: Show info about exe
-        run: bash shell_scripts/exe_info.sh ${{ env.TOOL_NAME }}
+        run: |
+          ./shell_scripts/exe_info.sh ${{ env.TOOL_NAME }}
+          ./shell_scripts/check_glibc_compatibility.sh ${{ env.TOOL_NAME }}
         shell: bash
 
       - name: Archive release for Unix

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -52,30 +52,35 @@ jobs:
           - os: windows-2022
             exe_ext: .exe
             zip_ext: zip
-            arch: ""
+            ucrt: ""
             arch_suffix: -x64
-          - os: windows-2022
+          - os: windows-11-arm
             exe_ext: .exe
             zip_ext: zip
-            arch: ARM
+            ucrt: ""
             arch_suffix: -arm64
           - os: windows-2022
             exe_ext: .exe
             zip_ext: zip
-            arch: UCRT
+            ucrt: UCRT
             arch_suffix: 10-x64
+          - os: windows-11-arm
+            exe_ext: .exe
+            zip_ext: zip
+            ucrt: UCRT
+            arch_suffix: 10-arm64
           - os: macos-14
             exe_ext: ""
             zip_ext: tar.xz
-            arch: ""
+            ucrt: ""
             arch_suffix: "-arm64"
           - os: macos-14
             exe_ext: ""
             zip_ext: tar.xz
-            arch: ""
+            ucrt: ""
             arch_suffix: "-universal"
 
-    name: build-${{ matrix.os }}${{ matrix.arch_suffix }}
+    name: build (${{ matrix.os }}, ${{ matrix.arch_suffix }})
     runs-on: ${{ matrix.os }}
     needs: setup
     steps:
@@ -100,7 +105,7 @@ jobs:
 
       - name: Build exe for Windows
         if: runner.os == 'Windows'
-        run: batch_files/build.bat Release ${{ matrix.arch }}
+        run: batch_files/build.bat Release ${{ matrix.ucrt }}
 
       - name: Build exe for Unix
         if: (runner.os != 'Windows') && (matrix.arch_suffix != '-universal')
@@ -111,13 +116,13 @@ jobs:
         run: ./shell_scripts/build_universal.sh Release
 
       - name: Show info about exe
-        run: ./shell_scripts/exe_info.sh build/Release${{ matrix.arch }}/${{ env.TOOL_NAME }}${{ matrix.exe_ext }}
+        run: ./shell_scripts/exe_info.sh build/Release${{ matrix.ucrt }}/${{ env.TOOL_NAME }}${{ matrix.exe_ext }}
         shell: bash
 
       - name: Copy files
         run: |
           mkdir -p archive/${{ env.TOOL_NAME }}
-          cp build/Release${{ matrix.arch }}/${{ env.TOOL_NAME }}${{ matrix.exe_ext }} archive/${{ env.TOOL_NAME }}
+          cp build/Release${{ matrix.ucrt }}/${{ env.TOOL_NAME }}${{ matrix.exe_ext }} archive/${{ env.TOOL_NAME }}
           cp examples/other_features/help/gui_definition.json archive/${{ env.TOOL_NAME }}
           cp docs/changelog.txt archive/${{ env.TOOL_NAME }}
           cp license.txt archive/${{ env.TOOL_NAME }}
@@ -142,7 +147,7 @@ jobs:
           gh release upload ${{ needs.setup.outputs.tag }} archive/${{ env.TOOL_NAME }}-${{ needs.setup.outputs.tag }}-${{ runner.os }}${{ matrix.arch_suffix }}.${{ matrix.zip_ext }}
 
   build-ubuntu:
-    name: build-ubuntu-${{ matrix.arch }}
+    name: build (${{ matrix.host }})
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
             buildtype: Release
           - os: windows-2022
             buildtype: Debug
+          - os: windows-11-arm
+            buildtype: Release
           - os: macos-14
             buildtype: Release
     runs-on: ${{ matrix.os }}
@@ -81,55 +83,3 @@ jobs:
       - name: Test with docker
         run: |
           docker build --build-arg TEST=true -t tuw_test -f docker/${{ matrix.os }}.dockerfile ./
-
-  build_tests_windows_arm64:
-    runs-on: windows-2022
-    needs: lint
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-
-      - name: Install Meson
-        run: pip install meson
-
-      - name: Prepare MSVC
-        uses: bus1/cabuild/action/msdevshell@v1
-        with:
-          architecture: x64
-
-      - name: build tests
-        run: |
-          cd batch_files
-          ./test_arm.bat
-
-      - name: copy test files to ./workspace
-        run: |
-          mkdir workspace
-          cp build/ReleaseARM-Test/tests/unit_test.exe workspace
-          mkdir workspace/json
-          cp build/ReleaseARM-Test/tests/json/*.json* workspace/json
-        shell: bash
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: tests-windows-arm64
-          path: workspace
-
-  run_tests_windows_arm64:
-    runs-on: ubuntu-latest
-    needs: [lint, build_tests_windows_arm64]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          name: tests-windows-arm64
-          path: workspace
-
-      - name: Run tests with wine-arm64
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static xvfb
-          docker run --rm --init -i -v $(pwd)/workspace/:/workspace docker.io/linaro/wine-arm64 xvfb-run wine-arm64 cmd.exe /c '/workspace/unit_test.exe'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, macos-14]
+        include:
+          - os: windows-2022
+            buildtype: Release
+          - os: windows-2022
+            buildtype: Debug
+          - os: macos-14
+            buildtype: Release
     runs-on: ${{ matrix.os }}
     needs: lint
     steps:
@@ -54,14 +60,14 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           cd batch_files
-          ./test.bat
+          ./test.bat ${{ matrix.buildtype }}
 
       # xquartz has xvfb functions
       - name: build and run tests for mac
         if: runner.os == 'macOS'
         run: |
           brew install --cask xquartz
-          ./shell_scripts/test.sh
+          ./shell_scripts/test.sh ${{ matrix.buildtype }}
 
   test_linux:
     needs: lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,8 +74,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Test with docker
         run: |
-          docker build -t tuw_test -f docker/${{ matrix.os }}.dockerfile ./
-          docker run --rm --init -i tuw_test xvfb-run ./test.sh
+          docker build --build-arg TEST=true -t tuw_test -f docker/${{ matrix.os }}.dockerfile ./
 
   build_tests_windows_arm64:
     runs-on: windows-2022

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install --cask xquartz
-          bash shell_scripts/test.sh
+          ./shell_scripts/test.sh
 
   test_linux:
     needs: lint
@@ -75,7 +75,7 @@ jobs:
       - name: Test with docker
         run: |
           docker build -t tuw_test -f docker/${{ matrix.os }}.dockerfile ./
-          docker run --rm --init -i tuw_test xvfb-run bash test.sh
+          docker run --rm --init -i tuw_test xvfb-run ./test.sh
 
   build_tests_windows_arm64:
     runs-on: windows-2022

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ out
 # python
 python
 *.py
+!tests/*.py
 *.pyd
 *.dll
 *.cat

--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,7 @@ subprojects/gtk_ansi_parser
 *.new
 *.zip
 
-Tuw
-Tuw.exe
+Tuw*
 SimpleCommandRunner
 *.tar.*
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,11 @@
 
 *.bat
 !batch_files/*.bat
+!examples/tips/ansicode/ansicode.bat
 
 *.sh
 !shell_scripts/*.sh
+!examples/tips/ansicode/ansicode.sh
 
 *.ps1
 !examples/**/*.ps1

--- a/batch_files/build.bat
+++ b/batch_files/build.bat
@@ -35,10 +35,9 @@ if %ERRORLEVEL% NEQ 0 (
 )
 
 @pushd %~dp0\..
-    meson setup build\%BUILD_TYPE%%~2 %PRESET%%OPTIONS%
+    meson setup build\%BUILD_TYPE%%~2 %PRESET%%OPTIONS% -Dbuild_test=false
     if %ERRORLEVEL% neq 0 goto :buildend
     cd build\%BUILD_TYPE%%~2
     meson compile -v
     :buildend
 popd
-pause

--- a/batch_files/build_arm.bat
+++ b/batch_files/build_arm.bat
@@ -1,5 +1,5 @@
 REM Cross compile for ARM64 build
 
 @pushd %~dp0
-build.bat Release ARM
+call build.bat Release ARM
 popd

--- a/batch_files/build_debug.bat
+++ b/batch_files/build_debug.bat
@@ -1,3 +1,5 @@
 REM Build with debug mode.
 
+@pushd %~dp0
 build.bat Debug
+popd

--- a/batch_files/build_debug.bat
+++ b/batch_files/build_debug.bat
@@ -1,5 +1,5 @@
 REM Build with debug mode.
 
 @pushd %~dp0
-build.bat Debug
+call build.bat Debug
 popd

--- a/batch_files/build_with_ucrt.bat
+++ b/batch_files/build_with_ucrt.bat
@@ -2,5 +2,5 @@ REM Build with Universal CRT.
 REM This option makes exe much smaller. But the built binary only supports Windows10 or later.
 
 @pushd %~dp0
-build.bat Release UCRT
+call build.bat Release UCRT
 popd

--- a/batch_files/test.bat
+++ b/batch_files/test.bat
@@ -56,7 +56,7 @@ if %ERRORLEVEL% NEQ 0 (
 
     REM Test and get coverage report from tests.
     set MODULES=--modules %cd%\build\%BUILD_TYPE%%~2-Test\
-    set SOURCES=--sources %cd%\src
+    set SOURCES=--sources %cd%\src --sources %cd%\include
     set EXPORT_TYPE=--export_type html:%cd%\coverage-report
     set WORKDIR=--working_dir %cd%
     OpenCppCoverage --cover_children %WORKDIR% %EXPORT_TYPE% %MODULES% %SOURCES% -- meson test -v -C build\%BUILD_TYPE%%~2-Test

--- a/batch_files/test.bat
+++ b/batch_files/test.bat
@@ -4,18 +4,18 @@ REM You can also get coverage report if OpenCppCoverage is installed.
 
 if /I "%~1"=="Debug" (
     set BUILD_TYPE=Debug
-    set PRESET=--native-file presets\debug.ini --native-file presets\test.ini
+    set PRESET=--native-file presets\debug.ini
 ) else (
     set BUILD_TYPE=Release
-    set PRESET=--native-file presets\release.ini --native-file presets\test.ini
+    set PRESET=--native-file presets\release.ini
 )
 echo Build type: %BUILD_TYPE%
 
 if /I "%~2"=="ARM" (
     if /I "%~1"=="Debug" (
-        set PRESET=--cross-file presets\windows_arm64.ini --cross-file presets\debug.ini --cross-file presets\test.ini
+        set PRESET=--cross-file presets\windows_arm64.ini --cross-file presets\debug.ini
     ) else (
-        set PRESET=--cross-file presets\windows_arm64.ini --cross-file presets\release.ini --cross-file presets\test.ini
+        set PRESET=--cross-file presets\windows_arm64.ini --cross-file presets\release.ini
     )
 )
 
@@ -55,7 +55,7 @@ if %ERRORLEVEL% NEQ 0 (
     if %GET_COVERAGE% equ 0 goto nocoverage
 
     REM Test and get coverage report from tests.
-    set MODULES=--modules %cd%\build\%BUILD_TYPE%%~2-Test\tests
+    set MODULES=--modules %cd%\build\%BUILD_TYPE%%~2-Test\
     set SOURCES=--sources %cd%\src
     set EXPORT_TYPE=--export_type html:%cd%\coverage-report
     set WORKDIR=--working_dir %cd%
@@ -72,5 +72,4 @@ if %ERRORLEVEL% NEQ 0 (
     :testend
 @popd
 
-pause
 if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%

--- a/batch_files/test_arm.bat
+++ b/batch_files/test_arm.bat
@@ -1,3 +1,3 @@
 @pushd %~dp0
-test.bat Release ARM
+call test.bat Release ARM
 popd

--- a/batch_files/test_debug.bat
+++ b/batch_files/test_debug.bat
@@ -1,3 +1,5 @@
 REM Run tests for debug build.
 
+@pushd %~dp0
 test.bat Debug
+popd

--- a/batch_files/test_debug.bat
+++ b/batch_files/test_debug.bat
@@ -1,5 +1,5 @@
 REM Run tests for debug build.
 
 @pushd %~dp0
-test.bat Debug
+call test.bat Debug
 popd

--- a/docker/alpine.dockerfile
+++ b/docker/alpine.dockerfile
@@ -16,7 +16,7 @@
 #
 #   -You can run tests on the container.
 #    docker build -t tuw_alpine -f docker/alpine.dockerfile ./
-#    docker run --rm --init -i tuw_alpine xvfb-run bash test.sh
+#    docker run --rm --init -i tuw_alpine xvfb-run ./test.sh
 
 # Base image
 FROM alpine:3.16.5
@@ -38,4 +38,4 @@ COPY .. /Tuw
 
 # Build
 WORKDIR /Tuw/shell_scripts
-RUN bash build.sh
+RUN ./build.sh

--- a/docker/alpine.dockerfile
+++ b/docker/alpine.dockerfile
@@ -7,25 +7,30 @@
 #    docker run --name tuw_alpine tuw_alpine
 #
 # 3. Use "docker cp" to get the built executable.
-#    docker cp tuw_alpine:/Tuw/build/Release/Tuw ./
+#    docker cp tuw_alpine:/Tuw/build/Release-Test/Tuw ./
 #
 # Notes:
 #   -You can use buildx for cross compiling
 #    sudo apt install -y qemu-user-static binfmt-support
 #    docker buildx build --platform linux/arm64 -t tuw_alpine_arm -f docker/alpine.dockerfile ./
 #
-#   -You can run tests on the container.
-#    docker build -t tuw_alpine -f docker/alpine.dockerfile ./
-#    docker run --rm --init -i tuw_alpine xvfb-run ./test.sh
+#   -You can run test.sh with build-arg
+#    docker build --build-arg TEST=true -t tuw_alpine -f docker/alpine.dockerfile ./
 
 # Base image
 FROM alpine:3.16.5
+
+# Run test.sh when true
+ARG TEST=false
 
 # Install packages
 RUN apk update && \
     apk add --no-cache \
         alpine-sdk linux-headers bash gtk+3.0-dev \
-        py3-pip python3 ttf-freefont xvfb-run
+        py3-pip python3 ttf-freefont && \
+    if [ "$TEST" = "true" ]; then \
+        apk add --no-cache dbus-x11 xdg-utils xorg-server xvfb firefox; \
+    fi
 
 # Need ttf-freefont to avoid a GTK warning
 # "Native Windows wider or taller than * pixels are not supported"
@@ -34,8 +39,16 @@ RUN apk update && \
 RUN pip3 install meson==1.3.1 ninja==1.11.1
 
 # Clone the repo
-COPY .. /Tuw
+COPY . /Tuw
 
 # Build
+ENV XDG_CURRENT_DESKTOP=GNOME
 WORKDIR /Tuw/shell_scripts
-RUN ./build.sh
+RUN if [ "$TEST" = "true" ]; then \
+        Xvfb :99 -screen 0 1024x768x24 & \
+        export DISPLAY=:99 && \
+        gio mime x-scheme-handler/https org.mozilla.firefox.desktop && \
+        ./test.sh; \
+    else \
+        ./build.sh; \
+    fi

--- a/docker/ubuntu.dockerfile
+++ b/docker/ubuntu.dockerfile
@@ -16,7 +16,7 @@
 #
 #   -You can run tests on the container.
 #    docker build -t tuw_ubuntu -f docker/ubuntu.dockerfile ./
-#    docker run --rm --init -i tuw_ubuntu xvfb-run bash test.sh
+#    docker run --rm --init -i tuw_ubuntu xvfb-run ./test.sh
 
 # Base image
 FROM ubuntu:20.04
@@ -38,4 +38,4 @@ COPY . /Tuw
 
 # Build
 WORKDIR /Tuw/shell_scripts
-RUN bash build.sh
+RUN ./build.sh

--- a/docs/Build-on-Linux.md
+++ b/docs/Build-on-Linux.md
@@ -18,21 +18,21 @@ You can install meson and ninja via apt. (`sudo apt install meson ninja`)
 
 ## Build
 
-Run `bash shell_scripts/build.sh`.  
+Run `./shell_scripts/build.sh`.  
 The executable will be generated in `build/Release/`.  
 
 ## Debug
 
-If you want a debug build, run `bash shell_scripts/build.sh Debug` on the terminal.  
+If you want a debug build, run `./shell_scripts/build.sh Debug` on the terminal.  
 
 ## Test
 
-To build tests, type `bash shell_scripts/test.sh` or `bash shell_scripts/test.sh Debug` on the terminal.
+To build tests, type `./shell_scripts/test.sh` or `./shell_scripts/test.sh Debug` on the terminal.
 
 ## Coverage
 
 If you use GCC, you can get coverage reports.  
-Install lcov with `sudo apt install lcov` and run `bash shell_scripts/coverage.sh` or `bash shell_scripts/coverage.sh Debug` on the terminal.  
+Install lcov with `sudo apt install lcov` and run `./shell_scripts/coverage.sh` or `./shell_scripts/coverage.sh Debug` on the terminal.  
 It'll generate html files in `./Tuw/coverage-report/`.
 
 ## GLIBC Dependencies
@@ -40,7 +40,7 @@ It'll generate html files in `./Tuw/coverage-report/`.
 If you have built the binary with GLIBC, you can use `check_glibc_compatibility.sh` to see the required versions of GLIBC and GLIBCXX.  
 
 ```console
-$ bash shell_scripts/check_libc_compatibility.sh build/Release/Tuw
+$ ./shell_scripts/check_libc_compatibility.sh build/Release/Tuw
 Required GLIBC versions
 2.2.5
 2.3

--- a/docs/Build-on-Mac.md
+++ b/docs/Build-on-Mac.md
@@ -19,12 +19,12 @@ You can install meson and ninja via Homebrew. (`brew install meson ninja`)
 
 ## Build
 
-Run `bash shell_scripts/build.sh`. The executable will be generated in `build/Release/`. You can also use `shell_scripts/build_universal.sh` instead of `build.sh` to build universal binary.
+Run `./shell_scripts/build.sh`. The executable will be generated in `build/Release/`. You can also use `./shell_scripts/build_universal.sh` instead of `build.sh` to build universal binary.
 
 ## Debug
 
-If you want a debug build, run `bash shell_scripts/build.sh Debug` on the terminal.  
+If you want a debug build, run `./shell_scripts/build.sh Debug` on the terminal.  
 
 ## Test
 
-To build tests, type `bash shell_scripts/test.sh` or `bash shell_scripts/test.sh Debug` on the terminal.  
+To build tests, type `./shell_scripts/test.sh` or `./shell_scripts/test.sh Debug` on the terminal.  

--- a/docs/Build-on-Other.md
+++ b/docs/Build-on-Other.md
@@ -20,7 +20,7 @@ On FreeBSD, you can get all the required tools with `pkg`.
 pkg install git bash pkgconf meson ninja
 git clone https://github.com/matyalatte/tuw.git
 cd tuw
-bash shell_scripts/build.sh
+./shell_scripts/build.sh
 ./build/Release/Tuw
 ```
 
@@ -32,7 +32,7 @@ On OpenBSD, you can get all the required tools with `pkg_add`.
 pkg_add bash meson ninja
 git clone https://github.com/matyalatte/tuw.git
 cd tuw
-bash shell_scripts/build.sh
+./shell_scripts/build.sh
 ./build/Release/Tuw
 ```
 
@@ -44,7 +44,7 @@ On NetBSD, you can get all the required tools with `pkgin`.
 pkgin in git mozilla-rootcerts-openssl bash pkgconf meson ninja
 git clone https://github.com/matyalatte/tuw.git
 cd tuw
-bash shell_scripts/build.sh
+./shell_scripts/build.sh
 ./build/Release/Tuw
 ```
 
@@ -56,7 +56,7 @@ On Haiku, you can get all the required tools with `pkgman`.
 pkgman install meson ninja gtk3_devel
 git clone https://github.com/matyalatte/tuw.git
 cd tuw
-bash shell_scripts/build.sh
+./shell_scripts/build.sh
 ./build/Release/Tuw
 ```
 
@@ -86,6 +86,6 @@ On OpenIndiana, you can get all the required tools with `pkg`.
 pkg install bash git meson
 git clone https://github.com/matyalatte/tuw.git
 cd tuw
-bash shell_scripts/build.sh
+./shell_scripts/build.sh
 ./build/Release/Tuw
 ```

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to Tuw
+
+Tuw is an open-source project that warmly welcomes contributions. We appreciate your help in improving the project!
+
+## Coding Style
+
+Tuw follows [Google's C++ Style Guide](http://google.github.io/styleguide/cppguide.html) with the following modifications:
+
+- Line length should not exceed 100 characters.
+- Use 4 spaces for indentation.
+- No copyright notice or author line is required in source files.
+- `std` c++ library is prohibited.
+- Use [`noex`](../include/noex) library if you need strings and vectors.
+- All functions should have `noexcept` specifiers.
+
+## CI Workflow
+
+No PR is merged until it passes the following code checks:
+
+- Linting by cpplint.py 1.6
+- Typo check by [codespell](https://github.com/codespell-project/codespell)
+- Unit tests with `meson test -C build`
+
+Before sending PRs, it is recommended to run tests and linting using the following commands.
+
+```sh
+meson setup build
+meson compile -C build
+meson test -C build -v
+cpplint --recursive --quiet .
+codespell -S "build,subprojects"
+```
+
+You can also run [test.yml](../.github/workflows/test.yml) manually on your forked repo.
+
+[Manually running a workflow - GitHub Docs](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow)

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,9 +16,9 @@
 [![donate](https://img.shields.io/static/v1?label=donate&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86)](https://github.com/sponsors/matyalatte)  
 [Examples](../examples/README.md) | [Build Instructions](./Building.md) | [FAQ](./FAQ.md)
 
-## Only 300KB for a portable GUI
+## Only 200KB for a portable GUI
 
-Tuw provides a very simple GUI for your scripts.  
+Tuw provides a simple GUI, like a web form, for your scripts.  
 All you need is a JSON file and a tiny executable.  
 **No need for compilers, browsers, or huge executables!**  
 
@@ -43,7 +43,7 @@ You can download executables from [the release page](https://github.com/matyalat
 
 -   `Tuw-*-Windows-*.zip` is for Windows (7 or later.)  
 -   `Tuw-*-Windows10-*.zip` requires Windows 10 or later, but it's much smaller than the standard version.  
--   `Tuw-*-macOS.tar.xz` is for macOS (10.9 or later.)  
+-   `Tuw-*-macOS-*.tar.xz` is for macOS (10.9 or later.)  
 -   `Tuw-*-Linux-*.tar.xz` is for Linux (with GTK3.14, GLIBC2.28, and GLIBCXX3.4, or later versions of the libraries.)  
 
 > [!Note]
@@ -95,7 +95,6 @@ Files in this repository are available under the [MIT license](../license.txt).
 | Project | About | License |
 | -- | -- | -- |
 | [libui-ng](https://github.com/libui-ng/libui-ng) | GUI framework | [MIT](http://opensource.org/licenses/MIT) |
-| [RapidJSON](https://github.com/Tencent/rapidjson) | JSON parser | [MIT](http://opensource.org/licenses/MIT) |
 | [subprocess.h](https://github.com/sheredom/subprocess.h) | Command processor | [Unlicense](https://github.com/sheredom/subprocess.h/blob/master/LICENSE) |
 | [c-env-utils](https://github.com/matyalatte/c-env-utils) | Utilities for environment info | [MIT](http://opensource.org/licenses/MIT) |
 | [tiny-str-match](https://github.com/matyalatte/tiny-str-match) | String validator | [MIT](http://opensource.org/licenses/MIT) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,6 +82,10 @@ For VSCode, you can add the schema path to `settings.json` (`File > Preferences 
 
 [Building Executables](./Building.md)
 
+## Contributing
+
+[Contributing to Tuw](./CONTRIBUTING.md)
+
 ## License
 
 Files in this repository are available under the [MIT license](../license.txt).  

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,17 @@
+ver 0.10.0
+- Improved JSON parser. (#108)
+  - Reduced binary size (about 16% for Windows10 build.)
+  - It now shows error messages with line and column of a JSON file.
+    e.g. "id" should be a string (line: 4, column: 5)
+  - Revised some error messages.
+- Tuw now shows a deprecation warning when a component has no id. (#107)
+- Fixed a Windows-specific issue where "merge" and "split" commands was not able to show UTF8 strings. (#108)
+- Fixed an issue where the default value of "inc" for float pickers was wrong. (#104)
+- Fixed an assertion error on debug build. (#100)
+- Removed unnecessary memory allocations and function calls. (#101, #103 and #110)
+- Removed asynchronous unwind tables from Linux-x64 build. (#102)
+- Added "windows10-arm64.zip" to the release packages. (#111)
+
 ver 0.9.2
 - Improved the performance of redirection (#91)
   (Fixed a Windows-specific issue where stdout redirection was unexpectedly slow.)

--- a/examples/README.md
+++ b/examples/README.md
@@ -67,3 +67,4 @@ Not about the JSON format, but they might help you.
 -   [Unicode Characters](./tips/unicode): Tuw supports UTF-8!
 -   [Safe Mode](./tips/safe_mode): You can check commands without executing them.
 -   [JSON with Comments](./tips/comments): Tuw supports C-style comments in JSON files.
+-   [ANSI Codes](./tips/ansicode): Tuw supports many of the ANSI escape sequences.

--- a/examples/all_keys/gui_definition.json
+++ b/examples/all_keys/gui_definition.json
@@ -1,5 +1,5 @@
 {
-    "recommended": "0.9.2",
+    "recommended": "0.10.0",
     "minimum_required": "0.8.0",
     "gui": [
         {

--- a/examples/comp_options/id/README.md
+++ b/examples/comp_options/id/README.md
@@ -24,6 +24,9 @@ You can use the defined ids as variable names in commands.
 
 ## Undefined IDs
 
+> [!warning]
+> Undifined ids are deprecated. Please define an id for each component.
+
 When you put an undefined id in `%*%`, it'll use one of the components that have no id.
 
 ```json

--- a/examples/components/path_pickers/README.md
+++ b/examples/components/path_pickers/README.md
@@ -37,7 +37,7 @@ Each component should be defined as a dictionary.
 
 -   `type` is the component type. `file` for a file picker, and `folder` for a directory picker.
 -   `label` is the string written above the text box of the picker.
--   `extension` is an option for file pickers. It specifies the wildcard for file extensions. Use the same syntax as for [wxWidget's wildcards](https://docs.wxwidgets.org/3.0/classwx_file_dialog.html).
+-   `extension` is an option for file pickers. It specifies the wildcard for file extensions. Use the same syntax as for [WinAPI's filter string](https://learn.microsoft.com/en-us/dotnet/api/microsoft.win32.filedialog.filter).
 -   `add_quotes` is an option for components. It adds quotes (`""`) to the input strings.
 
 ## Command

--- a/examples/tips/ansicode/README.md
+++ b/examples/tips/ansicode/README.md
@@ -1,0 +1,57 @@
+# ANSI Codes
+
+Tuw supports many of the ANSI escape sequences. You can use colors, font styles, and carriage returns to output strings.  
+You can also see the list of supported escape sequences here.  
+[gtk-ansi-parser: Supported Escape Sequences](https://matyalatte.github.io/gtk-ansi-parser/md_docs__a_n_s_icodes.html)  
+
+![ansicode](https://github.com/user-attachments/assets/270f7236-2665-46f0-ba55-a4f570f6378a)
+
+```json
+{
+    "gui": {
+        "label": "ANSI escape sequences",
+        "command": "bash ansicode.sh",
+        "command_win": "ansicode.bat",
+        "components": []
+    }
+}
+```
+
+```bash
+#!/bin/bash
+# ansicode.sh
+
+for y in {0..15}; do
+    for x in {0..15}; do
+        color=$((y * 16 + x))
+        printf "\033[48;5;%dm  \033[0m" "$color"
+    done
+    echo ""
+done
+
+echo -e "\033[1mBold\033[0m\033[3mItalic\033[0m\033[4mUnderline\033[0m"
+echo -e "\033[31;5mRedBlink\033[0m\033[31;2mRedFaint\033[0m"
+echo -e "\033[9mStrikethrough\033[0m\033[7mReverse\033[0m\033[8mConceal\033[0m"
+echo -e "0123456789abcdefghjklmn\rCarriage returns!"
+```
+
+```bat
+@echo off
+REM ansicode.bat
+
+setlocal EnableDelayedExpansion
+for /f %%i in ('cmd /k prompt $e^<nul') do set ESC=%%i
+
+for /L %%y in (0,1,15) do (
+    for /L %%x in (0,1,15) do (
+        set /a color=%%y * 16 + %%x
+        <nul set /p=%ESC%[48;5;!color!m  %ESC%[0m
+    )
+    echo.
+)
+
+echo %ESC%[1mBold%ESC%[0m%ESC%[3mItalic%ESC%[0m%ESC%[4mUnderline%ESC%[0m
+echo %ESC%[31;5mRedBlink%ESC%[0m%ESC%[31;2mRedFaint%ESC%[0m
+echo %ESC%[9mStrikethrough%ESC%[0m%ESC%[7mReverse%ESC%[0m%ESC%[8mConceal%ESC%[0m
+echo 0123456789abcdefghjklmn%ESC%[1K%ESC%[0GCarriage returns!
+```

--- a/examples/tips/ansicode/ansicode.bat
+++ b/examples/tips/ansicode/ansicode.bat
@@ -1,0 +1,18 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+REM Enable ANSI escape codes
+for /f %%i in ('cmd /k prompt $e^<nul') do set ESC=%%i
+
+for /L %%y in (0,1,15) do (
+    for /L %%x in (0,1,15) do (
+        set /a color=%%y * 16 + %%x
+        <nul set /p=%ESC%[48;5;!color!m  %ESC%[0m
+    )
+    echo.
+)
+
+echo %ESC%[1mBold%ESC%[0m%ESC%[3mItalic%ESC%[0m%ESC%[4mUnderline%ESC%[0m
+echo %ESC%[31;5mRedBlink%ESC%[0m%ESC%[31;2mRedFaint%ESC%[0m
+echo %ESC%[9mStrikethrough%ESC%[0m%ESC%[7mReverse%ESC%[0m%ESC%[8mConceal%ESC%[0m
+echo 0123456789abcdefghjklmn%ESC%[1K%ESC%[0GCarriage returns!

--- a/examples/tips/ansicode/ansicode.sh
+++ b/examples/tips/ansicode/ansicode.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+for y in {0..15}; do
+    for x in {0..15}; do
+        color=$((y * 16 + x))
+        printf "\033[48;5;%dm  \033[0m" "$color"
+    done
+    echo ""
+done
+
+echo -e "\033[1mBold\033[0m\033[3mItalic\033[0m\033[4mUnderline\033[0m"
+echo -e "\033[31;5mRedBlink\033[0m\033[31;2mRedFaint\033[0m"
+echo -e "\033[9mStrikethrough\033[0m\033[7mReverse\033[0m\033[8mConceal\033[0m"
+echo -e "0123456789abcdefghjklmn\rCarriage returns!"

--- a/examples/tips/ansicode/gui_definition.json
+++ b/examples/tips/ansicode/gui_definition.json
@@ -1,0 +1,8 @@
+{
+    "gui": {
+        "label": "ANSI escape sequences",
+        "command": "bash ansicode.sh",
+        "command_win": "ansicode.bat",
+        "components": []
+    }
+}

--- a/include/component.h
+++ b/include/component.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "rapidjson/document.h"
+#include "json.h"
 #include "ui.h"
 #include "string_utils.h"
 #include "noex/vector.hpp"
@@ -25,14 +25,14 @@ class Component {
     bool m_add_quotes;
 
  public:
-    explicit Component(const rapidjson::Value& j) noexcept;
+    explicit Component(const tuwjson::Value& j) noexcept;
     virtual ~Component() noexcept {}
     virtual noex::string GetRawString() noexcept { return "";}
     noex::string GetString() noexcept;
     const noex::string& GetID() const noexcept { return m_id; }
 
-    virtual void SetConfig(const rapidjson::Value& config) noexcept { UNUSED(config); }
-    virtual void GetConfig(rapidjson::Document& config) noexcept { UNUSED(config); }
+    virtual void SetConfig(const tuwjson::Value& config) noexcept { UNUSED(config); }
+    virtual void GetConfig(tuwjson::Value& config) noexcept { UNUSED(config); }
 
     bool HasString() const noexcept { return m_has_string; }
     bool IsWide() const noexcept { return m_is_wide; }
@@ -41,7 +41,7 @@ class Component {
     const noex::string& GetValidationError() const noexcept;
     void PutErrorWidget(uiBox* box) noexcept;
 
-    static Component* PutComponent(uiBox* box, const rapidjson::Value& j) noexcept;
+    static Component* PutComponent(uiBox* box, const tuwjson::Value& j) noexcept;
 };
 
 // containers for Combo and CheckArray
@@ -57,19 +57,19 @@ class MultipleValuesContainer {
 
 class EmptyComponent : public Component {
  public:
-    EmptyComponent(uiBox* box, const rapidjson::Value& j) noexcept
+    EmptyComponent(uiBox* box, const tuwjson::Value& j) noexcept
         : Component(j) { UNUSED(box); }
 };
 
 class StaticText : public Component {
  public:
-    StaticText(uiBox* box, const rapidjson::Value& j) noexcept;
+    StaticText(uiBox* box, const tuwjson::Value& j) noexcept;
 };
 
 class StringComponentBase : public Component {
  public:
-    StringComponentBase(uiBox* box, const rapidjson::Value& j) noexcept;
-    void GetConfig(rapidjson::Document& config) noexcept override;
+    StringComponentBase(uiBox* box, const tuwjson::Value& j) noexcept;
+    void GetConfig(tuwjson::Value& config) noexcept override;
 };
 
 class FilePicker : public StringComponentBase {
@@ -77,33 +77,33 @@ class FilePicker : public StringComponentBase {
     noex::string m_ext;
  public:
     noex::string GetRawString() noexcept override;
-    FilePicker(uiBox* box, const rapidjson::Value& j) noexcept;
-    void SetConfig(const rapidjson::Value& config) noexcept override;
+    FilePicker(uiBox* box, const tuwjson::Value& j) noexcept;
+    void SetConfig(const tuwjson::Value& config) noexcept override;
     void OpenFile() noexcept;
 };
 
 class DirPicker : public StringComponentBase {
  public:
     noex::string GetRawString() noexcept override;
-    DirPicker(uiBox* box, const rapidjson::Value& j) noexcept;
-    void SetConfig(const rapidjson::Value& config) noexcept override;
+    DirPicker(uiBox* box, const tuwjson::Value& j) noexcept;
+    void SetConfig(const tuwjson::Value& config) noexcept override;
     void OpenFolder() noexcept;
 };
 
 class ComboBox : public StringComponentBase, MultipleValuesContainer {
  public:
     noex::string GetRawString() noexcept override;
-    ComboBox(uiBox* box, const rapidjson::Value& j) noexcept;
-    void GetConfig(rapidjson::Document& config) noexcept override;
-    void SetConfig(const rapidjson::Value& config) noexcept override;
+    ComboBox(uiBox* box, const tuwjson::Value& j) noexcept;
+    void GetConfig(tuwjson::Value& config) noexcept override;
+    void SetConfig(const tuwjson::Value& config) noexcept override;
 };
 
 class RadioButtons : public StringComponentBase, MultipleValuesContainer {
  public:
     noex::string GetRawString() noexcept override;
-    RadioButtons(uiBox* box, const rapidjson::Value& j) noexcept;
-    void GetConfig(rapidjson::Document& config) noexcept override;
-    void SetConfig(const rapidjson::Value& config) noexcept override;
+    RadioButtons(uiBox* box, const tuwjson::Value& j) noexcept;
+    void GetConfig(tuwjson::Value& config) noexcept override;
+    void SetConfig(const tuwjson::Value& config) noexcept override;
 };
 
 class CheckBox : public Component {
@@ -111,9 +111,9 @@ class CheckBox : public Component {
     noex::string m_value;
  public:
     noex::string GetRawString() noexcept override;
-    CheckBox(uiBox* box, const rapidjson::Value& j) noexcept;
-    void GetConfig(rapidjson::Document& config) noexcept override;
-    void SetConfig(const rapidjson::Value& config) noexcept override;
+    CheckBox(uiBox* box, const tuwjson::Value& j) noexcept;
+    void GetConfig(tuwjson::Value& config) noexcept override;
+    void SetConfig(const tuwjson::Value& config) noexcept override;
 };
 
 class CheckArray : public StringComponentBase, MultipleValuesContainer {
@@ -121,31 +121,31 @@ class CheckArray : public StringComponentBase, MultipleValuesContainer {
     noex::vector<uiCheckbox*> m_checks;
  public:
     noex::string GetRawString() noexcept override;
-    CheckArray(uiBox* box, const rapidjson::Value& j) noexcept;
-    void GetConfig(rapidjson::Document& config) noexcept override;
-    void SetConfig(const rapidjson::Value& config) noexcept override;
+    CheckArray(uiBox* box, const tuwjson::Value& j) noexcept;
+    void GetConfig(tuwjson::Value& config) noexcept override;
+    void SetConfig(const tuwjson::Value& config) noexcept override;
 };
 
 class TextBox : public StringComponentBase {
  public:
     noex::string GetRawString() noexcept override;
-    TextBox(uiBox* box, const rapidjson::Value& j) noexcept;
-    void SetConfig(const rapidjson::Value& config) noexcept override;
+    TextBox(uiBox* box, const tuwjson::Value& j) noexcept;
+    void SetConfig(const tuwjson::Value& config) noexcept override;
 };
 
 class IntPicker : public StringComponentBase {
  public:
-    IntPicker(uiBox* box, const rapidjson::Value& j) noexcept;
+    IntPicker(uiBox* box, const tuwjson::Value& j) noexcept;
     noex::string GetRawString() noexcept override;
-    void GetConfig(rapidjson::Document& config) noexcept override;
-    void SetConfig(const rapidjson::Value& config) noexcept override;
+    void GetConfig(tuwjson::Value& config) noexcept override;
+    void SetConfig(const tuwjson::Value& config) noexcept override;
 };
 
 // This is the same as IntPicker cause uiSpinboxDouble is not supported yet.
 class FloatPicker : public StringComponentBase {
  public:
-    FloatPicker(uiBox* box, const rapidjson::Value& j) noexcept;
+    FloatPicker(uiBox* box, const tuwjson::Value& j) noexcept;
     noex::string GetRawString() noexcept override;
-    void GetConfig(rapidjson::Document& config) noexcept override;
-    void SetConfig(const rapidjson::Value& config) noexcept override;
+    void GetConfig(tuwjson::Value& config) noexcept override;
+    void SetConfig(const tuwjson::Value& config) noexcept override;
 };

--- a/include/component.h
+++ b/include/component.h
@@ -11,15 +11,15 @@
 class Component {
  protected:
     void* m_widget;
-    noex::string m_label;
-    noex::string m_id;
+    const char* m_label;
+    const char* m_id;
     bool m_has_string;
     bool m_is_wide;
     Validator m_validator;
     uiLabel* m_error_widget;
     bool m_optional;
-    noex::string m_prefix;
-    noex::string m_suffix;
+    const char* m_prefix;
+    const char* m_suffix;
 
  private:
     bool m_add_quotes;
@@ -29,7 +29,7 @@ class Component {
     virtual ~Component() noexcept {}
     virtual noex::string GetRawString() noexcept { return "";}
     noex::string GetString() noexcept;
-    const noex::string& GetID() const noexcept { return m_id; }
+    const char* GetID() const noexcept { return m_id; }
 
     virtual void SetConfig(const tuwjson::Value& config) noexcept { UNUSED(config); }
     virtual void GetConfig(tuwjson::Value& config) noexcept { UNUSED(config); }
@@ -42,17 +42,6 @@ class Component {
     void PutErrorWidget(uiBox* box) noexcept;
 
     static Component* PutComponent(uiBox* box, const tuwjson::Value& j) noexcept;
-};
-
-// containers for Combo and CheckArray
-class MultipleValuesContainer {
- protected:
-    noex::vector<noex::string> m_values;
-
- public:
-    void SetValues(noex::vector<noex::string> values) noexcept {
-        m_values = values;
-    }
 };
 
 class EmptyComponent : public Component {
@@ -72,9 +61,30 @@ class StringComponentBase : public Component {
     void GetConfig(tuwjson::Value& config) noexcept override;
 };
 
+class FilterList {
+ private:
+    noex::string filter_buf_str;
+    noex::vector<const char*> patterns;
+    noex::vector<uiFileDialogParamsFilter> ui_filters;
+
+ public:
+    FilterList() noexcept: filter_buf_str(), patterns(), ui_filters() {}
+
+    void MakeFilters(const char* ext) noexcept;
+
+    size_t GetSize() const noexcept {
+        return ui_filters.size();
+    }
+
+    uiFileDialogParamsFilter* ToLibuiFilterList() const noexcept {
+        return ui_filters.data();
+    }
+};
+
 class FilePicker : public StringComponentBase {
  private:
-    noex::string m_ext;
+    const char* m_ext;
+
  public:
     noex::string GetRawString() noexcept override;
     FilePicker(uiBox* box, const tuwjson::Value& j) noexcept;
@@ -90,7 +100,10 @@ class DirPicker : public StringComponentBase {
     void OpenFolder() noexcept;
 };
 
-class ComboBox : public StringComponentBase, MultipleValuesContainer {
+class ComboBox : public StringComponentBase {
+ private:
+    noex::vector<const char*> m_values;
+
  public:
     noex::string GetRawString() noexcept override;
     ComboBox(uiBox* box, const tuwjson::Value& j) noexcept;
@@ -98,7 +111,10 @@ class ComboBox : public StringComponentBase, MultipleValuesContainer {
     void SetConfig(const tuwjson::Value& config) noexcept override;
 };
 
-class RadioButtons : public StringComponentBase, MultipleValuesContainer {
+class RadioButtons : public StringComponentBase {
+ private:
+    noex::vector<const char*> m_values;
+
  public:
     noex::string GetRawString() noexcept override;
     RadioButtons(uiBox* box, const tuwjson::Value& j) noexcept;
@@ -108,7 +124,8 @@ class RadioButtons : public StringComponentBase, MultipleValuesContainer {
 
 class CheckBox : public Component {
  private:
-    noex::string m_value;
+    const char* m_value;
+
  public:
     noex::string GetRawString() noexcept override;
     CheckBox(uiBox* box, const tuwjson::Value& j) noexcept;
@@ -116,9 +133,11 @@ class CheckBox : public Component {
     void SetConfig(const tuwjson::Value& config) noexcept override;
 };
 
-class CheckArray : public StringComponentBase, MultipleValuesContainer {
+class CheckArray : public StringComponentBase {
  private:
+    noex::vector<const char*> m_values;
     noex::vector<uiCheckbox*> m_checks;
+
  public:
     noex::string GetRawString() noexcept override;
     CheckArray(uiBox* box, const tuwjson::Value& j) noexcept;

--- a/include/exe_container.h
+++ b/include/exe_container.h
@@ -16,8 +16,9 @@ class ExeContainer {
         m_json.SetObject();
     }
 
-    json_utils::JsonResult Read(const noex::string& exe_path) noexcept;
-    json_utils::JsonResult Write(const noex::string& exe_path) noexcept;
+    // Returns an empty string if succeed. An error message otherwise.
+    noex::string Read(const noex::string& exe_path) noexcept;
+    noex::string Write(const noex::string& exe_path) noexcept;
 
     bool HasJson() noexcept {
         return m_json.IsObject() && !m_json.ObjectEmpty();

--- a/include/exe_container.h
+++ b/include/exe_container.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "rapidjson/document.h"
+#include "json.h"
 #include "json_utils.h"
 #include "string_utils.h"
 
@@ -7,7 +7,7 @@ class ExeContainer {
  private:
     noex::string m_exe_path;
     uint32_t m_exe_size;
-    rapidjson::Document m_json;
+    tuwjson::Value m_json;
 
  public:
     ExeContainer(): m_exe_path(""),
@@ -21,19 +21,19 @@ class ExeContainer {
     noex::string Write(const noex::string& exe_path) noexcept;
 
     bool HasJson() noexcept {
-        return m_json.IsObject() && !m_json.ObjectEmpty();
+        return m_json.IsObject() && !m_json.IsEmpty();
     }
 
-    void GetJson(rapidjson::Document& json) noexcept {
-        json.CopyFrom(m_json, json.GetAllocator());
+    void GetJson(tuwjson::Value& json) noexcept {
+        json.CopyFrom(m_json);
     }
 
-    void SetJson(rapidjson::Document& json) noexcept {
-        m_json.CopyFrom(json, m_json.GetAllocator());
+    void SetJson(tuwjson::Value& json) noexcept {
+        m_json.CopyFrom(json);
     }
 
     void RemoveJson() noexcept {
-        rapidjson::Document doc;
+        tuwjson::Value doc;
         doc.SetObject();
         SetJson(doc);
     }

--- a/include/exec.h
+++ b/include/exec.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstring>
 #include "string_utils.h"
 
 struct ExecuteResult {
@@ -12,3 +13,72 @@ struct ExecuteResult {
 ExecuteResult Execute(const noex::string& cmd,
                       bool use_utf8_on_windows = false) noexcept;
 ExecuteResult LaunchDefaultApp(const noex::string& url) noexcept;
+
+// We use ring buffers to store outputs.
+template <size_t Size>
+class RingStrBuffer {
+ private:
+    char m_buffer[Size];
+    size_t m_tail;
+    bool m_is_full;
+
+ public:
+    RingStrBuffer() noexcept : m_tail(0), m_is_full(false) {}
+
+    bool IsFull() const noexcept {
+        return m_is_full;
+    }
+
+    bool IsEmpty() const noexcept {
+        return (!m_is_full && m_tail == 0);
+    }
+
+    void PushBack(char value) noexcept {
+        m_buffer[m_tail] = value;
+
+        m_tail = (m_tail + 1) % Size;
+        m_is_full = (m_is_full || m_tail == 0);
+    }
+
+    void PushBack(const char* buf, size_t size) noexcept {
+        if (!buf)
+            return;
+
+        if (size >= Size) {
+            memcpy(m_buffer, buf + (size - Size) * sizeof(char), Size * sizeof(char));
+            m_tail = 0;
+            m_is_full = true;
+            return;
+        }
+
+        if (m_tail + size >= Size) {
+            size_t first_chunk_size = (Size - m_tail) * sizeof(char);
+            memcpy(m_buffer + m_tail * sizeof(char), buf, first_chunk_size);
+            memcpy(m_buffer, buf + first_chunk_size, size * sizeof(char) - first_chunk_size);
+            m_is_full = true;
+        } else {
+            memcpy(m_buffer + m_tail * sizeof(char), buf, size * sizeof(char));
+        }
+        m_tail = (m_tail + size) % Size;
+    }
+
+    // Slide tail to 0
+    void SlideToInitialPos() noexcept {
+        if (!m_is_full || m_tail == 0)
+            return;
+        char buf[Size];
+        size_t first_chunk_size = (Size - m_tail) * sizeof(char);
+        size_t second_chunk_size = m_tail * sizeof(char);
+        memcpy(buf, m_buffer, second_chunk_size);
+        memmove(m_buffer, m_buffer + second_chunk_size, first_chunk_size);
+        memcpy(m_buffer + first_chunk_size, buf, second_chunk_size);
+        m_tail = 0;
+    }
+
+    noex::string ToString() noexcept {
+        if (!m_is_full)
+            return noex::string(m_buffer, m_tail);
+        SlideToInitialPos();
+        return noex::string(m_buffer, Size);
+    }
+};

--- a/include/json.h
+++ b/include/json.h
@@ -1,0 +1,436 @@
+#pragma once
+
+#include <assert.h>
+#include "noex/string.hpp"
+#include "noex/vector.hpp"
+#include "noex/new.hpp"
+
+namespace tuwjson {
+
+/*
+ * JSON module which supports RFC8259 (https://datatracker.ietf.org/doc/html/rfc8259)
+ * without unicode escape (\uXXXX).
+ * It also supports C style comments and trailing commas.
+ * Note that this module focuses on parsing small data with small code.
+ * You should use another JSON library if the performance is a consideration for you.
+ */
+
+enum Type : int {
+    JSON_TYPE_NULL = 0,
+    JSON_TYPE_OBJECT,
+    JSON_TYPE_ARRAY,
+    JSON_TYPE_STRING,
+    JSON_TYPE_INT,
+    JSON_TYPE_DOUBLE,
+    JSON_TYPE_BOOL,  // true or false
+    JSON_TYPE_END,  // null terminator
+    JSON_TYPE_UNKNOWN,  // unsupported type
+    JSON_TYPE_MAX,
+};
+
+class Value;
+
+class Item {
+ public:
+    noex::string key;
+    Value* val;
+
+    Item() noexcept : key(), val() {
+        val = noex::new_ref<Value>();
+    }
+    Item(Item&& item) noexcept :
+            key(static_cast<noex::string&&>(item.key)), val(item.val) {
+        item.val = nullptr;
+    }
+
+    ~Item() noexcept {
+        noex::del_ref(val);
+    }
+};
+
+typedef noex::vector<Item> Object;
+typedef noex::vector<Value> Array;
+
+class Value {
+ private:
+    Type m_type;
+    size_t m_line_count;
+    size_t m_column;
+    union {
+        Object* m_object;
+        Array* m_array;
+        noex::string* m_string;
+        int m_int;
+        double m_double;
+        bool m_bool;
+    } u;
+
+ public:
+    Value() noexcept :
+        m_type(JSON_TYPE_NULL), m_line_count(0), m_column(0) {}
+    Value(Value&& val) noexcept :
+        m_type(val.m_type), m_line_count(val.m_line_count),
+        m_column(val.m_column), u(val.u) {
+        val.m_type = JSON_TYPE_NULL;
+    }
+    Value& MoveFrom(Value& val) noexcept {
+        FreeValue();
+        m_type = val.m_type;
+        m_line_count = val.m_line_count;
+        m_column = val.m_column;
+        u = val.u;
+        val.m_type = JSON_TYPE_NULL;
+        return *this;
+    }
+    Value& operator=(Value&& val) noexcept {
+        return MoveFrom(val);
+    }
+    ~Value() noexcept {
+        FreeValue();
+    }
+
+    Type GetType() const noexcept {
+        return m_type;
+    }
+
+    bool HasOffset() const noexcept {
+        return m_line_count > 0;
+    }
+    void GetLineColumn(size_t* line_count, size_t* column) const noexcept {
+        *line_count = m_line_count;
+        *column = m_column;
+    }
+    void SetLineColumn(size_t line_count, size_t column) noexcept {
+        m_line_count = line_count;
+        m_column = column;
+    }
+    noex::string GetLineColumnStr() const noexcept;
+
+    void FreeValue() noexcept;
+    void CopyFrom(const Value& val) noexcept;
+    void Swap(Value& val) noexcept;
+
+    bool operator==(const Value& val) const noexcept;
+    inline bool operator!=(const Value& val) const noexcept {
+        return !(*this == val);
+    }
+
+    // object
+    inline bool IsObject() const noexcept {
+        return m_type == JSON_TYPE_OBJECT;
+    }
+    void SetObject() noexcept;
+    Object* GetObject() const noexcept {
+        assert(IsObject());
+        return u.m_object;
+    }
+    bool HasMember(const char* key) const noexcept;
+    inline bool HasMember(const noex::string& key) const noexcept {
+        return HasMember(key.c_str());
+    }
+    Value& At(const char* key) const noexcept;
+    inline Value& At(const noex::string& key) const noexcept {
+        return At(key.c_str());
+    }
+    inline Value& operator[](const char* key) const noexcept {
+        return At(key);
+    }
+    inline Value& operator[](const noex::string& key) const noexcept {
+        return At(key.c_str());
+    }
+    void ReplaceKey(const char* key, const char* new_key) noexcept;
+    void ConvertToObject(const char* key) noexcept;
+
+    // array
+    inline bool IsArray() const noexcept {
+        return m_type == JSON_TYPE_ARRAY;
+    }
+    void SetArray() noexcept;
+    Array* GetArray() const noexcept {
+        assert(IsArray());
+        return u.m_array;
+    }
+    Value& At(size_t id) const noexcept {
+        assert(IsArray());
+        assert(u.m_array->size() > id);
+        return u.m_array->at(id);
+    }
+    inline Value& At(int id) const noexcept {
+        return At(static_cast<size_t>(id));
+    }
+    inline Value& operator[](size_t id) const noexcept {
+        return At(id);
+    }
+    inline Value& operator[](int id) const noexcept {
+        return At(id);
+    }
+    Value* begin() const noexcept {
+        assert(IsArray());
+        return u.m_array->begin();
+    }
+    Value* end() const noexcept {
+        assert(IsArray());
+        return u.m_array->end();
+    }
+    size_t Size() const noexcept;
+    inline bool IsEmpty() const noexcept {
+        return Size() == 0;
+    }
+    void ConvertToArray() noexcept;
+    inline void MoveAndPush(Value& val) noexcept {
+        assert(IsArray());
+        u.m_array->push_back(static_cast<Value&&>(val));
+    }
+
+    // string
+    inline bool IsString() const noexcept {
+        return m_type == JSON_TYPE_STRING;
+    }
+    void SetString() noexcept;
+    void SetString(const char* val) noexcept {
+        SetString();
+        if (u.m_string)
+            *u.m_string = val;
+    }
+    void SetString(const noex::string& str) noexcept {
+        SetString();
+        if (u.m_string)
+            *u.m_string = str;
+    }
+    void SetString(noex::string&& str) noexcept {
+        SetString();
+        if (u.m_string)
+            *u.m_string = str;
+    }
+    const char* GetString() const noexcept {
+        assert(m_type == JSON_TYPE_STRING);
+        return u.m_string->c_str();
+    }
+
+    // int
+    inline bool IsInt() const noexcept {
+        return m_type == JSON_TYPE_INT;
+    }
+    void SetInt(int val) noexcept {
+        FreeValue();
+        m_type = JSON_TYPE_INT;
+        u.m_int = val;
+    }
+    int GetInt() const noexcept {
+        assert(IsInt());
+        return u.m_int;
+    }
+
+    // double
+    inline bool IsDouble() const noexcept {
+        return m_type == JSON_TYPE_INT || m_type == JSON_TYPE_DOUBLE;
+    }
+    void SetDouble(double val) noexcept {
+        FreeValue();
+        m_type = JSON_TYPE_DOUBLE;
+        u.m_double = val;
+    }
+    double GetDouble() const noexcept {
+        assert(IsDouble());
+        if (IsInt())
+            return static_cast<double>(u.m_int);
+        return u.m_double;
+    }
+
+    // bool
+    inline bool IsBool() const noexcept {
+        return m_type == JSON_TYPE_BOOL;
+    }
+    void SetBool(bool val) noexcept {
+        FreeValue();
+        m_type = JSON_TYPE_BOOL;
+        u.m_bool = val;
+    }
+    bool GetBool() const noexcept {
+        assert(IsBool());
+        return u.m_bool;
+    }
+
+    // null
+    inline bool IsNull() const noexcept {
+        return m_type == JSON_TYPE_NULL;
+    }
+    void SetNull() noexcept {
+        FreeValue();
+        m_type = JSON_TYPE_NULL;
+    }
+};
+
+enum Error : int {
+    JSON_OK = 0,
+    JSON_ERR_ALLOC,  // Allocation error
+    JSON_ERR_UNKNOWN_LITERAL,  // Unknown literal value detected.
+    JSON_ERR_INVALID_UTF,  // Invalid UTF8 character detected.
+    JSON_ERR_INVALID_INT,  // Failed to parse an integer.
+    JSON_ERR_INVALID_DOUBLE,  // Failed to parse a double.
+    JSON_ERR_INVALID_COMMA,  // There is a comma in the wrong position.
+    JSON_ERR_CONTROL_CHAR,  // There is a control character in a string.
+    JSON_ERR_INVALID_ESCAPE,  // Invalid escaped character. \c
+    JSON_ERR_UNICODE_ESCAPE,  // Unicode escape is not supported. \uxxxx
+    JSON_ERR_UNCLOSED_STR,  // " is missing.
+    JSON_ERR_UNCLOSED_COMMENT,  // */ is missing.
+    JSON_ERR_UNCLOSED_ARRAY,  // , or ] is missing.
+    JSON_ERR_EXPECTED_COLON,  // : is missing.
+    JSON_ERR_INVALID_KEY,  // String key is missing.
+    JSON_ERR_DUPLICATED_KEY,  // There is a duplicated key.
+    JSON_ERR_UNCLOSED_OBJECT,  // , or } is missing.
+    JSON_ERR_PARSER_MAX,
+    JSON_ERR_SMALL_BUFFER,  // Writer wants larger buffer.
+    JSON_ERR_NUMBER_FORMAT,  // Failed to convert number to string.
+    JSON_ERR_UNEXPECTED,  // Unexpected error.
+    JSON_ERR_MAX,
+};
+
+class Parser {
+ private:
+    const char* m_ptr;
+    const char* m_line_ptr;
+    size_t m_line_count;
+    Error m_err;
+    noex::string m_err_msg;
+
+    inline char Peek(size_t pos = 0) const noexcept {
+        return *(m_ptr + pos);
+    }
+
+    void Consume() noexcept {
+        if (Peek() == '\n') {
+            m_line_count++;
+            m_line_ptr = m_ptr + 1;
+        }
+        m_ptr++;
+    }
+
+    static inline bool IsSpace(char c) noexcept {
+        return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+    }
+
+    static inline bool IsLiteralEnd(char c) noexcept {
+        return !c || IsSpace(c) || c == ',' || c == ']' || c == '}';
+    }
+
+    static bool IsLiteral(const char* actual, const char* expected) noexcept {
+        while (*actual && *expected) {
+            if (*actual != *expected)
+                return false;
+            actual++;
+            expected++;
+        }
+        return IsLiteralEnd(*actual) && !*expected;
+    }
+
+    inline void ConsumeNonSpace(size_t len = 1) noexcept {
+        m_ptr += len;
+    }
+
+    void SkipSpaces() noexcept {
+        while (IsSpace(Peek()))
+            Consume();
+    }
+
+    bool SkipToValue() noexcept;
+    Type PeekValueType() const noexcept;
+    noex::string ParseString() noexcept;
+    int ParseInt() noexcept;
+    double ParseDouble() noexcept;
+    void ParseArray(Array* array) noexcept;
+    void ParseObject(Object* object) noexcept;
+    void ParseValue(Value* value) noexcept;
+    bool ValidateUTF8(const char* str) noexcept;
+    inline size_t GetColumn() const noexcept {
+        return static_cast<size_t>(m_ptr - m_line_ptr) + 1;
+    }
+
+ public:
+    Parser() noexcept {
+        Init(nullptr);
+    }
+
+    void Init(const char* str) noexcept {
+        m_ptr = str;
+        m_line_ptr = str;
+        m_line_count = 1;
+        m_err = JSON_OK;
+        m_err_msg = "";
+    }
+
+    inline bool HasError() const noexcept {
+        return m_err != JSON_OK;
+    }
+    inline void SetError(Error error) noexcept {
+        assert(m_err == JSON_OK);
+        m_err = error;
+    }
+    inline Error GetError() const noexcept {
+        return m_err;
+    }
+
+    Error ParseJson(const char* json, Value* root) noexcept;
+    inline Error ParseJson(const noex::string& json, Value* root) noexcept {
+        return ParseJson(json.c_str(), root);
+    }
+
+    const char* GetErrMsg() noexcept;
+};
+
+class Writer {
+ private:
+    const char* m_indent_ptr;
+    size_t m_indent_size;
+    bool m_use_linefeed;
+    size_t m_depth;
+
+    char* m_buf;
+    size_t m_buf_size;
+
+    Error m_err;
+
+    void WriteChar(char c) noexcept;
+    void WriteBytes(const char* bytes, size_t size) noexcept;
+    void WriteIndent() noexcept;
+    void WriteLinefeed() noexcept;
+    void WriteString(const char* str) noexcept;
+    void WriteObject(const Object* obj) noexcept;
+    void WriteArray(const Array* ary) noexcept;
+    void WriteValue(const Value* val) noexcept;
+
+ public:
+    Writer() noexcept {
+        Init(nullptr, 0, false);
+    }
+    Writer(const char* indent_ptr, size_t indent_size, bool use_linefeed) noexcept {
+        Init(indent_ptr, indent_size, use_linefeed);
+    }
+
+    void Init(const char* indent_ptr, size_t indent_size, bool use_linefeed) noexcept {
+        m_indent_ptr = indent_ptr;
+        m_indent_size = indent_size;
+        m_use_linefeed = use_linefeed;
+        m_depth = 0;
+        m_buf = nullptr;
+        m_buf_size = 0;
+        m_err = JSON_OK;
+    }
+
+    // returns a pointer to null terminator when succeed. returns null when failed.
+    char* WriteJson(const Value* root, char* buf, size_t buf_size) noexcept;
+
+    inline bool HasError() const noexcept {
+        return m_err != JSON_OK;
+    }
+    inline void SetError(Error error) noexcept {
+        assert(m_err == JSON_OK);
+        m_err = error;
+    }
+    inline Error GetError() const noexcept {
+        return m_err;
+    }
+    const char* GetErrMsg() noexcept;
+};
+
+}  // namespace tuwjson

--- a/include/json_utils.h
+++ b/include/json_utils.h
@@ -35,6 +35,7 @@ FILE* FileOpen(const char* path, const char* mode) noexcept;
 #else
 #define FileOpen(path, mode) fopen(path, mode)
 #endif
+noex::string GetFileError(const noex::string& path) noexcept;
 
 namespace json_utils {
 

--- a/include/json_utils.h
+++ b/include/json_utils.h
@@ -31,8 +31,12 @@ constexpr char CMD_TOKEN_CURRENT_DIR[] = "__CWD__";
 constexpr char CMD_TOKEN_HOME_DIR[] = "__HOME__";
 
 #ifdef _WIN32
-FILE* FileOpen(const char* path, const char* mode) noexcept;
+constexpr wchar_t FILE_MODE_READ[] = L"rb";
+constexpr wchar_t FILE_MODE_WRITE[] = L"wb";
+FILE* FileOpen(const char* path, const wchar_t* mode) noexcept;
 #else
+constexpr char FILE_MODE_READ[] = "rb";
+constexpr char FILE_MODE_WRITE[] = "wb";
 #define FileOpen(path, mode) fopen(path, mode)
 #endif
 noex::string GetFileError(const noex::string& path) noexcept;

--- a/include/json_utils.h
+++ b/include/json_utils.h
@@ -4,6 +4,22 @@
 #include "rapidjson/document.h"
 #include "string_utils.h"
 
+enum ComponentType: int {
+    COMP_UNKNOWN = 0,
+    COMP_EMPTY,
+    COMP_STATIC_TEXT,
+    COMP_FILE,
+    COMP_FOLDER,
+    COMP_COMBO,
+    COMP_RADIO,
+    COMP_CHECK,
+    COMP_CHECK_ARRAY,
+    COMP_TEXT,
+    COMP_INT,
+    COMP_FLOAT,
+    COMP_MAX
+};
+
 enum CmdPredefinedIds: int {
     CMD_ID_PERCENT = -1,
     CMD_ID_CURRENT_DIR = -2,
@@ -32,8 +48,10 @@ struct JsonResult {
 // Max binary size for JSON files.
 #define JSON_SIZE_MAX 128 * 1024
 
-JsonResult LoadJson(const noex::string& file, rapidjson::Document& json) noexcept;
-JsonResult SaveJson(rapidjson::Document& json, const noex::string& file) noexcept;
+// Returns an empty string if succeed. An error message otherwise.
+noex::string LoadJson(const noex::string& file, rapidjson::Document& json) noexcept;
+noex::string SaveJson(rapidjson::Document& json, const noex::string& file) noexcept;
+
 noex::string JsonToString(rapidjson::Document& json) noexcept;
 
 const char* GetString(const rapidjson::Value& json, const char* key, const char* def) noexcept;

--- a/include/json_utils.h
+++ b/include/json_utils.h
@@ -1,7 +1,7 @@
 // Functions related to json.
 
 #pragma once
-#include "rapidjson/document.h"
+#include "json.h"
 #include "string_utils.h"
 
 enum ComponentType: int {
@@ -50,22 +50,19 @@ struct JsonResult {
 #define JSON_SIZE_MAX 128 * 1024
 
 // Returns an empty string if succeed. An error message otherwise.
-noex::string LoadJson(const noex::string& file, rapidjson::Document& json) noexcept;
-noex::string SaveJson(rapidjson::Document& json, const noex::string& file) noexcept;
+noex::string LoadJson(const noex::string& file, tuwjson::Value& json) noexcept;
+noex::string SaveJson(tuwjson::Value& json, const noex::string& file) noexcept;
 
-noex::string JsonToString(rapidjson::Document& json) noexcept;
+const char* GetString(const tuwjson::Value& json, const char* key, const char* def) noexcept;
+bool GetBool(const tuwjson::Value& json, const char* key, bool def) noexcept;
+int GetInt(const tuwjson::Value& json, const char* key, int def) noexcept;
+double GetDouble(const tuwjson::Value& json, const char* key, double def) noexcept;
 
-const char* GetString(const rapidjson::Value& json, const char* key, const char* def) noexcept;
-bool GetBool(const rapidjson::Value& json, const char* key, bool def) noexcept;
-int GetInt(const rapidjson::Value& json, const char* key, int def) noexcept;
-double GetDouble(const rapidjson::Value& json, const char* key, double def) noexcept;
-
-void GetDefaultDefinition(rapidjson::Document& definition) noexcept;
-void CheckVersion(JsonResult& result, rapidjson::Document& definition) noexcept;
-void CheckDefinition(JsonResult& result, rapidjson::Document& definition) noexcept;
-void CheckSubDefinition(JsonResult& result, rapidjson::Value& sub_definition,
-                        int index,
-                        rapidjson::Document::AllocatorType& alloc) noexcept;
-void CheckHelpURLs(JsonResult& result, rapidjson::Document& definition) noexcept;
+void GetDefaultDefinition(tuwjson::Value& definition) noexcept;
+void CheckVersion(JsonResult& result, tuwjson::Value& definition) noexcept;
+void CheckDefinition(JsonResult& result, tuwjson::Value& definition) noexcept;
+void CheckSubDefinition(JsonResult& result, tuwjson::Value& sub_definition,
+                        int index) noexcept;
+void CheckHelpURLs(JsonResult& result, tuwjson::Value& definition) noexcept;
 
 }  // namespace json_utils

--- a/include/main_frame.h
+++ b/include/main_frame.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "rapidjson/document.h"
+#include "json.h"
 #include "component.h"
 #include "json_utils.h"
 #include "string_utils.h"
@@ -13,7 +13,7 @@ struct MenuData {
     int menu_id;
 };
 
-#define EMPTY_DOCUMENT rapidjson::Document(rapidjson::kObjectType)
+#define EMPTY_JSON tuwjson::Value()
 
 // Get "gui_definition.*"
 const char* GetDefaultJsonPath() noexcept;
@@ -21,9 +21,9 @@ const char* GetDefaultJsonPath() noexcept;
 // Main window
 class MainFrame {
  private:
-    rapidjson::Document m_definition;
-    unsigned m_definition_id;
-    rapidjson::Document m_config;
+    tuwjson::Value m_definition;
+    size_t m_definition_id;
+    tuwjson::Value m_config;
     uiWindow* m_mainwin;
 #ifdef __TUW_UNIX__
     uiWindow* m_logwin;
@@ -37,7 +37,7 @@ class MainFrame {
 
     void CreateFrame() noexcept;
     void CreateMenu() noexcept;
-    json_utils::JsonResult CheckDefinition(rapidjson::Document& definition) noexcept;
+    json_utils::JsonResult CheckDefinition(tuwjson::Value& definition) noexcept;
     void UpdateConfig() noexcept;
     void ShowSuccessDialog(const char* msg, const char* title = "Success") noexcept;
     void ShowErrorDialog(const char* msg, const char* title = "Error") noexcept;
@@ -73,27 +73,27 @@ class MainFrame {
     }
 
  public:
-    explicit MainFrame(const rapidjson::Document& definition = EMPTY_DOCUMENT,
-                       const rapidjson::Document& config = EMPTY_DOCUMENT,
+    explicit MainFrame(const tuwjson::Value& definition = EMPTY_JSON,
+                       const tuwjson::Value& config = EMPTY_JSON,
                        const char* json_path = nullptr) noexcept {
         Initialize(definition, config, json_path);
     }
 
     explicit MainFrame(const char* json_path) noexcept {
-        Initialize(EMPTY_DOCUMENT, EMPTY_DOCUMENT, json_path);
+        Initialize(EMPTY_JSON, EMPTY_JSON, json_path);
     }
 
-    void Initialize(const rapidjson::Document& definition,
-                    const rapidjson::Document& config,
+    void Initialize(const tuwjson::Value& definition,
+                    const tuwjson::Value& config,
                     noex::string json_path) noexcept;
 
-    void UpdatePanel(unsigned definition_id) noexcept;
+    void UpdatePanel(size_t definition_id) noexcept;
     noex::string OpenURLBase(int id) noexcept;
     void OpenURL(int id) noexcept;
     bool Validate() noexcept;
     noex::string GetCommand() noexcept;
     void RunCommand() noexcept;
-    void GetDefinition(rapidjson::Document& json) noexcept;
+    void GetDefinition(tuwjson::Value& json) noexcept;
     void SaveConfig() noexcept;
     void Fit(bool keep_width = false) noexcept;
     void Close() noexcept {

--- a/include/main_frame.h
+++ b/include/main_frame.h
@@ -16,7 +16,7 @@ struct MenuData {
 #define EMPTY_DOCUMENT rapidjson::Document(rapidjson::kObjectType)
 
 // Get "gui_definition.*"
-noex::string GetDefaultJsonPath() noexcept;
+const char* GetDefaultJsonPath() noexcept;
 
 // Main window
 class MainFrame {
@@ -41,15 +41,36 @@ class MainFrame {
     void UpdateConfig() noexcept;
     void ShowSuccessDialog(const char* msg, const char* title = "Success") noexcept;
     void ShowErrorDialog(const char* msg, const char* title = "Error") noexcept;
-    inline void ShowSuccessDialog(const noex::string& msg,
-                                  const noex::string& title = "Success") noexcept {
-        ShowSuccessDialog(msg.c_str(), title.c_str());
+    void ShowErrorDialogWithLog(
+        const char* func, const char* msg, const char* title = "Error") noexcept;
+    inline void ShowSuccessDialog(
+            const noex::string& msg,
+            const char* title = "Success") noexcept {
+        ShowSuccessDialog(msg.c_str(), title);
     }
-    inline void ShowErrorDialog(const noex::string& msg,
-                                const noex::string& title = "Error") noexcept {
-        ShowErrorDialog(msg.c_str(), title.c_str());
+    inline void ShowErrorDialog(
+            const noex::string& msg,
+            const char* title = "Error") noexcept {
+        ShowErrorDialog(msg.c_str(), title);
     }
-    void JsonLoadFailed(const noex::string& msg) noexcept;
+    inline void ShowErrorDialogWithLog(
+            const char* func,
+            const noex::string& msg,
+            const char* title = "Error") noexcept {
+        ShowErrorDialogWithLog(func, msg.c_str(), title);
+    }
+    inline void Log(const char* func, const char* msg) noexcept {
+        PrintFmt("[%s] %s\n", func, msg);
+    }
+    inline void Log(const char* func, const char* label, const char* msg) noexcept {
+        PrintFmt("[%s] %s: %s\n", func, label, msg);
+    }
+    inline void Log(const char* func, const noex::string&msg) {
+        Log(func, msg.c_str());
+    }
+    inline void Log(const char* func, const char* label, const noex::string&msg) {
+        Log(func, label, msg.c_str());
+    }
 
  public:
     explicit MainFrame(const rapidjson::Document& definition = EMPTY_DOCUMENT,
@@ -67,7 +88,8 @@ class MainFrame {
                     noex::string json_path) noexcept;
 
     void UpdatePanel(unsigned definition_id) noexcept;
-    noex::string OpenURL(int id) noexcept;
+    noex::string OpenURLBase(int id) noexcept;
+    void OpenURL(int id) noexcept;
     bool Validate() noexcept;
     noex::string GetCommand() noexcept;
     void RunCommand() noexcept;

--- a/include/main_frame.h
+++ b/include/main_frame.h
@@ -8,11 +8,6 @@
 
 class MainFrame;
 
-struct MenuData {
-    MainFrame* main_frame;
-    int menu_id;
-};
-
 #define EMPTY_JSON tuwjson::Value()
 
 // Get "gui_definition.*"
@@ -22,6 +17,7 @@ const char* GetDefaultJsonPath() noexcept;
 class MainFrame {
  private:
     tuwjson::Value m_definition;
+    tuwjson::Value* m_gui_json;
     size_t m_definition_id;
     tuwjson::Value m_config;
     uiWindow* m_mainwin;
@@ -33,7 +29,6 @@ class MainFrame {
     uiGrid* m_grid;
     uiButton* m_run_button;
     uiMenuItem* m_menu_item;
-    noex::vector<MenuData> m_menu_data_vec;
 
     void CreateFrame() noexcept;
     void CreateMenu() noexcept;
@@ -88,8 +83,8 @@ class MainFrame {
                     noex::string json_path) noexcept;
 
     void UpdatePanel(size_t definition_id) noexcept;
-    noex::string OpenURLBase(int id) noexcept;
-    void OpenURL(int id) noexcept;
+    noex::string OpenURLBase(size_t id) noexcept;
+    void OpenURL(size_t id) noexcept;
     bool Validate() noexcept;
     noex::string GetCommand() noexcept;
     void RunCommand() noexcept;

--- a/include/main_frame.h
+++ b/include/main_frame.h
@@ -67,7 +67,7 @@ class MainFrame {
                     noex::string json_path) noexcept;
 
     void UpdatePanel(unsigned definition_id) noexcept;
-    void OpenURL(int id) noexcept;
+    noex::string OpenURL(int id) noexcept;
     bool Validate() noexcept;
     noex::string GetCommand() noexcept;
     void RunCommand() noexcept;

--- a/include/noex/error.hpp
+++ b/include/noex/error.hpp
@@ -4,6 +4,7 @@ namespace noex {
 
 enum ErrorNo : int {
     OK = 0,
+    NEW_ALLOCATION_ERROR,  // Failed to call noex::new() oeperator.
     STR_ALLOCATION_ERROR,  // Failed to allocate memory for string.
     STR_BOUNDARY_ERROR,  // Accessed out-of-bounds with substr or [].
     STR_FORMAT_ERROR,  // Failed to convert a number to string.

--- a/include/noex/new.hpp
+++ b/include/noex/new.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+namespace noex {
+
+template <typename T>
+T* new_ref() {
+    T* obj = reinterpret_cast<T*>(calloc(1, sizeof(T)));
+    if (obj) {
+        if (std::is_trivial<T>::value)
+            new (obj) T();
+    } else {
+        set_error_no(NEW_ALLOCATION_ERROR);
+    }
+    return obj;
+}
+
+template <typename T>
+void del_ref(T* obj) {
+    if (!obj)
+        return;
+    if (std::is_trivial<T>::value)
+        obj->~T();
+    free(obj);
+}
+
+}  // namespace noex

--- a/include/noex/string.hpp
+++ b/include/noex/string.hpp
@@ -66,10 +66,12 @@ class basic_string {
     basic_string operator+(int num) const noexcept;
     basic_string operator+(size_t num) const noexcept;
     basic_string operator+(uint32_t num) const noexcept;
+    basic_string operator+(double num) const noexcept;
 
     static basic_string to_string(int num) noexcept;
     static basic_string to_string(size_t num) noexcept;
     static basic_string to_string(uint32_t num) noexcept;
+    static basic_string to_string(double num) noexcept;
 
     bool operator==(const charT* str) const noexcept;
     bool operator==(const basic_string& str) const noexcept;

--- a/include/noex/string.hpp
+++ b/include/noex/string.hpp
@@ -144,4 +144,9 @@ inline wstring to_wstring(numT num) {
     return wstring::to_string(num);
 }
 
+template <typename charT>
+basic_string<charT> concat_cstr(const charT* str1, const charT* str2) noexcept;
+template <typename charT>
+basic_string<charT> concat_cstr(const charT* str1, const charT* str2, const charT* str3) noexcept;
+
 }  // namespace noex

--- a/include/noex/vector.hpp
+++ b/include/noex/vector.hpp
@@ -65,7 +65,7 @@ class non_trivial_vector {
 
         // Move or copy existing elements to the new memory
         for (size_t i = 0; i < m_size; ++i) {
-            new (data + i) T(std::move(m_data[i]));
+            new (data + i) T(static_cast<T&&>(m_data[i]));
             m_data[i].~T();
         }
 
@@ -155,6 +155,13 @@ class non_trivial_vector {
         return at(m_size - 1);
     }
 
+    void pop_back() noexcept {
+        if (empty())
+            return;
+        back().~T();
+        m_size--;
+    }
+
     void push_back(const T& val) noexcept {
         reserve(m_size + 1);
         if (m_capacity < m_size + 1) return;
@@ -190,7 +197,7 @@ class non_trivial_vector {
 
         // Move or copy existing elements to the new memory
         for (size_t i = 0; i < m_size; ++i) {
-            new (data + i) T(std::move(m_data[i]));
+            new (data + i) T(static_cast<T&&>(m_data[i]));
             m_data[i].~T();
         }
 
@@ -235,6 +242,12 @@ class trivial_vector_base {
     }
 
     void shrink_to_fit() noexcept;
+
+    void pop_back() noexcept {
+        if (empty())
+            return;
+        m_size--;
+    }
 };
 
 // base class for trivial classes

--- a/include/noex/vector.hpp
+++ b/include/noex/vector.hpp
@@ -48,7 +48,7 @@ class non_trivial_vector {
     }
     non_trivial_vector(non_trivial_vector&& vec) noexcept :
             m_data(nullptr), m_size(0), m_capacity(0) {
-        *this = vec;
+        *this = static_cast<non_trivial_vector&&>(vec);
     }
 
     ~non_trivial_vector() noexcept { clear(); }
@@ -125,7 +125,7 @@ class non_trivial_vector {
         reserve(vec.m_capacity);
         if (m_capacity != vec.m_size) return *this;
         for (size_t i = 0; i < vec.m_size; ++i) {
-            new (m_data + i) T(std::move(vec.m_data[i]));
+            new (m_data + i) T(static_cast<T&&>(vec.m_data[i]));
         }
         m_size = vec.m_size;
         vec.clear();
@@ -165,7 +165,7 @@ class non_trivial_vector {
     void push_back(T&& val) noexcept {
         reserve(m_size + 1);
         if (m_capacity < m_size + 1) return;
-        new (m_data + m_size) T(std::move(val));
+        new (m_data + m_size) T(static_cast<T&&>(val));
         m_size++;
     }
 
@@ -249,7 +249,7 @@ class trivial_vector : public trivial_vector_base {
     trivial_vector(const trivial_vector& vec) noexcept :
         trivial_vector_base(vec) {}
     trivial_vector(trivial_vector&& vec) noexcept :
-        trivial_vector_base(vec) {}
+        trivial_vector_base(static_cast<trivial_vector&&>(vec)) {}
 
     trivial_vector& operator=(const trivial_vector& vec) noexcept {
         assign(vec);
@@ -257,7 +257,7 @@ class trivial_vector : public trivial_vector_base {
     }
 
     trivial_vector& operator=(trivial_vector&& vec) noexcept {
-        assign(vec);
+        assign(static_cast<trivial_vector&&>(vec));
         return *this;
     }
 

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -9,7 +9,10 @@ noex::string GetLastLine(const noex::string& str) noexcept;
 // Convert allocated string with env_utils.h into noex::string
 noex::string envuStr(char *cstr) noexcept;
 
-uint32_t Fnv1Hash32(const noex::string& str) noexcept;
+uint32_t Fnv1Hash32(const char* str) noexcept;
+inline uint32_t Fnv1Hash32(const noex::string& str) noexcept {
+    return Fnv1Hash32(str.c_str());
+}
 
 #ifdef _WIN32
 noex::string ANSItoUTF8(const noex::string& str) noexcept;

--- a/include/tuw_constants.h
+++ b/include/tuw_constants.h
@@ -1,44 +1,46 @@
 #pragma once
 namespace tuw_constants {
-    constexpr char LOGO[] =
-        "  _____  \n"
-        " |_   _|   ___      __\n"
-        "   | || | | \\ \\ /\\ / /\n"
-        "   | || |_| |\\ V  V /\n"
-        "   |_| \\__,_| \\_/\\_/\n"
-        "  Tiny UI wrapper for\n"
-        "       CLI tools\n";
-    constexpr char TOOL_NAME[] = "Tuw";
-    constexpr char AUTHOR[] = "matyalatte";
-    constexpr char VERSION[] = "0.9.2";
-    constexpr int VERSION_INT = 902;
+constexpr char LOGO[] =
+    "  _____  \n"
+    " |_   _|   ___      __\n"
+    "   | || | | \\ \\ /\\ / /\n"
+    "   | || |_| |\\ V  V /\n"
+    "   |_| \\__,_| \\_/\\_/\n"
+    "  Tiny UI wrapper for\n"
+    "       CLI tools\n";
+constexpr char TOOL_NAME[] = "Tuw";
+constexpr char AUTHOR[] = "matyalatte";
+constexpr char VERSION[] = "0.9.2";
+constexpr int VERSION_INT = 902;
 
 #ifdef _WIN32
-    #define TUW_CONSTANTS_OS "win"
-    const int GRID_COMP_XSPACE = 2;
-    const int GRID_MAIN_SPACE = 7;
-    const int BOX_MAIN_SPACE = 6;
-    const int BOX_SUB_SPACE = 1;
-    const int BOX_CHECKS_SPACE = 0;
-    const int BTN_WIDTH = 90;
-    const int BTN_HEIGHT = 24;
+#define TUW_CONSTANTS_OS "win"
+const int GRID_COMP_XSPACE = 2;
+const int GRID_MAIN_SPACE = 7;
+const int BOX_MAIN_SPACE = 6;
+const int BOX_SUB_SPACE = 1;
+const int BOX_CHECKS_SPACE = 0;
+const int BTN_WIDTH = 90;
+const int BTN_HEIGHT = 24;
+
 #elif defined(__TUW_UNIX__)
-    #define TUW_CONSTANTS_OS "linux"
-    const int GRID_COMP_XSPACE = 4;
-    const int GRID_MAIN_SPACE = 12;
-    const int BOX_MAIN_SPACE = 12;
-    const int BOX_SUB_SPACE = 4;
-    const int BOX_CHECKS_SPACE = 0;
-    const int BTN_WIDTH = 84;
-    const int BTN_HEIGHT = -1;
+#define TUW_CONSTANTS_OS "linux"
+const int GRID_COMP_XSPACE = 4;
+const int GRID_MAIN_SPACE = 12;
+const int BOX_MAIN_SPACE = 12;
+const int BOX_SUB_SPACE = 4;
+const int BOX_CHECKS_SPACE = 0;
+const int BTN_WIDTH = 84;
+const int BTN_HEIGHT = -1;
+
 #else
-    #define TUW_CONSTANTS_OS "mac"
-    const int GRID_COMP_XSPACE = 4;
-    const int GRID_MAIN_SPACE = 12;
-    const int BOX_MAIN_SPACE = 12;
-    const int BOX_SUB_SPACE = 4;
-    const int BOX_CHECKS_SPACE = 4;
-    const int BTN_WIDTH = 84;
-    const int BTN_HEIGHT = 0;
+#define TUW_CONSTANTS_OS "mac"
+const int GRID_COMP_XSPACE = 4;
+const int GRID_MAIN_SPACE = 12;
+const int BOX_MAIN_SPACE = 12;
+const int BOX_SUB_SPACE = 4;
+const int BOX_CHECKS_SPACE = 4;
+const int BTN_WIDTH = 84;
+const int BTN_HEIGHT = 0;
 #endif
 }  // namespace tuw_constants

--- a/include/tuw_constants.h
+++ b/include/tuw_constants.h
@@ -10,8 +10,8 @@ constexpr char LOGO[] =
     "       CLI tools\n";
 constexpr char TOOL_NAME[] = "Tuw";
 constexpr char AUTHOR[] = "matyalatte";
-constexpr char VERSION[] = "0.9.2";
-constexpr int VERSION_INT = 902;
+constexpr char VERSION[] = "0.10.0";
+constexpr int VERSION_INT = 1000;
 
 #ifdef _WIN32
 #define TUW_CONSTANTS_OS "win"

--- a/include/validator.h
+++ b/include/validator.h
@@ -5,18 +5,18 @@
 
 class Validator {
  private:
-    noex::string m_regex;
-    noex::string m_wildcard;
+    const char* m_regex;
+    const char* m_wildcard;
     bool m_not_empty;
     bool m_exist;
-    noex::string m_regex_error;
-    noex::string m_wildcard_error;
-    noex::string m_not_empty_error;
-    noex::string m_exist_error;
+    const char* m_regex_error;
+    const char* m_wildcard_error;
+    const char* m_not_empty_error;
+    const char* m_exist_error;
     noex::string m_error_msg;
 
  public:
-    Validator() : m_regex(""), m_wildcard(""),
+    Validator() : m_regex(nullptr), m_wildcard(nullptr),
                   m_not_empty(false), m_exist(false),
                   m_error_msg("") {}
     ~Validator() {}

--- a/include/validator.h
+++ b/include/validator.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "rapidjson/document.h"
+#include "json.h"
 
 #include "string_utils.h"
 
@@ -20,7 +20,7 @@ class Validator {
                   m_not_empty(false), m_exist(false),
                   m_error_msg("") {}
     ~Validator() {}
-    void Initialize(const rapidjson::Value& j) noexcept;
+    void Initialize(const tuwjson::Value& j) noexcept;
     bool Validate(const noex::string& str) noexcept;
     const noex::string& GetError() const noexcept { return m_error_msg; }
 };

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ project('Tuw', ['c', 'cpp'],
         'cpp_winlibs=',                 # likewise as with c_winlibs
     ],)
 
+tuw_languages = ['c', 'cpp']
 tuw_sources = []
 tuw_manifest = []
 tuw_link_args = []
@@ -65,10 +66,10 @@ if tuw_OS == 'windows'
     endif
 elif tuw_OS == 'darwin'
     add_languages('objc', required: true)
-    languages = ['c', 'cpp', 'objc']
+    tuw_languages += ['objc']
     macosx_version_min = '-mmacosx-version-min=' + get_option('macosx_version_min')
-    add_global_arguments(macosx_version_min, language: languages)
-    add_global_link_arguments(macosx_version_min, language: languages)
+    add_global_arguments(macosx_version_min, language: tuw_languages)
+    add_global_link_arguments(macosx_version_min, language: tuw_languages)
 
     if get_option('macosx_universal')
         # Check if SDKs support universal binaries or not.
@@ -79,8 +80,8 @@ elif tuw_OS == 'darwin'
             name : 'universal binary test',
             args: arch)
         if result.compiled()
-            add_global_arguments(arch, language: languages)
-            add_global_link_arguments(arch, language: languages)
+            add_global_arguments(arch, language: tuw_languages)
+            add_global_link_arguments(arch, language: tuw_languages)
         else
             warning('Universal build is disabled since your SDKs do not support it.')
         endif
@@ -90,9 +91,6 @@ elif tuw_OS == 'darwin'
         warning('This project has NOT been tested with your compiler. (' + tuw_compiler + ')')
     endif
 else
-    gtkansi_dep = dependency('gtk_ansi_parser', fallback : ['gtk_ansi_parser', 'gtkansi_dep'])
-    tuw_dependencies += [gtkansi_dep]
-
     tuw_link_args += ['-no-pie']
     tuw_cpp_args += ['-D__TUW_UNIX__']
     if tuw_compiler != 'gcc'
@@ -110,7 +108,12 @@ if tuw_OS != 'windows'
     endif
     if tuw_is_release and tuw_OS != 'sunos'
         # Note: solaris requires gld (not ld) to use --gc-sections
-        tuw_cpp_args += ['-ffunction-sections', '-fdata-sections']
+        strip_options = [
+            '-fno-asynchronous-unwind-tables',
+            '-ffunction-sections',
+            '-fdata-sections',
+        ]
+        add_global_arguments(strip_options, language: tuw_languages)
         if tuw_compiler == 'gcc'
             tuw_link_args += ['-Wl,--gc-sections']
         elif tuw_compiler.startswith('clang') and tuw_OS == 'darwin'
@@ -126,6 +129,10 @@ env_utils_dep = dependency('env_utils', fallback : ['env_utils', 'env_utils_dep'
 tiny_str_match_dep = dependency('tiny_str_match', fallback : ['tiny_str_match', 'tiny_str_match_dep'])
 
 tuw_dependencies += [libui_dep, rapidjson_dep, subprocess_dep, env_utils_dep, tiny_str_match_dep]
+if tuw_OS != 'windows' and tuw_OS != 'darwin'
+    gtkansi_dep = dependency('gtk_ansi_parser', fallback : ['gtk_ansi_parser', 'gtkansi_dep'])
+    tuw_dependencies += [gtkansi_dep]
+endif
 
 tuw_sources += [
     'src/main_frame.cpp',

--- a/meson.build
+++ b/meson.build
@@ -139,37 +139,36 @@ tuw_sources += [
     'src/noex/vector.cpp',
 ]
 
-if get_option('build_exe')
-    executable('Tuw',
-        tuw_manifest + tuw_sources + ['src/main.cpp'],
-        dependencies : tuw_dependencies,
-        cpp_args: tuw_cpp_args,
-        link_args: tuw_link_args,
-        gnu_symbol_visibility: 'hidden',
-        include_directories: include_directories('include'),
-        install : false)
-endif
+# build codes as a library for testing
+tuw_lib = library('tuw_lib',
+    tuw_manifest + tuw_sources,
+    dependencies : tuw_dependencies,
+    cpp_args: tuw_cpp_args,
+    link_args: tuw_link_args,
+    include_directories: include_directories('include'),
+    build_rpath: '',
+    install_rpath: '',
+    name_prefix: 'lib',
+    install: false,
+    gnu_symbol_visibility: 'hidden',
+    soversion: '',
+    darwin_versions: [])
+
+tuw_dep = declare_dependency(include_directories: include_directories('include'),
+    dependencies : tuw_dependencies,
+    link_with : tuw_lib)
+
+# main app
+executable('Tuw',
+    tuw_manifest + ['src/main.cpp'],
+    dependencies : tuw_dep,
+    cpp_args: tuw_cpp_args,
+    link_args: tuw_link_args,
+    gnu_symbol_visibility: 'hidden',
+    include_directories: include_directories('include'),
+    install : false)
 
 if get_option('build_test')
-    # build codes as a library
-    tuw_lib = library('tuw_lib',
-        tuw_manifest + tuw_sources,
-        dependencies : tuw_dependencies,
-        cpp_args: tuw_cpp_args,
-        link_args: tuw_link_args,
-        include_directories: include_directories('include'),
-        build_rpath: '',
-        install_rpath: '',
-        name_prefix: 'lib',
-        install: false,
-        gnu_symbol_visibility: 'hidden',
-        soversion: '',
-        darwin_versions: [])
-
-    tuw_dep = declare_dependency(include_directories: include_directories('include'),
-        dependencies : tuw_dependencies,
-	    link_with : tuw_lib)
-
     # get gtest
     gtest_proj = subproject('gtest')
     gtest_dep = gtest_proj.get_variable('gtest_dep')

--- a/meson.build
+++ b/meson.build
@@ -123,12 +123,11 @@ if tuw_OS != 'windows'
 endif
 
 libui_dep = dependency('libui', fallback : ['libui', 'libui_dep'])
-rapidjson_dep = dependency('rapidjson', fallback : ['rapidjson', 'rapidjson_dep'])
 subprocess_dep = dependency('subprocess', fallback : ['subprocess', 'subprocess_dep'])
 env_utils_dep = dependency('env_utils', fallback : ['env_utils', 'env_utils_dep'])
 tiny_str_match_dep = dependency('tiny_str_match', fallback : ['tiny_str_match', 'tiny_str_match_dep'])
 
-tuw_dependencies += [libui_dep, rapidjson_dep, subprocess_dep, env_utils_dep, tiny_str_match_dep]
+tuw_dependencies += [libui_dep, subprocess_dep, env_utils_dep, tiny_str_match_dep]
 if tuw_OS != 'windows' and tuw_OS != 'darwin'
     gtkansi_dep = dependency('gtk_ansi_parser', fallback : ['gtk_ansi_parser', 'gtkansi_dep'])
     tuw_dependencies += [gtkansi_dep]
@@ -142,6 +141,7 @@ tuw_sources += [
     'src/exec.cpp',
     'src/string_utils.cpp',
     'src/validator.cpp',
+    'src/json.cpp',
     'src/noex/string.cpp',
     'src/noex/vector.cpp',
 ]

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,4 @@
-option('build_exe', type : 'boolean', value : true, description : 'Build executable')
-option('build_test', type : 'boolean', value : false, description : 'Build tests')
+option('build_test', type : 'boolean', value : true, description : 'Build tests')
 option('macosx_version_min', type : 'string', value : '10.9',
        description : 'Deployment target for macOS.')
 option('macosx_universal', type : 'boolean', value : false,

--- a/presets/debug.ini
+++ b/presets/debug.ini
@@ -1,6 +1,7 @@
 [built-in options]
 buildtype = 'debug'
 default_library = 'static'
+b_coverage = true
 
 [libui:built-in options]
 buildtype = 'debug'

--- a/presets/release.ini
+++ b/presets/release.ini
@@ -16,10 +16,6 @@ tests = false
 examples = false
 no_area_colorbtn_fontbtn = true
 
-[env_utils:built-in options]
-buildtype = 'custom'
-default_library = 'static'
-
 [env_utils:project options]
 cli = false
 tests = false

--- a/presets/test.ini
+++ b/presets/test.ini
@@ -1,6 +1,0 @@
-[built-in options]
-b_coverage = true
-
-[project options]
-build_exe = false
-build_test = true

--- a/shell_scripts/build.sh
+++ b/shell_scripts/build.sh
@@ -24,7 +24,7 @@ elif [[ "$build_type" == "Release" ]]; then
 fi
 
 pushd $(dirname "$0")/..
-    meson setup build/${build_type} ${preset} ${options} || exit 1
+    meson setup build/${build_type} ${preset} ${options} -Dbuild_test=false || exit 1
     cd build/${build_type}
     meson compile -v || exit 1
 

--- a/shell_scripts/build.sh
+++ b/shell_scripts/build.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Build an executable.
 # Tuw will be generated in ../build/${build_type}
 
-# You can specify build type as an argument like "bash build.sh Debug"
+# You can specify build type as an argument like "./build.sh Debug"
 if [ "$1" = "Debug" ]; then
     build_type="Debug"
     preset="--native-file presets/debug.ini"

--- a/shell_scripts/build_universal.sh
+++ b/shell_scripts/build_universal.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Build an universal binary for macOS.
 # Tuw will be generated in ../build/${build_type}
 
-# You can specify build type as an argument like "bash build_universal.sh Debug"
+# You can specify build type as an argument like "./build_universal.sh Debug"
 if [ "$1" = "Debug" ]; then
     build_type="Debug"
     preset="--native-file presets/debug.ini"

--- a/shell_scripts/build_universal.sh
+++ b/shell_scripts/build_universal.sh
@@ -20,7 +20,7 @@ if [[ "$build_type" == "Release" ]]; then
 fi
 
 pushd $(dirname "$0")/..
-    meson setup build/${build_type} ${preset} -Dmacosx_universal=true ${options} || exit 1
+    meson setup build/${build_type} ${preset} -Dmacosx_universal=true -Dbuild_test=false ${options} || exit 1
     cd build/${build_type}
     meson compile -v || exit 1
 

--- a/shell_scripts/check_glibc_compatibility.sh
+++ b/shell_scripts/check_glibc_compatibility.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Checks required versions of GLIBC and GLIBCXX.
-# bash ./check_glibc_compatibility.sh path/to/your/binary
+# ./check_glibc_compatibility.sh path/to/your/binary
 
 glibc_deps=$(objdump -T $1 | grep GLIBC_ | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -Vu)
 glibcxx_deps=$(objdump -T $1 | grep GLIBCXX_ | sed 's/.*GLIBCXX_\([.0-9]*\).*/\1/g' | sort -Vu)

--- a/shell_scripts/coverage.sh
+++ b/shell_scripts/coverage.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Generate html report for coverage (./Tuw/coverage-report/index.html)
 # It only works with GCC.
 
-# You can specify build type as an argument like "bash coverage.sh Release"
+# You can specify build type as an argument like "./coverage.sh Release"
 if [ "$1" = "Debug" ]; then
     build_type="Debug"
 else

--- a/shell_scripts/exe_info.sh
+++ b/shell_scripts/exe_info.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo Dynamic lib dependencies:
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/shell_scripts/test.sh
+++ b/shell_scripts/test.sh
@@ -4,10 +4,10 @@
 # You can specify build type as an argument like "./test.sh Debug"
 if [ "$1" = "Debug" ]; then
     build_type="Debug"
-    preset="--native-file presets/debug.ini --native-file presets/test.ini"
+    preset="--native-file presets/debug.ini"
 else
     build_type="Release"
-    preset="--native-file presets/release.ini --native-file presets/test.ini -Dcpp_eh=none"
+    preset="--native-file presets/release.ini -Dcpp_eh=none"
 fi
 echo "Build type: ${build_type}"
 

--- a/shell_scripts/test.sh
+++ b/shell_scripts/test.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run tests.
 
-# You can specify build type as an argument like "bash test.sh Debug"
+# You can specify build type as an argument like "./test.sh Debug"
 if [ "$1" = "Debug" ]; then
     build_type="Debug"
     preset="--native-file presets/debug.ini --native-file presets/test.ini"

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -639,7 +639,7 @@ FloatPicker::FloatPicker(uiBox* box, const rapidjson::Value& j) noexcept
         min = max;
         max = x;
     }
-    double inc = json_utils::GetDouble(j, "inc", 1.0);
+    double inc = json_utils::GetDouble(j, "inc", 0.1);
     if (inc < 0)
         inc = -inc;
     else if (inc == 0)

--- a/src/exe_container.cpp
+++ b/src/exe_container.cpp
@@ -77,7 +77,7 @@ noex::string ExeContainer::Read(const noex::string& exe_path) noexcept {
     m_exe_path = exe_path;
     FILE* file_io = FileOpen(exe_path.c_str(), "rb");
     if (!file_io)
-        return "Failed to open " + exe_path;
+        return GetFileError(exe_path);
 
     // Read the last 4 bytes
     fseek(file_io, 0, SEEK_END);
@@ -161,12 +161,12 @@ noex::string ExeContainer::Write(const noex::string& exe_path) noexcept {
 
     FILE* old_io = FileOpen(m_exe_path.c_str(), "rb");
     if (!old_io)
-        return "Failed to open " + m_exe_path;
+        return GetFileError(m_exe_path);
 
     FILE* new_io = FileOpen(exe_path.c_str(), "wb");
     if (!new_io) {
         fclose(old_io);
-        return "Failed to open " + exe_path;
+        return GetFileError(exe_path);
     }
     m_exe_path = exe_path;
 

--- a/src/exe_container.cpp
+++ b/src/exe_container.cpp
@@ -57,13 +57,6 @@ static bool CopyBinary(FILE* reader, FILE* writer, uint32_t size) noexcept {
     return true;
 }
 
-static void ReadMagic(FILE* io, char* magic) noexcept {
-    magic[4] = '\0';
-    if (fread(magic, 1, 4, io) != 4)
-        memset(magic, 0, sizeof(char) * 4);
-    return;
-}
-
 static uint32_t Length(FILE* io) noexcept {
     uint32_t cur = ftell(io);
     fseek(io, 0, SEEK_END);
@@ -72,31 +65,31 @@ static uint32_t Length(FILE* io) noexcept {
     return len;
 }
 
-static const uint32_t EXE_SIZE_MAX = 20000000;  // Allowed size of exe
+constexpr uint32_t EXE_SIZE_MAX = 20000000;  // Allowed size of exe
+constexpr uint32_t JSON_MAGIC = 0x4A534F4E;  // 'J', 'S', 'O', 'N'
 
-json_utils::JsonResult ExeContainer::Read(const noex::string& exe_path) noexcept {
+noex::string ExeContainer::Read(const noex::string& exe_path) noexcept {
     if (noex::get_error_no() != noex::OK) {
         // Reject the operation as the exe_path might have an unexpected value.
-        return { false, "Fatal error has occurred while editing strings or vectors." };
+        return "Fatal error has occurred while editing strings or vectors.";
     }
 
     m_exe_path = exe_path;
     FILE* file_io = FileOpen(exe_path.c_str(), "rb");
     if (!file_io)
-        return { false, "Failed to open " + exe_path };
+        return "Failed to open " + exe_path;
 
     // Read the last 4 bytes
     fseek(file_io, 0, SEEK_END);
     uint32_t end_off = ftell(file_io);
     fseek(file_io, -4, SEEK_CUR);
-    char magic[5];
-    ReadMagic(file_io, magic);
+    uint32_t magic = ReadUint32(file_io);
 
-    if (strcmp(magic, "JSON") != 0) {
+    if (magic != JSON_MAGIC) {
         // Json data not found
         m_exe_size = end_off;
         fclose(file_io);
-        return JSON_RESULT_OK;
+        return "";
     }
 
     // Read exe size
@@ -104,22 +97,27 @@ json_utils::JsonResult ExeContainer::Read(const noex::string& exe_path) noexcept
     m_exe_size = end_off + ReadUint32(file_io);
     if (EXE_SIZE_MAX <= m_exe_size || end_off < m_exe_size) {
         fclose(file_io);
-        return { false, noex::string("Unexpected exe size. (") + m_exe_size + ")" };
+        return noex::concat_cstr(
+            "Unexpected exe size. (",
+            noex::to_string(m_exe_size).c_str(), ")");
     }
     fseek(file_io, m_exe_size, SEEK_SET);
 
     // Read a header for json data
-    ReadMagic(file_io, magic);
-    if (strcmp(magic, "JSON") != 0) {
+    magic = ReadUint32(file_io);
+    if (magic != JSON_MAGIC) {
         fclose(file_io);
-        return { false, noex::string("Invalid magic. (") + magic + ")" };
+        return noex::concat_cstr(
+            "Invalid magic. (", noex::to_string(magic).c_str(), ")");
     }
 
     uint32_t json_size = ReadUint32(file_io);
     uint32_t stored_hash = ReadUint32(file_io);
     if (JSON_SIZE_MAX <= json_size || end_off < m_exe_size + json_size + 20) {
         fclose(file_io);
-        return { false, noex::string("Unexpected json size. (") + json_size + ")" };
+        return noex::concat_cstr(
+            "Unexpected json size. (",
+            noex::to_string(json_size).c_str(), ")");
     }
 
     // Read json data
@@ -127,28 +125,27 @@ json_utils::JsonResult ExeContainer::Read(const noex::string& exe_path) noexcept
     fclose(file_io);
 
     if (json_str.length() != json_size)
-        return { false, "Unexpected char detected." };
+        return "Unexpected char detected.";
 
     if (stored_hash != Fnv1Hash32(json_str))
-        return { false, noex::string("Invalid JSON hash. (") + stored_hash + ")" };
+        return noex::concat_cstr(
+            "Invalid JSON hash. (", noex::to_string(stored_hash).c_str(), ")");
 
     rapidjson::ParseResult ok = m_json.Parse(json_str.c_str());
     if (!ok) {
-        return {
-            false,
-            noex::string("Failed to parse JSON: ") +
-                rapidjson::GetParseError_En(ok.Code()) +
-                " (offset: " + ok.Offset() + ")"
-        };
+        return noex::concat_cstr(
+            "Failed to parse JSON: ",
+            rapidjson::GetParseError_En(ok.Code()),
+            " (offset: ") + ok.Offset() + ")";
     }
 
-    return JSON_RESULT_OK;
+    return "";
 }
 
-json_utils::JsonResult ExeContainer::Write(const noex::string& exe_path) noexcept {
+noex::string ExeContainer::Write(const noex::string& exe_path) noexcept {
     if (noex::get_error_no() != noex::OK) {
         // Reject the operation as the exe_path might have an unexpected value.
-        return { false, "Fatal error has occurred while editing strings or vectors." };
+        return "Fatal error has occurred while editing strings or vectors.";
     }
 
     assert(!m_exe_path.empty());
@@ -158,16 +155,18 @@ json_utils::JsonResult ExeContainer::Write(const noex::string& exe_path) noexcep
 
     uint32_t json_size = static_cast<uint32_t>(json_str.length());
     if (JSON_SIZE_MAX <= json_size)
-        return { false, noex::string("Unexpected json size. (") + json_size + ")" };
+        return noex::concat_cstr(
+            "Unexpected json size. (",
+            noex::to_string(json_size).c_str(), ")");
 
     FILE* old_io = FileOpen(m_exe_path.c_str(), "rb");
     if (!old_io)
-        return { false, "Failed to open a file. (" + m_exe_path + ")" };
+        return "Failed to open " + m_exe_path;
 
     FILE* new_io = FileOpen(exe_path.c_str(), "wb");
     if (!new_io) {
         fclose(old_io);
-        return { false, "Failed to open a file. (" + exe_path + ")" };
+        return "Failed to open " + exe_path;
     }
     m_exe_path = exe_path;
 
@@ -175,34 +174,35 @@ json_utils::JsonResult ExeContainer::Write(const noex::string& exe_path) noexcep
     if (!ok) {
         fclose(old_io);
         fclose(new_io);
-        return { false, "Failed to copy the original executable (" +
-                        m_exe_path + ")" };
+        return noex::concat_cstr(
+            "Failed to copy the original executable (",
+            m_exe_path.c_str(), ")");
     }
 
     uint32_t pos = ftell(old_io);
     if (pos != Length(old_io)) {
-        char magic[5];
-        ReadMagic(old_io, magic);
-        if (strcmp(magic, "JSON") != 0) {
+        uint32_t magic = ReadUint32(old_io);
+        if (magic != JSON_MAGIC) {
             fclose(old_io);
             fclose(new_io);
-            return { false, noex::string("Invalid magic. (") + magic + ")" };
+            return noex::concat_cstr(
+                "Invalid magic. (", noex::to_string(magic).c_str(), ")");
         }
     }
 
     fclose(old_io);
     if (json_size == 0) {
         fclose(new_io);
-        return JSON_RESULT_OK;
+        return "";
     }
 
     // Write json data
-    fwrite("JSON", 1, 4, new_io);
+    WriteUint32(new_io, JSON_MAGIC);
     WriteUint32(new_io, json_size);
     WriteUint32(new_io, Fnv1Hash32(json_str));
     WriteStr(new_io, json_str);
     WriteUint32(new_io, m_exe_size - ftell(new_io) - 8);
-    fwrite("JSON", 1, 4, new_io);
+    WriteUint32(new_io, JSON_MAGIC);
     fclose(new_io);
-    return JSON_RESULT_OK;
+    return "";
 }

--- a/src/exe_container.cpp
+++ b/src/exe_container.cpp
@@ -1,10 +1,7 @@
 #include "exe_container.h"
 #include <cassert>
 
-#include "rapidjson/stringbuffer.h"
-#include "rapidjson/writer.h"
-#include "rapidjson/error/en.h"
-
+#include "json.h"
 #include "string_utils.h"
 
 static uint32_t ReadUint32(FILE* io) noexcept {
@@ -28,15 +25,15 @@ static void WriteUint32(FILE* io, const uint32_t& num) noexcept {
 #define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
 #define BUF_SIZE 1024
 
-static noex::string ReadStr(FILE* io, const uint32_t& size) noexcept {
+static noex::string ReadStr(FILE* io, uint32_t size) noexcept {
     noex::string str(size);
     if (fread(str.data(), 1, size, io) != size)
         return "";
     return str;
 }
 
-static void WriteStr(FILE* io, const noex::string& str) noexcept {
-    fwrite(str.data(), 1, str.size(), io);
+static void WriteStr(FILE* io, const char* str, uint32_t size) noexcept {
+    fwrite(str, 1, size, io);
 
     // Zero padding
     size_t padding = (8 - ftell(io) % 8) % 8;
@@ -131,13 +128,10 @@ noex::string ExeContainer::Read(const noex::string& exe_path) noexcept {
         return noex::concat_cstr(
             "Invalid JSON hash. (", noex::to_string(stored_hash).c_str(), ")");
 
-    rapidjson::ParseResult ok = m_json.Parse(json_str.c_str());
-    if (!ok) {
-        return noex::concat_cstr(
-            "Failed to parse JSON: ",
-            rapidjson::GetParseError_En(ok.Code()),
-            " (offset: ") + ok.Offset() + ")";
-    }
+    tuwjson::Parser parser;
+    parser.ParseJson(json_str, &m_json);
+    if (parser.HasError())
+        return noex::concat_cstr("Failed to parse JSON: ", parser.GetErrMsg());
 
     return "";
 }
@@ -149,11 +143,17 @@ noex::string ExeContainer::Write(const noex::string& exe_path) noexcept {
     }
 
     assert(!m_exe_path.empty());
-    noex::string json_str;
-    if (HasJson())
-        json_str = json_utils::JsonToString(m_json);
+    char json_buffer[JSON_SIZE_MAX];
+    uint32_t json_size = 0;
+    if (HasJson()) {
+        tuwjson::Writer writer;
+        char* end = writer.WriteJson(&m_json, json_buffer, JSON_SIZE_MAX);
+        if (end)
+            json_size = static_cast<uint32_t>(end - json_buffer);
+        else
+            return writer.GetErrMsg();
+    }
 
-    uint32_t json_size = static_cast<uint32_t>(json_str.length());
     if (JSON_SIZE_MAX <= json_size)
         return noex::concat_cstr(
             "Unexpected json size. (",
@@ -199,8 +199,8 @@ noex::string ExeContainer::Write(const noex::string& exe_path) noexcept {
     // Write json data
     WriteUint32(new_io, JSON_MAGIC);
     WriteUint32(new_io, json_size);
-    WriteUint32(new_io, Fnv1Hash32(json_str));
-    WriteStr(new_io, json_str);
+    WriteUint32(new_io, Fnv1Hash32(json_buffer));
+    WriteStr(new_io, json_buffer, json_size);
     WriteUint32(new_io, m_exe_size - ftell(new_io) - 8);
     WriteUint32(new_io, JSON_MAGIC);
     fclose(new_io);

--- a/src/exe_container.cpp
+++ b/src/exe_container.cpp
@@ -72,7 +72,7 @@ noex::string ExeContainer::Read(const noex::string& exe_path) noexcept {
     }
 
     m_exe_path = exe_path;
-    FILE* file_io = FileOpen(exe_path.c_str(), "rb");
+    FILE* file_io = FileOpen(exe_path.c_str(), FILE_MODE_READ);
     if (!file_io)
         return GetFileError(exe_path);
 
@@ -159,11 +159,11 @@ noex::string ExeContainer::Write(const noex::string& exe_path) noexcept {
             "Unexpected json size. (",
             noex::to_string(json_size).c_str(), ")");
 
-    FILE* old_io = FileOpen(m_exe_path.c_str(), "rb");
+    FILE* old_io = FileOpen(m_exe_path.c_str(), FILE_MODE_READ);
     if (!old_io)
         return GetFileError(m_exe_path);
 
-    FILE* new_io = FileOpen(exe_path.c_str(), "wb");
+    FILE* new_io = FileOpen(exe_path.c_str(), FILE_MODE_WRITE);
     if (!new_io) {
         fclose(old_io);
         return GetFileError(exe_path);

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -96,7 +96,8 @@ class RedirectContext {
 
     noex::string GetLastChars() noexcept {
         noex::string str = m_last_chars.ToString();
-        ReplaceFirstCharsWithDots(&str);
+        if (m_last_chars.IsFull())
+            ReplaceFirstCharsWithDots(&str);
         return str;
     }
 

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -1,0 +1,752 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
+#include "json.h"
+#include "noex/error.hpp"
+#include "noex/new.hpp"
+
+namespace tuwjson {
+
+// Value
+
+bool Value::operator==(const Value& val) const noexcept {
+    if (m_type != val.m_type)
+        return false;
+    if (m_type == JSON_TYPE_OBJECT) {
+        if (val.Size() != Size())
+            return false;
+        for (const Item& item : *val.u.m_object) {
+            if (!HasMember(item.key))
+                return false;
+            if (*item.val != At(item.key))
+                return false;
+        }
+    } else if (m_type == JSON_TYPE_ARRAY) {
+        if (val.Size() != Size())
+            return false;
+        for (size_t i = 0; i < Size(); i++) {
+            if (At(i) != val[i])
+                return false;
+        }
+    } else if (m_type == JSON_TYPE_STRING) {
+        return *u.m_string == *val.u.m_string;
+    } else if (m_type == JSON_TYPE_INT) {
+        return GetInt() == val.GetInt();
+    } else if (m_type == JSON_TYPE_DOUBLE) {
+        double diff = GetDouble() - val.GetDouble();
+        if (diff < 0)
+            diff = -diff;
+        return diff < 0.00001;
+    } else if (m_type == JSON_TYPE_BOOL) {
+        return GetBool() == val.GetBool();
+    }
+    return true;
+}
+
+static noex::string LineColumnToStr(size_t line_count, size_t column) noexcept {
+    if (line_count <= 0)
+        return "";
+    return " (line: " + noex::to_string(line_count) +
+            ", column: " + noex::to_string(column) + ")";
+}
+
+noex::string Value::GetLineColumnStr() const noexcept {
+    return LineColumnToStr(m_line_count, m_column);
+}
+
+void Value::FreeValue() noexcept {
+    if (m_type == JSON_TYPE_OBJECT && u.m_object) {
+        noex::del_ref(u.m_object);
+    } else if (m_type == JSON_TYPE_ARRAY && u.m_array) {
+        noex::del_ref(u.m_array);
+    } else if (m_type == JSON_TYPE_STRING && u.m_string) {
+        noex::del_ref(u.m_string);
+    }
+}
+
+void Value::CopyFrom(const Value& val) noexcept {
+    Type type = val.m_type;
+    m_line_count = val.m_line_count;
+    m_column = val.m_column;
+    if (type == JSON_TYPE_OBJECT) {
+        SetObject();
+        for (const Item& item : *val.u.m_object) {
+            Value& new_v = At(item.key);
+            new_v.CopyFrom(*item.val);
+        }
+    } else if (type == JSON_TYPE_ARRAY) {
+        SetArray();
+        for (const Value& v : val) {
+            Value new_v;
+            new_v.CopyFrom(v);
+            u.m_array->push_back(static_cast<Value&&>(new_v));
+        }
+    } else if (type == JSON_TYPE_STRING) {
+        SetString(*val.u.m_string);
+    } else if (type == JSON_TYPE_INT) {
+        SetInt(val.u.m_int);
+    } else if (type == JSON_TYPE_DOUBLE) {
+        SetDouble(val.u.m_double);
+    } else if (type == JSON_TYPE_BOOL) {
+        SetBool(val.u.m_bool);
+    }
+    return;
+}
+
+void Value::Swap(Value& val) noexcept {
+    Value tmp;
+    tmp.MoveFrom(val);
+    val.MoveFrom(*this);
+    MoveFrom(tmp);
+}
+
+void Value::SetObject() noexcept {
+    FreeValue();
+    m_type = JSON_TYPE_OBJECT;
+    u.m_object = noex::new_ref<Object>();
+}
+
+static bool object_has_member(const Object* obj, const char* key) {
+    for (const Item& item : *obj) {
+        if (item.key == key)
+            return true;
+    }
+    return false;
+}
+
+bool Value::HasMember(const char* key) const noexcept {
+    assert(m_type == JSON_TYPE_OBJECT);
+    return object_has_member(u.m_object, key);
+}
+
+Value& Value::At(const char* key) const noexcept {
+    assert(m_type == JSON_TYPE_OBJECT);
+    static Value dummy{};
+    for (Item& item : *u.m_object) {
+        if (item.key == key) {
+            if (item.val)
+                return *item.val;
+            break;
+        }
+    }
+    Item item;
+    item.key = key;
+    u.m_object->push_back(static_cast<Item&&>(item));
+    return *u.m_object->back().val;
+}
+
+void Value::ReplaceKey(const char* key, const char* new_key) noexcept {
+    assert(m_type == JSON_TYPE_OBJECT);
+    for (Item& item : *u.m_object) {
+        if (item.key == key) {
+            item.key = new_key;
+            break;
+        }
+    }
+}
+
+void Value::ConvertToObject(const char* key) noexcept {
+    Object* object = u.m_object;
+    Type type = m_type;
+    u.m_object = nullptr;
+    m_type = JSON_TYPE_NULL;
+    SetObject();
+    Item item;
+    item.key = key;
+    item.val->u.m_object = object;
+    item.val->m_type = type;
+    u.m_object->push_back(static_cast<Item&&>(item));
+}
+
+size_t Value::Size() const noexcept {
+    assert(m_type == JSON_TYPE_OBJECT || m_type == JSON_TYPE_ARRAY);
+    if (m_type == JSON_TYPE_OBJECT)
+        return u.m_object->size();
+    if (m_type == JSON_TYPE_ARRAY)
+        return u.m_array->size();
+    return 0;
+}
+
+void Value::SetArray() noexcept {
+    FreeValue();
+    m_type = JSON_TYPE_ARRAY;
+    u.m_array = noex::new_ref<Array>();
+}
+
+void Value::ConvertToArray() noexcept {
+    Array* array = u.m_array;
+    Type type = m_type;
+    u.m_array = nullptr;
+    m_type = JSON_TYPE_NULL;
+    SetArray();
+    Value val;
+    val.u.m_array = array;
+    val.m_type = type;
+    u.m_array->push_back(static_cast<Value&&>(val));
+}
+
+void Value::SetString() noexcept {
+    FreeValue();
+    m_type = JSON_TYPE_STRING;
+    u.m_string = noex::new_ref<noex::string>();
+}
+
+// Parser
+bool Parser::SkipToValue() noexcept {
+    while (true) {
+        SkipSpaces();
+        if (Peek() == '/' && Peek(1) == '/') {
+            while (Peek() && Peek() != '\n')
+                ConsumeNonSpace();
+        } else if (Peek() == '/' && Peek(1) == '*') {
+            ConsumeNonSpace(2);
+            while (Peek() && !(Peek() == '*' && Peek(1) == '/')) {
+                Consume();
+            }
+            if (Peek() == '*' && Peek(1) == '/') {
+                ConsumeNonSpace(2);
+            } else {
+                m_err = JSON_ERR_UNCLOSED_COMMENT;
+                return false;
+            }
+        } else {
+            break;
+        }
+    }
+    return true;
+}
+
+Type Parser::PeekValueType() const noexcept {
+    char c = Peek();
+    if (c == '{')
+        return JSON_TYPE_OBJECT;
+    if (c == '[')
+        return JSON_TYPE_ARRAY;
+    if (c == '"')
+        return JSON_TYPE_STRING;
+    if (c == '-' || ('0' <= c && c <= '9')) {
+        const char* s = m_ptr + 1;
+        while ('0' <= *s && *s <= '9')
+            s++;
+        if (*s != '.' && *s != 'e' && *s != 'E')
+            return JSON_TYPE_INT;
+        if (*s == '.') {
+            s++;
+            while ('0' <= *s && *s <= '9')
+                s++;
+        }
+        if (*s == 'e' || *s == 'E') {
+            s++;
+            if (*s == '-')
+                s++;
+            while ('0' <= *s && *s <= '9')
+                s++;
+        }
+        if (IsLiteralEnd(*s))
+            return JSON_TYPE_DOUBLE;
+        return JSON_TYPE_UNKNOWN;
+    }
+    if (IsLiteral(m_ptr, "null")) {
+        return JSON_TYPE_NULL;
+    }
+    if (IsLiteral(m_ptr, "true") || IsLiteral(m_ptr, "false")) {
+        return JSON_TYPE_BOOL;
+    }
+    return JSON_TYPE_UNKNOWN;
+}
+
+#define CONTROL_CHAR_MAX 0x1F  // control characters 0x00 ~ 0x1F
+#define is_control_char(c) (static_cast<uint8_t>(c) <= CONTROL_CHAR_MAX)
+
+noex::string Parser::ParseString() noexcept {
+    const char* s = m_ptr + 1;
+    size_t len = 0;
+    while (*s && *s != '\n' && *s != '"') {
+        if (*s == '\\' && s[1]) {
+            s++;
+        }
+        len++;
+        s++;
+    }
+    if (!*s || *s == '\n') {
+        m_err = JSON_ERR_UNCLOSED_STR;
+        m_ptr = s - 1;
+        return "";
+    }
+    noex::string buf(len);
+    char* cstr = buf.data();
+    if (!cstr) {
+        m_err = JSON_ERR_ALLOC;
+        return "";
+    }
+    ConsumeNonSpace();
+    while (Peek() != '"') {
+        char c = Peek();
+        if (c == '\\') {
+            ConsumeNonSpace();
+            c = Peek();
+            if (c == '"' || c == '\\' || c == '/') {
+                *cstr = c;
+            } else if (c == 'b') {
+                *cstr = '\b';
+            } else if (c == 'f') {
+                *cstr = '\f';
+            } else if (c == 'n') {
+                *cstr = '\n';
+            } else if (c == 'r') {
+                *cstr = '\r';
+            } else if (c == 't') {
+                *cstr = '\t';
+            } else {
+                if (c == 'u')
+                    m_err = JSON_ERR_UNICODE_ESCAPE;
+                else if (is_control_char(c))
+                    m_err = JSON_ERR_CONTROL_CHAR;
+                else
+                    m_err = JSON_ERR_INVALID_ESCAPE;
+                return "";
+            }
+        } else if (is_control_char(c)) {
+            m_err = JSON_ERR_CONTROL_CHAR;
+            return "";
+        } else {
+            *cstr = c;
+        }
+        cstr++;
+        ConsumeNonSpace();
+    }
+    ConsumeNonSpace();
+    return buf;
+}
+
+int Parser::ParseInt() noexcept {
+    char* endptr;
+    errno = 0;
+    int value = static_cast<int>(strtol(m_ptr, &endptr, 10));
+    if (errno) {
+        m_err = JSON_ERR_INVALID_INT;
+        return 0;
+    }
+    ConsumeNonSpace(static_cast<size_t>(endptr - m_ptr));
+    return value;
+}
+
+double Parser::ParseDouble() noexcept {
+    char* endptr;
+    errno = 0;
+    double value = strtod(m_ptr, &endptr);
+    if (errno) {
+        m_err = JSON_ERR_INVALID_DOUBLE;
+        return 0.0;
+    }
+    ConsumeNonSpace(static_cast<size_t>(endptr - m_ptr));
+    return value;
+}
+
+void Parser::ParseArray(Array* array) noexcept {
+    bool comma_exists = true;
+    while (true) {
+        if (!SkipToValue())
+            return;
+        if (!Peek()) {
+            m_err = JSON_ERR_UNCLOSED_ARRAY;
+            return;
+        }
+        if (Peek() == ']') {
+            ConsumeNonSpace();
+            break;
+        }
+        if (!comma_exists) {
+            m_err = JSON_ERR_UNCLOSED_ARRAY;
+            return;
+        }
+        Value val;
+        ParseValue(&val);
+        array->push_back(static_cast<Value&&>(val));
+        if (noex::get_error_no() != noex::OK)
+            m_err = JSON_ERR_ALLOC;
+        if (HasError())
+            return;
+        if (!SkipToValue())
+            return;
+        comma_exists = Peek() == ',';
+        if (comma_exists)
+            ConsumeNonSpace();
+    }
+}
+
+void Parser::ParseObject(Object* object) noexcept {
+    bool comma_exists = true;
+    while (true) {
+        if (!SkipToValue())
+            return;
+        if (!Peek()) {
+            m_err = JSON_ERR_UNCLOSED_OBJECT;
+            return;
+        }
+        if (Peek() == '}') {
+            ConsumeNonSpace();
+            break;
+        }
+        if (!comma_exists) {
+            m_err = JSON_ERR_UNCLOSED_OBJECT;
+            return;
+        }
+        if (PeekValueType() != JSON_TYPE_STRING) {
+            m_err = JSON_ERR_INVALID_KEY;
+            return;
+        }
+        Item item;
+        const char* str_ptr = m_ptr;
+        item.key = ParseString();
+        if (HasError())
+            return;
+        if (object_has_member(object, item.key.c_str())) {
+            m_ptr = str_ptr;
+            m_err = JSON_ERR_DUPLICATED_KEY;
+            return;
+        }
+        if (!SkipToValue())
+            return;
+        if (Peek() != ':') {
+            m_err = JSON_ERR_EXPECTED_COLON;
+            return;
+        }
+        ConsumeNonSpace();
+
+        ParseValue(item.val);
+        object->push_back(static_cast<Item&&>(item));
+        if (noex::get_error_no() != noex::OK)
+            m_err = JSON_ERR_ALLOC;
+        if (HasError())
+            return;
+        if (!SkipToValue())
+            return;
+        comma_exists = Peek() == ',';
+        if (comma_exists)
+            ConsumeNonSpace();
+    }
+}
+
+void Parser::ParseValue(Value* value) noexcept {
+    if (!value)
+        return;
+    if (!SkipToValue())
+        return;
+    Type type = PeekValueType();
+    value->SetLineColumn(m_line_count, GetColumn());
+    if (type == JSON_TYPE_OBJECT) {
+        ConsumeNonSpace();
+        value->SetObject();
+        Object* object = value->GetObject();
+        if (!object) {
+            m_err = JSON_ERR_ALLOC;
+            return;
+        }
+        ParseObject(object);
+    } else if (type == JSON_TYPE_ARRAY) {
+        ConsumeNonSpace();
+        value->SetArray();
+        Array* array = value->GetArray();
+        if (!array) {
+            m_err = JSON_ERR_ALLOC;
+            return;
+        }
+        ParseArray(array);
+    } else if (type == JSON_TYPE_STRING) {
+        value->SetString(ParseString());
+    } else if (type == JSON_TYPE_INT) {
+        value->SetInt(ParseInt());
+    } else if (type == JSON_TYPE_DOUBLE) {
+        value->SetDouble(ParseDouble());
+    } else if (type == JSON_TYPE_BOOL) {
+        bool val = Peek() == 't';
+        value->SetBool(val);
+        ConsumeNonSpace(val ? 4 : 5);
+    } else if (type == JSON_TYPE_NULL) {
+        ConsumeNonSpace(4);
+    } else if (type == JSON_TYPE_UNKNOWN) {
+        char c = Peek();
+        if (c == ',')
+            m_err = JSON_ERR_INVALID_COMMA;
+        else if (c)
+            m_err = JSON_ERR_UNKNOWN_LITERAL;
+    }
+}
+
+#define ASCII_MAX 0x7F  // ascii 0x00 ~ 0x7F
+#define MULTIBYTE_SEQ_MAX 0xBF  // sequences for multibyte characters 0x80 ~ 0xBF
+#define TWO_BYTE_MIN 0xC2  // two-byte characters 0xC2 ~
+#define TWO_BYTE_MAX 0xDF  // two-byte characters ~ 0xDF
+#define THREE_BYTE_MAX 0xEF  // three-byte characters 0xE0 ~ 0xEF
+#define FOUR_BYTE_MAX 0xF4  // four-byte characters 0xF0 ~ 0xF4
+// unused codes 0xF5 ~ 0xFF
+
+#define is_multibyte_seq(c) ((ASCII_MAX < (c)) && ((c) <= MULTIBYTE_SEQ_MAX))
+
+bool Parser::ValidateUTF8(const char* str) noexcept {
+    size_t line_count = 1;
+    const char* ptr = str;
+    const char* line_ptr = str;
+    size_t multibyte_seq = 0;
+    bool valid = true;
+    while (*ptr) {
+        uint8_t c = static_cast<uint8_t>(*ptr);
+        if (multibyte_seq <= 0) {
+            if (c <= ASCII_MAX) {
+            } else if (c < TWO_BYTE_MIN) {
+                valid = false;
+                break;
+            } else if (c <= TWO_BYTE_MAX) {
+                multibyte_seq = 1;
+            } else if (c <= THREE_BYTE_MAX) {
+                multibyte_seq = 2;
+            } else if (c <= FOUR_BYTE_MAX) {
+                multibyte_seq = 3;
+            } else {
+                valid = false;
+                break;
+            }
+        } else {
+            if (!is_multibyte_seq(c)) {
+                valid = false;
+                break;
+            }
+            multibyte_seq--;
+        }
+        if (c == '\n') {
+            line_count++;
+            line_ptr = ptr;
+        }
+        ptr++;
+    }
+    if (!valid) {
+        m_line_count = line_count;
+        m_line_ptr = line_ptr;
+        m_ptr = ptr;
+        m_err = JSON_ERR_INVALID_UTF;
+    }
+    return valid;
+}
+
+Error Parser::ParseJson(const char* json, Value* root) noexcept {
+    Init(json);
+    if (!ValidateUTF8(json))
+        return m_err;
+    ParseValue(root);
+    return m_err;
+}
+
+static const char* get_def_err_msg(Error err) noexcept {
+    if (err == JSON_ERR_ALLOC)
+        return "Memory allocation error.";
+    if (err == JSON_ERR_UNKNOWN_LITERAL)
+        return "unknown literal detected";
+    if (err == JSON_ERR_INVALID_UTF)
+        return "invalid UTF8 character detected";
+    if (err == JSON_ERR_INVALID_INT)
+        return "failed to parse an integer";
+    if (err == JSON_ERR_INVALID_DOUBLE)
+        return "failed to parse a double number";
+    if (err == JSON_ERR_INVALID_COMMA)
+        return "there is a comma in the wrong position";
+    if (err == JSON_ERR_CONTROL_CHAR)
+        return "there is a control character in a string";
+    if (err == JSON_ERR_INVALID_ESCAPE)
+        return "invalid escaped character: \\";
+    if (err == JSON_ERR_UNICODE_ESCAPE)
+        return "unicode escape (\\uXXXX) is not supported. use UTF-8 characters instead";
+    if (err == JSON_ERR_UNCLOSED_STR)
+        return "string is not closed with '\"'";
+    if (err == JSON_ERR_UNCLOSED_COMMENT)
+        return "multiline comment is not closed";
+    if (err == JSON_ERR_UNCLOSED_ARRAY)
+        return "comma ',' or closing bracket ']' is missing";
+    if (err == JSON_ERR_UNCLOSED_OBJECT)
+        return "comma ',' or closing brace '}' is missing";
+    if (err == JSON_ERR_EXPECTED_COLON)
+        return "colon ':' is missing";
+    if (err == JSON_ERR_INVALID_KEY)
+        return "string key is missing";
+    if (err == JSON_ERR_DUPLICATED_KEY)
+        return "there is a duplicated key";
+    if (err == JSON_ERR_SMALL_BUFFER)
+        return "JSON writer requires a larger buffer";
+    if (err == JSON_ERR_NUMBER_FORMAT)
+        return "failed to convert a number to string";
+    if (err == JSON_ERR_UNEXPECTED)
+        return "unexpected error has occurred";
+    return "";
+}
+
+const char* Parser::GetErrMsg() noexcept {
+    const char* msg = get_def_err_msg(m_err);
+    if (m_err == JSON_OK ||
+        m_err == JSON_ERR_ALLOC ||
+        m_err >= JSON_ERR_PARSER_MAX)
+        return msg;
+
+    m_err_msg = msg;
+    if (m_err == JSON_ERR_INVALID_ESCAPE)
+        m_err_msg.push_back(*m_ptr);
+
+    m_err_msg += LineColumnToStr(m_line_count, GetColumn());
+    return m_err_msg.c_str();
+}
+
+void Writer::WriteChar(char c) noexcept {
+    if (!m_buf)
+        return;
+    if (m_buf_size <= 1) {
+        m_buf = nullptr;
+        return;
+    }
+    *m_buf = c;
+    m_buf++;
+    m_buf_size--;
+}
+
+void Writer::WriteBytes(const char* bytes, size_t size) noexcept {
+    if (!m_buf)
+        return;
+    if (m_buf_size <= size) {
+        m_buf = nullptr;
+        return;
+    }
+    memcpy(m_buf, bytes, size);
+    m_buf += size;
+    m_buf_size -= size;
+}
+
+void Writer::WriteIndent() noexcept {
+    for (size_t i = 0; i < m_depth; i++)
+        WriteBytes(m_indent_ptr, m_indent_size);
+}
+
+void Writer::WriteLinefeed() noexcept {
+    if (m_use_linefeed)
+        WriteChar('\n');
+}
+
+static bool need_escape(char c) noexcept {
+    return c == '"' || c == '\\' || c == '\b' ||
+            c == '\f' || c == '\n' || c == '\r' || c == '\t';
+}
+
+void Writer::WriteString(const char* str) noexcept {
+    WriteChar('"');
+    while (*str && m_buf) {
+        char c = *str;
+        if (need_escape(c))
+            WriteChar('\\');
+        if (c == '\b') {
+            WriteChar('b');
+        } else if (c == '\f') {
+            WriteChar('f');
+        } else if (c == '\n') {
+            WriteChar('n');
+        } else if (c == '\r') {
+            WriteChar('r');
+        } else if (c == '\t') {
+            WriteChar('t');
+        } else {
+            WriteChar(c);
+        }
+        str++;
+    }
+    WriteChar('"');
+}
+
+void Writer::WriteObject(const Object* obj) noexcept {
+    WriteChar('{');
+    WriteLinefeed();
+    m_depth++;
+    WriteIndent();
+    size_t object_size = obj->size();
+    for (size_t i = 0; i < object_size; i++) {
+        Item& item = obj->at(i);
+        WriteString(item.key.c_str());
+        WriteBytes(": ", 2);
+        WriteValue(item.val);
+        if (i + 1 < object_size) {
+            WriteChar(',');
+            WriteLinefeed();
+            WriteIndent();
+        }
+    }
+    m_depth--;
+    WriteLinefeed();
+    WriteIndent();
+    WriteChar('}');
+}
+
+void Writer::WriteArray(const Array* ary) noexcept {
+    WriteChar('[');
+    WriteLinefeed();
+    m_depth++;
+    WriteIndent();
+    size_t array_size = ary->size();
+    for (size_t i = 0; i < array_size; i++) {
+        WriteValue(&ary->at(i));
+        if (i + 1 < array_size) {
+            WriteChar(',');
+            WriteLinefeed();
+            WriteIndent();
+        }
+    }
+    m_depth--;
+    WriteLinefeed();
+    WriteIndent();
+    WriteChar(']');
+}
+
+void Writer::WriteValue(const Value* val) noexcept {
+    Type type = val->GetType();
+    if (type == JSON_TYPE_OBJECT) {
+        WriteObject(val->GetObject());
+    } else if (type == JSON_TYPE_ARRAY) {
+        WriteArray(val->GetArray());
+    } else if (type == JSON_TYPE_STRING) {
+        WriteString(val->GetString());
+    } else if (type == JSON_TYPE_INT) {
+        noex::string str = noex::to_string(val->GetInt());
+        WriteBytes(str.c_str(), str.size());
+    } else if (type == JSON_TYPE_DOUBLE) {
+        noex::string str = noex::to_string(val->GetDouble());
+        WriteBytes(str.c_str(), str.size());
+    } else if (type == JSON_TYPE_BOOL) {
+        if (val->GetBool())
+            WriteBytes("true", 4);
+        else
+            WriteBytes("false", 5);
+    } else if (type == JSON_TYPE_NULL) {
+        WriteBytes("null", 4);
+    }
+}
+
+char* Writer::WriteJson(const Value* root, char* buf, size_t buf_size) noexcept {
+    m_buf = buf;
+    m_buf_size = buf_size;
+    WriteValue(root);
+    WriteLinefeed();
+    if (m_buf) {
+        *m_buf = '\0';
+    } else {
+        noex::ErrorNo err = noex::get_error_no();
+        if (err == noex::OK)
+            m_err = JSON_ERR_SMALL_BUFFER;
+        else if (err == noex::STR_ALLOCATION_ERROR)
+            m_err = JSON_ERR_ALLOC;
+        else if (err == noex::STR_FORMAT_ERROR)
+            m_err = JSON_ERR_NUMBER_FORMAT;
+        else
+            m_err = JSON_ERR_UNEXPECTED;
+    }
+    return m_buf;
+}
+
+const char* Writer::GetErrMsg() noexcept {
+    return get_def_err_msg(m_err);
+}
+
+}  // namespace tuwjson

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -299,7 +299,7 @@ static void CompileCommand(JsonResult& result,
     }
     sub_definition["command_splitted"].MoveFrom(splitted_cmd_json);
 
-    tuwjson::Value& components = sub_definition["components"];;
+    tuwjson::Value& components = sub_definition["components"];
     tuwjson::Value cmd_int_ids;
     cmd_int_ids.SetArray();
     noex::string cmd_str;
@@ -486,7 +486,7 @@ void CheckSubDefinition(JsonResult& result, tuwjson::Value& sub_definition,
         if (type != COMP_STATIC_TEXT && !c.HasMember("id")) {
             PrintFmt(
                 "[CheckDefinition] DeprecationWarning: "
-                "\"id\" is missing in [\"components\"][%d]%s."
+                "\"id\" is missing in [\"components\"][%zu]%s."
                 " Support for components without \"id\" will be removed in a future version.\n",
                 comp_ids.size(), c.GetLineColumnStr().c_str());
         }
@@ -704,7 +704,7 @@ void CheckDefinition(JsonResult& result, tuwjson::Value& definition) noexcept {
     if (gui_json.Size() == 0) {
         result.ok = false;
         result.msg = "The size of [\"gui\"] should NOT be zero."
-            + gui_json.GetLineColumnStr();;
+            + gui_json.GetLineColumnStr();
     }
 
     int i = 0;
@@ -732,7 +732,7 @@ void CheckHelpURLs(JsonResult& result, tuwjson::Value& definition) noexcept {
         } else {
             result.ok = false;
             result.msg = noex::concat_cstr("Unsupported help type: ", type)
-                + help_type.GetLineColumnStr();;
+                + help_type.GetLineColumnStr();
             return;
         }
     }

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -25,725 +25,730 @@ FILE* FileOpen(const char* path, const char* mode) noexcept {
 
 namespace json_utils {
 
-    enum ComponentType: int {
-        COMP_UNKNOWN = 0,
-        COMP_EMPTY,
-        COMP_STATIC_TEXT,
-        COMP_FILE,
-        COMP_FOLDER,
-        COMP_COMBO,
-        COMP_RADIO,
-        COMP_CHECK,
-        COMP_CHECK_ARRAY,
-        COMP_TEXT,
-        COMP_INT,
-        COMP_FLOAT,
-        COMP_MAX
-    };
+enum ComponentType: int {
+    COMP_UNKNOWN = 0,
+    COMP_EMPTY,
+    COMP_STATIC_TEXT,
+    COMP_FILE,
+    COMP_FOLDER,
+    COMP_COMBO,
+    COMP_RADIO,
+    COMP_CHECK,
+    COMP_CHECK_ARRAY,
+    COMP_TEXT,
+    COMP_INT,
+    COMP_FLOAT,
+    COMP_MAX
+};
 
-    // JSON parser allows c style comments and trailing commas.
-    constexpr auto JSONC_FLAGS =
-        rapidjson::kParseCommentsFlag | rapidjson::kParseTrailingCommasFlag;
+// JSON parser allows c style comments and trailing commas.
+constexpr auto JSONC_FLAGS =
+    rapidjson::kParseCommentsFlag | rapidjson::kParseTrailingCommasFlag;
 
-    JsonResult LoadJson(const noex::string& file, rapidjson::Document& json) noexcept {
-        FILE* fp = FileOpen(file.c_str(), "rb");
-        if (!fp)
-            return { false, "Failed to open " + file };
+JsonResult LoadJson(const noex::string& file, rapidjson::Document& json) noexcept {
+    FILE* fp = FileOpen(file.c_str(), "rb");
+    if (!fp)
+        return { false, "Failed to open " + file };
 
-        char readBuffer[JSON_SIZE_MAX];
-        rapidjson::FileReadStream is(fp, readBuffer, sizeof(readBuffer));
+    char readBuffer[JSON_SIZE_MAX];
+    rapidjson::FileReadStream is(fp, readBuffer, sizeof(readBuffer));
 
-        rapidjson::ParseResult ok = json.ParseStream<JSONC_FLAGS>(is);
-        fclose(fp);
+    rapidjson::ParseResult ok = json.ParseStream<JSONC_FLAGS>(is);
+    fclose(fp);
 
-        if (!ok) {
-            noex::string msg = noex::string("Failed to parse JSON: ") +
-                            rapidjson::GetParseError_En(ok.Code()) +
-                            " (offset: " + ok.Offset() + ")";
-            return { false, msg };
-        }
-        if (!json.IsObject())
-            json.SetObject();
-
-        return JSON_RESULT_OK;
+    if (!ok) {
+        noex::string msg = noex::string("Failed to parse JSON: ") +
+                        rapidjson::GetParseError_En(ok.Code()) +
+                        " (offset: " + ok.Offset() + ")";
+        return { false, msg };
     }
+    if (!json.IsObject())
+        json.SetObject();
 
-    JsonResult SaveJson(rapidjson::Document& json, const noex::string& file) noexcept {
-        FILE* fp = FileOpen(file.c_str(), "wb");
-        if (!fp)
-            return { false, "Failed to open " + file + "." };
+    return JSON_RESULT_OK;
+}
 
-        char writeBuffer[JSON_SIZE_MAX];
-        rapidjson::FileWriteStream os(fp, writeBuffer, sizeof(writeBuffer));
-        rapidjson::PrettyWriter<rapidjson::FileWriteStream> writer(os);
-        json.Accept(writer);
-        fclose(fp);
-        return JSON_RESULT_OK;
+JsonResult SaveJson(rapidjson::Document& json, const noex::string& file) noexcept {
+    FILE* fp = FileOpen(file.c_str(), "wb");
+    if (!fp)
+        return { false, "Failed to open " + file + "." };
+
+    char writeBuffer[JSON_SIZE_MAX];
+    rapidjson::FileWriteStream os(fp, writeBuffer, sizeof(writeBuffer));
+    rapidjson::PrettyWriter<rapidjson::FileWriteStream> writer(os);
+    json.Accept(writer);
+    fclose(fp);
+    return JSON_RESULT_OK;
+}
+
+noex::string JsonToString(rapidjson::Document& json) noexcept {
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    json.Accept(writer);
+    return buffer.GetString();
+}
+
+const char* GetString(const rapidjson::Value& json, const char* key, const char* def) noexcept {
+    if (json.HasMember(key))
+        return json[key].GetString();
+    return def;
+}
+
+bool GetBool(const rapidjson::Value& json, const char* key, bool def) noexcept {
+    if (json.HasMember(key))
+        return json[key].GetBool();
+    return def;
+}
+
+int GetInt(const rapidjson::Value& json, const char* key, int def) noexcept {
+    if (json.HasMember(key))
+        return json[key].GetInt();
+    return def;
+}
+
+double GetDouble(const rapidjson::Value& json, const char* key, double def) noexcept {
+    if (json.HasMember(key))
+        return json[key].GetDouble();
+    return def;
+}
+
+static noex::string GetLabel(const char* label, const char* key) noexcept {
+    noex::string msg;
+    if (*label != '\0') {
+        msg = noex::string("['") + label + "']";
     }
+    msg += noex::string("['") + key + "']";
+    return msg;
+}
 
-    noex::string JsonToString(rapidjson::Document& json) noexcept {
-        rapidjson::StringBuffer buffer;
-        rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-        json.Accept(writer);
-        return buffer.GetString();
+enum class JsonType {
+    BOOLEAN,
+    INTEGER,
+    FLOAT,
+    STRING,
+    JSON,
+    MAX
+};
+
+static const bool OPTIONAL = true;
+
+static void CheckJsonType(JsonResult& result, const rapidjson::Value& j, const char* key,
+        const JsonType& type, const char* label = "", const bool& optional = false) noexcept {
+    if (!j.HasMember(key)) {
+        if (optional) return;
+        result.ok = false;
+        result.msg = GetLabel(label, key) + " not found.";
+        return;
     }
-
-    const char* GetString(const rapidjson::Value& json, const char* key, const char* def) noexcept {
-        if (json.HasMember(key))
-            return json[key].GetString();
-        return def;
+    bool valid = false;
+    const char* type_name = nullptr;
+    switch (type) {
+    case JsonType::BOOLEAN:
+        valid = j[key].IsBool();
+        type_name = "a boolean";
+        break;
+    case JsonType::INTEGER:
+        valid = j[key].IsInt();
+        type_name = "an int";
+        break;
+    case JsonType::FLOAT:
+        valid = j[key].IsDouble() || j[key].IsInt();
+        type_name = "a float";
+        break;
+    case JsonType::STRING:
+        valid = j[key].IsString();
+        type_name = "a string";
+        break;
+    case JsonType::JSON:
+        valid = j[key].IsObject();
+        type_name = "a json object";
+        break;
+    default:
+        assert(false);
+        type_name = "";
+        break;
     }
-
-    bool GetBool(const rapidjson::Value& json, const char* key, bool def) noexcept {
-        if (json.HasMember(key))
-            return json[key].GetBool();
-        return def;
+    if (!valid) {
+        result.ok = false;
+        result.msg = GetLabel(label, key) + " should be " + type_name + ".";
     }
+}
 
-    int GetInt(const rapidjson::Value& json, const char* key, int def) noexcept {
-        if (json.HasMember(key))
-            return json[key].GetInt();
-        return def;
+static bool IsJsonArray(rapidjson::Value& j, const char* key,
+                        rapidjson::Document::AllocatorType& alloc) noexcept {
+    if (!j[key].IsArray()) {
+        if (!j[key].IsObject())
+            return false;
+        rapidjson::Value array(rapidjson::kArrayType);
+        array.PushBack(j[key].Move(), alloc);
+        j[key] = array;
     }
-
-    double GetDouble(const rapidjson::Value& json, const char* key, double def) noexcept {
-        if (json.HasMember(key))
-            return json[key].GetDouble();
-        return def;
+    for (const rapidjson::Value& el : j[key].GetArray()) {
+        if (!el.IsObject())
+            return false;
     }
+    return true;
+}
 
-    static noex::string GetLabel(const char* label, const char* key) noexcept {
-        noex::string msg;
-        if (*label != '\0') {
-            msg = noex::string("['") + label + "']";
-        }
-        msg += noex::string("['") + key + "']";
-        return msg;
-    }
-
-    enum class JsonType {
-        BOOLEAN,
-        INTEGER,
-        FLOAT,
-        STRING,
-        JSON,
-        MAX
-    };
-
-    static const bool OPTIONAL = true;
-
-    static void CheckJsonType(JsonResult& result, const rapidjson::Value& j, const char* key,
-            const JsonType& type, const char* label = "", const bool& optional = false) noexcept {
-        if (!j.HasMember(key)) {
-            if (optional) return;
-            result.ok = false;
-            result.msg = GetLabel(label, key) + " not found.";
-            return;
-        }
-        bool valid = false;
-        const char* type_name = nullptr;
-        switch (type) {
-        case JsonType::BOOLEAN:
-            valid = j[key].IsBool();
-            type_name = "a boolean";
-            break;
-        case JsonType::INTEGER:
-            valid = j[key].IsInt();
-            type_name = "an int";
-            break;
-        case JsonType::FLOAT:
-            valid = j[key].IsDouble() || j[key].IsInt();
-            type_name = "a float";
-            break;
-        case JsonType::STRING:
-            valid = j[key].IsString();
-            type_name = "a string";
-            break;
-        case JsonType::JSON:
-            valid = j[key].IsObject();
-            type_name = "a json object";
-            break;
-        default:
-            assert(false);
-            type_name = "";
-            break;
-        }
-        if (!valid) {
-            result.ok = false;
-            result.msg = GetLabel(label, key) + " should be " + type_name + ".";
-        }
-    }
-
-
-    static bool IsJsonArray(rapidjson::Value& j, const char* key,
+static bool IsStringArray(rapidjson::Value& j, const char* key,
                             rapidjson::Document::AllocatorType& alloc) noexcept {
-        if (!j[key].IsArray()) {
-            if (!j[key].IsObject())
-                return false;
-            rapidjson::Value array(rapidjson::kArrayType);
-            array.PushBack(j[key].Move(), alloc);
-            j[key] = array;
-        }
-        for (const rapidjson::Value& el : j[key].GetArray()) {
-            if (!el.IsObject())
-                return false;
-        }
-        return true;
+    if (!j[key].IsArray()) {
+        if (!j[key].IsString())
+            return false;
+        rapidjson::Value array(rapidjson::kArrayType);
+        array.PushBack(j[key].Move(), alloc);
+        j[key] = array;
     }
-
-    static bool IsStringArray(rapidjson::Value& j, const char* key,
-                              rapidjson::Document::AllocatorType& alloc) noexcept {
-        if (!j[key].IsArray()) {
-            if (!j[key].IsString())
-                return false;
-            rapidjson::Value array(rapidjson::kArrayType);
-            array.PushBack(j[key].Move(), alloc);
-            j[key] = array;
-        }
-        for (const rapidjson::Value& el : j[key].GetArray()) {
-            if (!el.IsString())
-                return false;
-        }
-        return true;
+    for (const rapidjson::Value& el : j[key].GetArray()) {
+        if (!el.IsString())
+            return false;
     }
+    return true;
+}
 
-    static void CheckJsonArrayType(JsonResult& result, rapidjson::Value& j, const char* key,
-            const JsonType& type, rapidjson::Document::AllocatorType& alloc,
-            const char* label = "", const bool& optional = false) noexcept {
-        if (!j.HasMember(key)) {
-            if (optional) return;
-            result.ok = false;
-            result.msg = GetLabel(label, key) + " not found.";
-            return;
-        }
-        bool valid = false;
-        const char* type_name = nullptr;
-        switch (type) {
-        case JsonType::STRING:
-            valid = IsStringArray(j, key, alloc);
-            type_name = "an array of strings";
+static void CheckJsonArrayType(JsonResult& result, rapidjson::Value& j, const char* key,
+        const JsonType& type, rapidjson::Document::AllocatorType& alloc,
+        const char* label = "", const bool& optional = false) noexcept {
+    if (!j.HasMember(key)) {
+        if (optional) return;
+        result.ok = false;
+        result.msg = GetLabel(label, key) + " not found.";
+        return;
+    }
+    bool valid = false;
+    const char* type_name = nullptr;
+    switch (type) {
+    case JsonType::STRING:
+        valid = IsStringArray(j, key, alloc);
+        type_name = "an array of strings";
+        break;
+    case JsonType::JSON:
+        valid = IsJsonArray(j, key, alloc);
+        type_name = "an array of json objects";
+        break;
+    default:
+        assert(false);
+        type_name = "";
+        break;
+    }
+    if (!valid) {
+        result.ok = false;
+        result.msg = GetLabel(label, key) + " should be " + type_name + ".";
+    }
+}
+
+// get default definition of gui
+void GetDefaultDefinition(rapidjson::Document& definition) noexcept {
+    static const char* def_str = "{"
+#ifdef _WIN32
+        "\"command\":\"dir\","
+        "\"button\":\"run 'dir'\","
+#else
+        "\"command\":\"ls\","
+        "\"button\":\"run 'ls'\","
+#endif
+        "\"components\":[]"
+        "}";
+    rapidjson::ParseResult ok = definition.Parse(def_str);
+    assert(ok);
+    (void) ok;  // GCC says it's unused even if you use it for assertion.
+    JsonResult result = JSON_RESULT_OK;
+    CheckDefinition(result, definition);
+    assert(result.ok);
+}
+
+static void CorrectKey(
+        rapidjson::Value& j,
+        const char* false_key, const char* true_key,
+        rapidjson::Document::AllocatorType& alloc) noexcept {
+    if (!j.HasMember(true_key) && j.HasMember(false_key)) {
+        rapidjson::Value n(true_key, alloc);
+        j.AddMember(n, j[false_key], alloc);
+        j.RemoveMember(false_key);
+    }
+}
+
+static noex::vector<noex::string>
+SplitString(const char* str, const char delimiter) noexcept {
+    if (!str)
+        return {};
+
+    noex::vector<noex::string> tokens;
+
+    const char* start = str;
+    while (*start != '\0') {
+        const char* pos = strchr(start, delimiter);
+        if (!pos) {
+            tokens.emplace_back(start);
             break;
-        case JsonType::JSON:
-            valid = IsJsonArray(j, key, alloc);
-            type_name = "an array of json objects";
-            break;
-        default:
-            assert(false);
-            type_name = "";
-            break;
         }
-        if (!valid) {
-            result.ok = false;
-            result.msg = GetLabel(label, key) + " should be " + type_name + ".";
-        }
+        tokens.emplace_back(start, pos - start);
+        start = pos + 1;
     }
+    return tokens;
+}
 
-    // get default definition of gui
-    void GetDefaultDefinition(rapidjson::Document& definition) noexcept {
-        static const char* def_str = "{"
-    #ifdef _WIN32
-            "\"command\":\"dir\","
-            "\"button\":\"run 'dir'\","
-    #else
-            "\"command\":\"ls\","
-            "\"button\":\"run 'ls'\","
-    #endif
-            "\"components\":[]"
-            "}";
-        rapidjson::ParseResult ok = definition.Parse(def_str);
-        assert(ok);
-        (void) ok;  // GCC says it's unused even if you use it for assertion.
-        JsonResult result = JSON_RESULT_OK;
-        CheckDefinition(result, definition);
-        assert(result.ok);
-    }
-
-    static void CorrectKey(rapidjson::Value& j,
-                           const char* false_key,
-                           const char* true_key,
-                           rapidjson::Document::AllocatorType& alloc) noexcept {
-        if (!j.HasMember(true_key) && j.HasMember(false_key)) {
-            rapidjson::Value n(true_key, alloc);
-            j.AddMember(n, j[false_key], alloc);
-            j.RemoveMember(false_key);
-        }
-    }
-
-    static noex::vector<noex::string> SplitString(const char* str,
-                                                const char delimiter) noexcept {
-        if (!str)
-            return {};
-
-        noex::vector<noex::string> tokens;
-
-        const char* start = str;
-        while (*start != '\0') {
-            const char* pos = strchr(start, delimiter);
-            if (!pos) {
-                tokens.emplace_back(start);
-                break;
-            }
-            tokens.emplace_back(start, pos - start);
-            start = pos + 1;
-        }
-        return tokens;
-    }
-
-    static void CheckIndexDuplication(JsonResult& result,
-                                      const noex::vector<noex::string>& component_ids) noexcept {
-        size_t size = component_ids.size();
-        if (size == 0)
-            return;
-        for (size_t i = 0; i < size - 1; i++) {
-            const noex::string& str = component_ids[i];
-            if (str.empty()) { continue; }
-            for (size_t j = i + 1; j < size; j++) {
-                if (str == component_ids[j]) {
-                    result.ok = false;
-                    result.msg = "[components][id]"
-                                 " should not be duplicated in a gui definition. (" +
-                                 str + ")";
-                    return;
-                }
+static void CheckIndexDuplication(
+        JsonResult& result, const noex::vector<noex::string>& component_ids) noexcept {
+    size_t size = component_ids.size();
+    if (size == 0)
+        return;
+    for (size_t i = 0; i < size - 1; i++) {
+        const noex::string& str = component_ids[i];
+        if (str.empty())
+            continue;
+        for (size_t j = i + 1; j < size; j++) {
+            if (str == component_ids[j]) {
+                result.ok = false;
+                result.msg = "[components][id]"
+                                " should not be duplicated in a gui definition. (" +
+                                str + ")";
+                return;
             }
         }
     }
+}
 
-    // split command by "%" symbol, and calculate which component should be inserted there.
-    static void CompileCommand(JsonResult& result,
-                               rapidjson::Value& sub_definition,
-                               const noex::vector<noex::string>& comp_ids,
-                               rapidjson::Document::AllocatorType& alloc) noexcept {
-        noex::vector<noex::string> cmd = SplitString(sub_definition["command"].GetString(), '%');
-        noex::vector<noex::string> cmd_ids;
-        noex::vector<noex::string> splitted_cmd;
-        if (sub_definition.HasMember("command_splitted"))
-            sub_definition.RemoveMember("command_splitted");
-        rapidjson::Value splitted_cmd_json(rapidjson::kArrayType);
+// split command by "%" symbol, and calculate which component should be inserted there.
+static void CompileCommand(JsonResult& result,
+                            rapidjson::Value& sub_definition,
+                            const noex::vector<noex::string>& comp_ids,
+                            rapidjson::Document::AllocatorType& alloc) noexcept {
+    noex::vector<noex::string> cmd = SplitString(sub_definition["command"].GetString(), '%');
+    noex::vector<noex::string> cmd_ids;
+    noex::vector<noex::string> splitted_cmd;
+    if (sub_definition.HasMember("command_splitted"))
+        sub_definition.RemoveMember("command_splitted");
+    rapidjson::Value splitted_cmd_json(rapidjson::kArrayType);
 
-        bool store_ids = false;
-        for (const noex::string& token : cmd) {
-            if (store_ids) {
-                cmd_ids.emplace_back(token);
-            } else {
-                splitted_cmd.emplace_back(token);
-                rapidjson::Value n(token.c_str(), alloc);
-                splitted_cmd_json.PushBack(n, alloc);
-            }
-            store_ids = !store_ids;
+    bool store_ids = false;
+    for (const noex::string& token : cmd) {
+        if (store_ids) {
+            cmd_ids.emplace_back(token);
+        } else {
+            splitted_cmd.emplace_back(token);
+            rapidjson::Value n(token.c_str(), alloc);
+            splitted_cmd_json.PushBack(n, alloc);
         }
-        sub_definition.AddMember("command_splitted", splitted_cmd_json, alloc);
+        store_ids = !store_ids;
+    }
+    sub_definition.AddMember("command_splitted", splitted_cmd_json, alloc);
 
-        rapidjson::Value& components = sub_definition["components"];;
-        rapidjson::Value cmd_int_ids(rapidjson::kArrayType);
-        noex::string cmd_str;
-        int comp_size = static_cast<int>(comp_ids.size());
-        int non_id_comp = 0;
-        for (int i = 0; i < static_cast<int>(cmd_ids.size()); i++) {
-            cmd_str += splitted_cmd[i];
-            const noex::string& id = cmd_ids[i];
-            int j;
-            if (id == CMD_TOKEN_PERCENT) {
-                j = CMD_ID_PERCENT;
-                cmd_str += "%";
-            } else if (id == CMD_TOKEN_CURRENT_DIR) {
-                j = CMD_ID_CURRENT_DIR;
-                cmd_str += id;
-            } else if (id == CMD_TOKEN_HOME_DIR) {
-                j = CMD_ID_HOME_DIR;
-                cmd_str += id;
-            } else {
-                for (j = 0; j < comp_size; j++)
-                    if (id == comp_ids[j]) break;
-                if (j == comp_size) {
-                    while (non_id_comp < comp_size
-                        && (components[non_id_comp]["type_int"] == COMP_STATIC_TEXT
-                            || !comp_ids[non_id_comp].empty()
-                            || components[non_id_comp]["type_int"] == COMP_EMPTY)) {
-                        non_id_comp++;
-                    }
-                    j = non_id_comp;
+    rapidjson::Value& components = sub_definition["components"];;
+    rapidjson::Value cmd_int_ids(rapidjson::kArrayType);
+    noex::string cmd_str;
+    int comp_size = static_cast<int>(comp_ids.size());
+    int non_id_comp = 0;
+    for (int i = 0; i < static_cast<int>(cmd_ids.size()); i++) {
+        cmd_str += splitted_cmd[i];
+        const noex::string& id = cmd_ids[i];
+        int j;
+        if (id == CMD_TOKEN_PERCENT) {
+            j = CMD_ID_PERCENT;
+            cmd_str += "%";
+        } else if (id == CMD_TOKEN_CURRENT_DIR) {
+            j = CMD_ID_CURRENT_DIR;
+            cmd_str += id;
+        } else if (id == CMD_TOKEN_HOME_DIR) {
+            j = CMD_ID_HOME_DIR;
+            cmd_str += id;
+        } else {
+            for (j = 0; j < comp_size; j++)
+                if (id == comp_ids[j]) break;
+            if (j == comp_size) {
+                while (non_id_comp < comp_size
+                    && (components[non_id_comp]["type_int"] == COMP_STATIC_TEXT
+                        || !comp_ids[non_id_comp].empty()
+                        || components[non_id_comp]["type_int"] == COMP_EMPTY)) {
                     non_id_comp++;
                 }
+                j = non_id_comp;
+                non_id_comp++;
             }
-            if (j < comp_size)
-                cmd_int_ids.PushBack(j, alloc);
-            if (j >= comp_size)
-                cmd_str += "__comp???__";
-            else if (j >= 0)
-                cmd_str += noex::string("__comp") + j + "__";
         }
-        if (cmd_ids.size() < splitted_cmd.size())
-            cmd_str += splitted_cmd.back();
+        if (j < comp_size)
+            cmd_int_ids.PushBack(j, alloc);
+        if (j >= comp_size)
+            cmd_str += "__comp???__";
+        else if (j >= 0)
+            cmd_str += noex::string("__comp") + j + "__";
+    }
+    if (cmd_ids.size() < splitted_cmd.size())
+        cmd_str += splitted_cmd.back();
 
-        // Check if the command requires more arguments or ignores some arguments.
-        for (int j = 0; j < comp_size; j++) {
-            int type_int = components[j]["type_int"].GetInt();
-            if (type_int == COMP_STATIC_TEXT || type_int == COMP_EMPTY)
-                continue;
-            bool found = false;
-            for (rapidjson::Value& id : cmd_int_ids.GetArray())
-                if (id.GetInt() == j) { found = true; break; }
-            if (!found) {
-                result.ok = false;
-                result.msg = noex::string("[\"components\"][") + j +
-                             "] is unused in the command; " + cmd_str;
-                if (!comp_ids[j].empty())
-                    result.msg = "The ID of " + result.msg;
-                return;
+    // Check if the command requires more arguments or ignores some arguments.
+    for (int j = 0; j < comp_size; j++) {
+        int type_int = components[j]["type_int"].GetInt();
+        if (type_int == COMP_STATIC_TEXT || type_int == COMP_EMPTY)
+            continue;
+        bool found = false;
+        for (rapidjson::Value& id : cmd_int_ids.GetArray())
+            if (id.GetInt() == j) {
+                found = true;
+                break;
             }
-        }
-        if (non_id_comp > comp_size) {
+        if (!found) {
             result.ok = false;
-            result.msg =
-                "The command requires more components for arguments; " + cmd_str;
+            result.msg = noex::string("[\"components\"][") + j +
+                            "] is unused in the command; " + cmd_str;
+            if (!comp_ids[j].empty())
+                result.msg = "The ID of " + result.msg;
             return;
         }
-        if (sub_definition.HasMember("command_str"))
-            sub_definition.RemoveMember("command_str");
-        rapidjson::Value v(cmd_str.c_str(), alloc);
-        sub_definition.AddMember("command_str", v, alloc);
-        if (sub_definition.HasMember("command_ids"))
-            sub_definition.RemoveMember("command_ids");
-        sub_definition.AddMember("command_ids", cmd_int_ids, alloc);
     }
-
-    // don't use map. it will make exe larger.
-    int ComptypeToInt(const char* comptype) noexcept {
-        if (strcmp(comptype, "static_text") == 0)
-            return COMP_STATIC_TEXT;
-        else if (strcmp(comptype, "file") == 0)
-            return COMP_FILE;
-        else if (strcmp(comptype, "folder") == 0)
-            return COMP_FOLDER;
-        else if (strcmp(comptype, "dir") == 0)
-            return COMP_FOLDER;
-        else if (strcmp(comptype, "choice") == 0)
-            return COMP_COMBO;
-        else if (strcmp(comptype, "combo") == 0)
-            return COMP_COMBO;
-        else if (strcmp(comptype, "radio") == 0)
-            return COMP_RADIO;
-        else if (strcmp(comptype, "check") == 0)
-            return COMP_CHECK;
-        else if (strcmp(comptype, "check_array") == 0)
-            return COMP_CHECK_ARRAY;
-        else if (strcmp(comptype, "checks") == 0)
-            return COMP_CHECK_ARRAY;
-        else if (strcmp(comptype, "text") == 0)
-            return COMP_TEXT;
-        else if (strcmp(comptype, "text_box") == 0)
-            return COMP_TEXT;
-        else if (strcmp(comptype, "int") == 0)
-            return COMP_INT;
-        else if (strcmp(comptype, "integer") == 0)
-            return COMP_INT;
-        else if (strcmp(comptype, "float") == 0)
-            return COMP_FLOAT;
-        return COMP_UNKNOWN;
+    if (non_id_comp > comp_size) {
+        result.ok = false;
+        result.msg =
+            "The command requires more components for arguments; " + cmd_str;
+        return;
     }
+    if (sub_definition.HasMember("command_str"))
+        sub_definition.RemoveMember("command_str");
+    rapidjson::Value v(cmd_str.c_str(), alloc);
+    sub_definition.AddMember("command_str", v, alloc);
+    if (sub_definition.HasMember("command_ids"))
+        sub_definition.RemoveMember("command_ids");
+    sub_definition.AddMember("command_ids", cmd_int_ids, alloc);
+}
 
-    void CheckValidator(JsonResult& result, rapidjson::Value& validator,
-                        const char* label) noexcept {
-        CheckJsonType(result, validator, "regex", JsonType::STRING, label, OPTIONAL);
-        CheckJsonType(result, validator, "regex_error", JsonType::STRING, label, OPTIONAL);
-        CheckJsonType(result, validator, "wildcard", JsonType::STRING, label, OPTIONAL);
-        CheckJsonType(result, validator, "wildcard_error", JsonType::STRING, label, OPTIONAL);
-        CheckJsonType(result, validator, "exist", JsonType::BOOLEAN, label, OPTIONAL);
-        CheckJsonType(result, validator, "exist_error", JsonType::STRING, label, OPTIONAL);
-        CheckJsonType(result, validator, "not_empty", JsonType::BOOLEAN, label, OPTIONAL);
-        CheckJsonType(result, validator, "not_empty_error", JsonType::STRING, label, OPTIONAL);
+// don't use map. it will make exe larger.
+int ComptypeToInt(const char* comptype) noexcept {
+    if (strcmp(comptype, "static_text") == 0)
+        return COMP_STATIC_TEXT;
+    else if (strcmp(comptype, "file") == 0)
+        return COMP_FILE;
+    else if (strcmp(comptype, "folder") == 0)
+        return COMP_FOLDER;
+    else if (strcmp(comptype, "dir") == 0)
+        return COMP_FOLDER;
+    else if (strcmp(comptype, "choice") == 0)
+        return COMP_COMBO;
+    else if (strcmp(comptype, "combo") == 0)
+        return COMP_COMBO;
+    else if (strcmp(comptype, "radio") == 0)
+        return COMP_RADIO;
+    else if (strcmp(comptype, "check") == 0)
+        return COMP_CHECK;
+    else if (strcmp(comptype, "check_array") == 0)
+        return COMP_CHECK_ARRAY;
+    else if (strcmp(comptype, "checks") == 0)
+        return COMP_CHECK_ARRAY;
+    else if (strcmp(comptype, "text") == 0)
+        return COMP_TEXT;
+    else if (strcmp(comptype, "text_box") == 0)
+        return COMP_TEXT;
+    else if (strcmp(comptype, "int") == 0)
+        return COMP_INT;
+    else if (strcmp(comptype, "integer") == 0)
+        return COMP_INT;
+    else if (strcmp(comptype, "float") == 0)
+        return COMP_FLOAT;
+    return COMP_UNKNOWN;
+}
+
+void CheckValidator(JsonResult& result, rapidjson::Value& validator,
+                    const char* label) noexcept {
+    CheckJsonType(result, validator, "regex", JsonType::STRING, label, OPTIONAL);
+    CheckJsonType(result, validator, "regex_error", JsonType::STRING, label, OPTIONAL);
+    CheckJsonType(result, validator, "wildcard", JsonType::STRING, label, OPTIONAL);
+    CheckJsonType(result, validator, "wildcard_error", JsonType::STRING, label, OPTIONAL);
+    CheckJsonType(result, validator, "exist", JsonType::BOOLEAN, label, OPTIONAL);
+    CheckJsonType(result, validator, "exist_error", JsonType::STRING, label, OPTIONAL);
+    CheckJsonType(result, validator, "not_empty", JsonType::BOOLEAN, label, OPTIONAL);
+    CheckJsonType(result, validator, "not_empty_error", JsonType::STRING, label, OPTIONAL);
+}
+
+// validate one of definitions (["gui"][i]) and store parsed info
+void CheckSubDefinition(JsonResult& result, rapidjson::Value& sub_definition,
+                        int index,
+                        rapidjson::Document::AllocatorType& alloc) noexcept {
+    CorrectKey(sub_definition, "window_title", "window_name", alloc);
+    CorrectKey(sub_definition, "title", "window_name", alloc);
+    CheckJsonType(result, sub_definition, "window_name", JsonType::STRING, "", OPTIONAL);
+
+    if (!sub_definition.HasMember("label")) {
+        noex::string default_label = noex::string("GUI ") + index;
+        const char* label = GetString(sub_definition, "window_name", default_label.c_str());
+        rapidjson::Value n(label, alloc);
+        sub_definition.AddMember("label", n, alloc);
     }
+    CheckJsonType(result, sub_definition, "label", JsonType::STRING);
 
-    // validate one of definitions (["gui"][i]) and store parsed info
-    void CheckSubDefinition(JsonResult& result, rapidjson::Value& sub_definition,
-                            int index,
-                            rapidjson::Document::AllocatorType& alloc) noexcept {
-        CorrectKey(sub_definition, "window_title", "window_name", alloc);
-        CorrectKey(sub_definition, "title", "window_name", alloc);
-        CheckJsonType(result, sub_definition, "window_name", JsonType::STRING, "", OPTIONAL);
+    CheckJsonType(result, sub_definition, "button", JsonType::STRING, "", OPTIONAL);
 
-        if (!sub_definition.HasMember("label")) {
-            noex::string default_label = noex::string("GUI ") + index;
-            const char* label = GetString(sub_definition, "window_name", default_label.c_str());
-            rapidjson::Value n(label, alloc);
-            sub_definition.AddMember("label", n, alloc);
-        }
-        CheckJsonType(result, sub_definition, "label", JsonType::STRING);
-
-        CheckJsonType(result, sub_definition, "button", JsonType::STRING, "", OPTIONAL);
-
-        CheckJsonType(result, sub_definition, "check_exit_code", JsonType::BOOLEAN, "", OPTIONAL);
-        CheckJsonType(result, sub_definition, "exit_success", JsonType::INTEGER, "", OPTIONAL);
-        CheckJsonType(result, sub_definition, "show_last_line", JsonType::BOOLEAN, "", OPTIONAL);
-        CheckJsonType(result, sub_definition,
-                      "show_success_dialog", JsonType::BOOLEAN, "", OPTIONAL);
-        CheckJsonType(result, sub_definition, "codepage", JsonType::STRING, "", OPTIONAL);
-        if (sub_definition.HasMember("codepage")) {
-            const char* codepage = sub_definition["codepage"].GetString();
-            if (strcmp(codepage, "utf8") != 0 && strcmp(codepage, "utf-8") != 0 &&
-                    strcmp(codepage, "default") != 0) {
-                result.ok = false;
-                result.msg = noex::string("Unknown codepage: ") + codepage;
-                return;
-            }
-        }
-
-        CorrectKey(sub_definition, "component", "components", alloc);
-        CorrectKey(sub_definition, "component_array", "components", alloc);
-        CheckJsonArrayType(result, sub_definition, "components", JsonType::JSON, alloc);
-
-        if (!result.ok) return;
-
-        // check components
-        noex::vector<noex::string> comp_ids;
-        for (rapidjson::Value& c : sub_definition["components"].GetArray()) {
-            // check if type and label exist
-            CheckJsonType(result, c, "label", JsonType::STRING, "components");
-            if (!result.ok) return;
-            const char* label = c["label"].GetString();
-
-            // convert ["type"] from string to enum.
-            CheckJsonType(result, c, "type", JsonType::STRING, label);
-            if (!result.ok) return;
-            const char* type_str = c["type"].GetString();
-            int type = ComptypeToInt(type_str);
-            if (c.HasMember("type_int"))
-                c.RemoveMember("type_int");
-            c.AddMember("type_int", type, alloc);
-            CorrectKey(c, "item", "items", alloc);
-            CorrectKey(c, "item_array", "items", alloc);
-            switch (type) {
-                case COMP_FILE:
-                    CheckJsonType(result, c, "extension", JsonType::STRING, label, OPTIONAL);
-                    /* Falls through. */
-                case COMP_FOLDER:
-                    CheckJsonType(result, c, "button", JsonType::STRING, label, OPTIONAL);
-                    /* Falls through. */
-                case COMP_TEXT:
-                    CheckJsonType(result, c, "default", JsonType::STRING, label, OPTIONAL);
-                    break;
-                case COMP_COMBO:
-                case COMP_RADIO:
-                    CheckJsonArrayType(result, c, "items", JsonType::JSON, alloc, label);
-                    if (!result.ok) return;
-                    for (rapidjson::Value& i : c["items"].GetArray()) {
-                        CheckJsonType(result, i, "label", JsonType::STRING, "items");
-                        CheckJsonType(result, i, "value", JsonType::STRING, "items", OPTIONAL);
-                    }
-                    CheckJsonType(result, c, "default", JsonType::INTEGER, label, OPTIONAL);
-                    break;
-                case COMP_CHECK:
-                    CheckJsonType(result, c, "value", JsonType::STRING, label, OPTIONAL);
-                    CheckJsonType(result, c, "default", JsonType::BOOLEAN, label, OPTIONAL);
-                    break;
-                case COMP_CHECK_ARRAY:
-                    CheckJsonArrayType(result, c, "items", JsonType::JSON, alloc, label);
-                    if (!result.ok) return;
-                    for (rapidjson::Value& i : c["items"].GetArray()) {
-                        CheckJsonType(result, i, "label", JsonType::STRING, "items");
-                        CheckJsonType(result, i, "value", JsonType::STRING, "items", OPTIONAL);
-                        CheckJsonType(result, i, "default", JsonType::BOOLEAN, "items", OPTIONAL);
-                        CheckJsonType(result, i, "tooltip", JsonType::STRING, "items", OPTIONAL);
-                    }
-                    break;
-                case COMP_INT:
-                case COMP_FLOAT:
-                    JsonType jtype;
-                    if (type == COMP_INT) {
-                        jtype = JsonType::INTEGER;
-                    } else {
-                        jtype = JsonType::FLOAT;
-                        CheckJsonType(result, c, "digits", JsonType::INTEGER, label, OPTIONAL);
-                        if (!result.ok) return;
-                        if (c.HasMember("digits") && c["digits"].GetInt() < 0) {
-                            result.ok = false;
-                            result.msg = GetLabel(label, "digits")
-                                         + " should be a non-negative integer.";
-                        }
-                    }
-                    CheckJsonType(result, c, "default", jtype, label, OPTIONAL);
-                    CheckJsonType(result, c, "min", jtype, label, OPTIONAL);
-                    CheckJsonType(result, c, "max", jtype, label, OPTIONAL);
-                    CheckJsonType(result, c, "inc", jtype, label, OPTIONAL);
-                    CheckJsonType(result, c, "wrap", JsonType::BOOLEAN, label, OPTIONAL);
-                    break;
-                case COMP_UNKNOWN:
-                    result.ok = false;
-                    result.msg = noex::string("Unknown component type: ") + type_str;
-                    break;
-            }
-            if (!result.ok) return;
-
-            if (c.HasMember("validator")) {
-                if (type == COMP_STATIC_TEXT) {
-                    result.ok = false;
-                    result.msg = "Static text does not support validator.";
-                    return;
-                }
-                CheckJsonType(result, c, "validator", JsonType::JSON, label);
-                CheckValidator(result, c["validator"], label);
-                if (!result.ok) return;
-            }
-
-            CorrectKey(c, "add_quote", "add_quotes", alloc);
-            CheckJsonType(result, c, "add_quotes", JsonType::BOOLEAN, label, OPTIONAL);
-            CorrectKey(c, "empty_message", "placeholder", alloc);
-            CheckJsonType(result, c, "placeholder", JsonType::STRING, label, OPTIONAL);
-            CheckJsonType(result, c, "id", JsonType::STRING, label, OPTIONAL);
-            CheckJsonType(result, c, "tooltip", JsonType::STRING, label, OPTIONAL);
-
-            CheckJsonType(result, c, "optional", JsonType::BOOLEAN, label, OPTIONAL);
-            CheckJsonType(result, c, "prefix", JsonType::STRING, label, OPTIONAL);
-            CheckJsonType(result, c, "suffix", JsonType::STRING, label, OPTIONAL);
-
-            bool ignore = false;
-            CorrectKey(c, "platform", "platforms", alloc);
-            CorrectKey(c, "platform_array", "platforms", alloc);
-            CheckJsonArrayType(result, c, "platforms", JsonType::STRING, alloc, label, OPTIONAL);
-            if (!result.ok) return;
-            if (c.HasMember("platforms")) {
-                ignore = true;
-                for (rapidjson::Value& v : c["platforms"].GetArray()) {
-                    if (strcmp(v.GetString(), TUW_CONSTANTS_OS) == 0) {
-                        ignore = false;
-                        break;
-                    }
-                }
-            }
-
-            const char* id = GetString(c, "id", "");
-            if (c.HasMember("id")) {
-                if (id[0] == '\0') {
-                    result.ok = false;
-                    result.msg = GetLabel(label, "id")
-                                 + " should NOT be an empty string.";
-                } else if (id[0] == '_') {
-                    result.ok = false;
-                    result.msg = GetLabel(label, "id")
-                                 + " should NOT start with '_'.";
-                }
-            }
-            if (!result.ok) return;
-
-            if (ignore) {
-                comp_ids.emplace_back("");
-                c["type_int"].SetInt(COMP_EMPTY);
-            } else {
-                comp_ids.emplace_back(id);
-            }
-        }
-        CheckIndexDuplication(result, comp_ids);
-        if (!result.ok) return;
-
-        // Overwrite ["command"] with ["command_'os'"] if exists.
-        const char* command_os_key = "command_" TUW_CONSTANTS_OS;
-        if (sub_definition.HasMember(command_os_key)) {
-            CheckJsonType(result, sub_definition, command_os_key, JsonType::STRING);
-            if (!result.ok) return;
-            const char* command_os = sub_definition[command_os_key].GetString();
-            if (sub_definition.HasMember("command"))
-                sub_definition.RemoveMember("command");
-            rapidjson::Value v(command_os, alloc);
-            sub_definition.AddMember("command", v, alloc);
-        }
-
-        // check sub_definition["command"] and convert it to more useful format.
-        CheckJsonType(result, sub_definition, "command", JsonType::STRING);
-        if (!result.ok) return;
-        CompileCommand(result, sub_definition, comp_ids, alloc);
-    }
-
-    // vX.Y.Z -> 10000*X + 100 * Y + Z
-    static int VersionStringToInt(JsonResult& result, const char* string) noexcept {
-        noex::vector<noex::string> version_strings =
-            SplitString(string, '.');
-        int digit = 10000;
-        int version_int = 0;
-        for (const noex::string& str : version_strings) {
-            if (str.length() == 0 || str.length() > 2) {
-                result.ok = false;
-                result.msg = noex::string("Can NOT convert '") + string + "' to int.";
-                return 0;
-            }
-            if (str.length() == 1) {
-                version_int += digit * (str[0] - 48);
-            } else {  // length() == 2
-                version_int += digit * (str[0] - 48) * 10;
-                version_int += digit * (str[1] - 48);
-            }
-            if (digit == 1) { break; }
-            digit /= 100;
-        }
-        return version_int;
-    }
-
-    void CheckVersion(JsonResult& result, rapidjson::Document& definition) noexcept {
-        CorrectKey(definition, "recommended_version", "recommended", definition.GetAllocator());
-        if (definition.HasMember("recommended")) {
-            CheckJsonType(result, definition, "recommended", JsonType::STRING);
-            if (!result.ok) return;
-            int recom_int = VersionStringToInt(result, definition["recommended"].GetString());
-            if (definition.HasMember("not_recommended")) definition.RemoveMember("not_recommended");
-            definition.AddMember("not_recommended",
-                                 tuw_constants::VERSION_INT != recom_int,
-                                 definition.GetAllocator());
-        }
-        CorrectKey(definition, "minimum_required_version",
-                   "minimum_required", definition.GetAllocator());
-        if (definition.HasMember("minimum_required")) {
-            CheckJsonType(result, definition, "minimum_required", JsonType::STRING);
-            if (!result.ok) return;
-            const char* required = definition["minimum_required"].GetString();
-            int required_int = VersionStringToInt(result, required);
-            if (tuw_constants::VERSION_INT < required_int) {
-                result.ok = false;
-                result.msg = noex::string("Version ") + required + " is required.";
-            }
-        }
-    }
-
-    void CheckDefinition(JsonResult& result, rapidjson::Document& definition) noexcept {
-        rapidjson::Document::AllocatorType& alloc = definition.GetAllocator();
-        if (!definition.HasMember("gui")) {
-            // definition["gui"] = definition
-            rapidjson::Value n(rapidjson::kObjectType);
-            n.CopyFrom(definition, alloc);
-            definition.AddMember("gui", n, alloc);
-        }
-        CheckJsonArrayType(result, definition, "gui", JsonType::JSON, alloc);
-        if (!result.ok) return;
-        if (definition["gui"].Size() == 0) {
+    CheckJsonType(result, sub_definition, "check_exit_code", JsonType::BOOLEAN, "", OPTIONAL);
+    CheckJsonType(result, sub_definition, "exit_success", JsonType::INTEGER, "", OPTIONAL);
+    CheckJsonType(result, sub_definition, "show_last_line", JsonType::BOOLEAN, "", OPTIONAL);
+    CheckJsonType(result, sub_definition,
+                    "show_success_dialog", JsonType::BOOLEAN, "", OPTIONAL);
+    CheckJsonType(result, sub_definition, "codepage", JsonType::STRING, "", OPTIONAL);
+    if (sub_definition.HasMember("codepage")) {
+        const char* codepage = sub_definition["codepage"].GetString();
+        if (strcmp(codepage, "utf8") != 0 && strcmp(codepage, "utf-8") != 0 &&
+                strcmp(codepage, "default") != 0) {
             result.ok = false;
-            result.msg = "The size of [\"gui\"] should NOT be zero.";
-        }
-
-        int i = 0;
-        for (rapidjson::Value& sub_d : definition["gui"].GetArray()) {
-            if (!result.ok) return;
-            CheckSubDefinition(result, sub_d, i, alloc);
-            i++;
+            result.msg = noex::string("Unknown codepage: ") + codepage;
+            return;
         }
     }
 
-    void CheckHelpURLs(JsonResult& result, rapidjson::Document& definition) noexcept {
-        if (!definition.HasMember("help")) return;
-        CheckJsonArrayType(result, definition, "help", JsonType::JSON, definition.GetAllocator());
+    CorrectKey(sub_definition, "component", "components", alloc);
+    CorrectKey(sub_definition, "component_array", "components", alloc);
+    CheckJsonArrayType(result, sub_definition, "components", JsonType::JSON, alloc);
+
+    if (!result.ok) return;
+
+    // check components
+    noex::vector<noex::string> comp_ids;
+    for (rapidjson::Value& c : sub_definition["components"].GetArray()) {
+        // check if type and label exist
+        CheckJsonType(result, c, "label", JsonType::STRING, "components");
         if (!result.ok) return;
-        for (const rapidjson::Value& h : definition["help"].GetArray()) {
-            CheckJsonType(result, h, "type", JsonType::STRING);
-            CheckJsonType(result, h, "label", JsonType::STRING);
-            if (!result.ok) return;
-            const char* type = h["type"].GetString();
-            if (strcmp(type, "url") == 0) {
-                CheckJsonType(result, h, "url", JsonType::STRING);
-            } else if (strcmp(type, "file") == 0) {
-                CheckJsonType(result, h, "path", JsonType::STRING);
-            } else {
+        const char* label = c["label"].GetString();
+
+        // convert ["type"] from string to enum.
+        CheckJsonType(result, c, "type", JsonType::STRING, label);
+        if (!result.ok) return;
+        const char* type_str = c["type"].GetString();
+        int type = ComptypeToInt(type_str);
+        if (c.HasMember("type_int"))
+            c.RemoveMember("type_int");
+        c.AddMember("type_int", type, alloc);
+        CorrectKey(c, "item", "items", alloc);
+        CorrectKey(c, "item_array", "items", alloc);
+        switch (type) {
+            case COMP_FILE:
+                CheckJsonType(result, c, "extension", JsonType::STRING, label, OPTIONAL);
+                /* Falls through. */
+            case COMP_FOLDER:
+                CheckJsonType(result, c, "button", JsonType::STRING, label, OPTIONAL);
+                /* Falls through. */
+            case COMP_TEXT:
+                CheckJsonType(result, c, "default", JsonType::STRING, label, OPTIONAL);
+                break;
+            case COMP_COMBO:
+            case COMP_RADIO:
+                CheckJsonArrayType(result, c, "items", JsonType::JSON, alloc, label);
+                if (!result.ok) return;
+                for (rapidjson::Value& i : c["items"].GetArray()) {
+                    CheckJsonType(result, i, "label", JsonType::STRING, "items");
+                    CheckJsonType(result, i, "value", JsonType::STRING, "items", OPTIONAL);
+                }
+                CheckJsonType(result, c, "default", JsonType::INTEGER, label, OPTIONAL);
+                break;
+            case COMP_CHECK:
+                CheckJsonType(result, c, "value", JsonType::STRING, label, OPTIONAL);
+                CheckJsonType(result, c, "default", JsonType::BOOLEAN, label, OPTIONAL);
+                break;
+            case COMP_CHECK_ARRAY:
+                CheckJsonArrayType(result, c, "items", JsonType::JSON, alloc, label);
+                if (!result.ok) return;
+                for (rapidjson::Value& i : c["items"].GetArray()) {
+                    CheckJsonType(result, i, "label", JsonType::STRING, "items");
+                    CheckJsonType(result, i, "value", JsonType::STRING, "items", OPTIONAL);
+                    CheckJsonType(result, i, "default", JsonType::BOOLEAN, "items", OPTIONAL);
+                    CheckJsonType(result, i, "tooltip", JsonType::STRING, "items", OPTIONAL);
+                }
+                break;
+            case COMP_INT:
+            case COMP_FLOAT:
+                JsonType jtype;
+                if (type == COMP_INT) {
+                    jtype = JsonType::INTEGER;
+                } else {
+                    jtype = JsonType::FLOAT;
+                    CheckJsonType(result, c, "digits", JsonType::INTEGER, label, OPTIONAL);
+                    if (!result.ok) return;
+                    if (c.HasMember("digits") && c["digits"].GetInt() < 0) {
+                        result.ok = false;
+                        result.msg = GetLabel(label, "digits")
+                                        + " should be a non-negative integer.";
+                    }
+                }
+                CheckJsonType(result, c, "default", jtype, label, OPTIONAL);
+                CheckJsonType(result, c, "min", jtype, label, OPTIONAL);
+                CheckJsonType(result, c, "max", jtype, label, OPTIONAL);
+                CheckJsonType(result, c, "inc", jtype, label, OPTIONAL);
+                CheckJsonType(result, c, "wrap", JsonType::BOOLEAN, label, OPTIONAL);
+                break;
+            case COMP_UNKNOWN:
                 result.ok = false;
-                result.msg = noex::string("Unsupported help type: ") + type;
+                result.msg = noex::string("Unknown component type: ") + type_str;
+                break;
+        }
+        if (!result.ok) return;
+
+        if (c.HasMember("validator")) {
+            if (type == COMP_STATIC_TEXT) {
+                result.ok = false;
+                result.msg = "Static text does not support validator.";
                 return;
             }
+            CheckJsonType(result, c, "validator", JsonType::JSON, label);
+            CheckValidator(result, c["validator"], label);
+            if (!result.ok) return;
+        }
+
+        CorrectKey(c, "add_quote", "add_quotes", alloc);
+        CheckJsonType(result, c, "add_quotes", JsonType::BOOLEAN, label, OPTIONAL);
+        CorrectKey(c, "empty_message", "placeholder", alloc);
+        CheckJsonType(result, c, "placeholder", JsonType::STRING, label, OPTIONAL);
+        CheckJsonType(result, c, "id", JsonType::STRING, label, OPTIONAL);
+        CheckJsonType(result, c, "tooltip", JsonType::STRING, label, OPTIONAL);
+
+        CheckJsonType(result, c, "optional", JsonType::BOOLEAN, label, OPTIONAL);
+        CheckJsonType(result, c, "prefix", JsonType::STRING, label, OPTIONAL);
+        CheckJsonType(result, c, "suffix", JsonType::STRING, label, OPTIONAL);
+
+        bool ignore = false;
+        CorrectKey(c, "platform", "platforms", alloc);
+        CorrectKey(c, "platform_array", "platforms", alloc);
+        CheckJsonArrayType(result, c, "platforms", JsonType::STRING, alloc, label, OPTIONAL);
+        if (!result.ok) return;
+        if (c.HasMember("platforms")) {
+            ignore = true;
+            for (rapidjson::Value& v : c["platforms"].GetArray()) {
+                if (strcmp(v.GetString(), TUW_CONSTANTS_OS) == 0) {
+                    ignore = false;
+                    break;
+                }
+            }
+        }
+
+        const char* id = GetString(c, "id", "");
+        if (c.HasMember("id")) {
+            if (id[0] == '\0') {
+                result.ok = false;
+                result.msg = GetLabel(label, "id")
+                                + " should NOT be an empty string.";
+            } else if (id[0] == '_') {
+                result.ok = false;
+                result.msg = GetLabel(label, "id")
+                                + " should NOT start with '_'.";
+            }
+        }
+        if (!result.ok) return;
+
+        if (ignore) {
+            comp_ids.emplace_back("");
+            c["type_int"].SetInt(COMP_EMPTY);
+        } else {
+            comp_ids.emplace_back(id);
         }
     }
+    CheckIndexDuplication(result, comp_ids);
+    if (!result.ok) return;
+
+    // Overwrite ["command"] with ["command_'os'"] if exists.
+    const char* command_os_key = "command_" TUW_CONSTANTS_OS;
+    if (sub_definition.HasMember(command_os_key)) {
+        CheckJsonType(result, sub_definition, command_os_key, JsonType::STRING);
+        if (!result.ok) return;
+        const char* command_os = sub_definition[command_os_key].GetString();
+        if (sub_definition.HasMember("command"))
+            sub_definition.RemoveMember("command");
+        rapidjson::Value v(command_os, alloc);
+        sub_definition.AddMember("command", v, alloc);
+    }
+
+    // check sub_definition["command"] and convert it to more useful format.
+    CheckJsonType(result, sub_definition, "command", JsonType::STRING);
+    if (!result.ok) return;
+    CompileCommand(result, sub_definition, comp_ids, alloc);
+}
+
+// vX.Y.Z -> 10000*X + 100 * Y + Z
+static int VersionStringToInt(JsonResult& result, const char* string) noexcept {
+    noex::vector<noex::string> version_strings =
+        SplitString(string, '.');
+    int digit = 10000;
+    int version_int = 0;
+    for (const noex::string& str : version_strings) {
+        if (str.length() == 0 || str.length() > 2) {
+            result.ok = false;
+            result.msg = noex::string("Can NOT convert '") + string + "' to int.";
+            return 0;
+        }
+        if (str.length() == 1) {
+            version_int += digit * (str[0] - 48);
+        } else {  // length() == 2
+            version_int += digit * (str[0] - 48) * 10;
+            version_int += digit * (str[1] - 48);
+        }
+        if (digit == 1)
+            break;
+        digit /= 100;
+    }
+    return version_int;
+}
+
+void CheckVersion(JsonResult& result, rapidjson::Document& definition) noexcept {
+    CorrectKey(definition, "recommended_version", "recommended", definition.GetAllocator());
+    if (definition.HasMember("recommended")) {
+        CheckJsonType(result, definition, "recommended", JsonType::STRING);
+        if (!result.ok) return;
+        int recom_int = VersionStringToInt(result, definition["recommended"].GetString());
+        if (definition.HasMember("not_recommended")) definition.RemoveMember("not_recommended");
+        definition.AddMember("not_recommended",
+                                tuw_constants::VERSION_INT != recom_int,
+                                definition.GetAllocator());
+    }
+    CorrectKey(definition, "minimum_required_version",
+                "minimum_required", definition.GetAllocator());
+    if (definition.HasMember("minimum_required")) {
+        CheckJsonType(result, definition, "minimum_required", JsonType::STRING);
+        if (!result.ok) return;
+        const char* required = definition["minimum_required"].GetString();
+        int required_int = VersionStringToInt(result, required);
+        if (tuw_constants::VERSION_INT < required_int) {
+            result.ok = false;
+            result.msg = noex::string("Version ") + required + " is required.";
+        }
+    }
+}
+
+void CheckDefinition(JsonResult& result, rapidjson::Document& definition) noexcept {
+    rapidjson::Document::AllocatorType& alloc = definition.GetAllocator();
+    if (!definition.HasMember("gui")) {
+        // definition["gui"] = definition
+        rapidjson::Value n(rapidjson::kObjectType);
+        n.CopyFrom(definition, alloc);
+        definition.AddMember("gui", n, alloc);
+    }
+    CheckJsonArrayType(result, definition, "gui", JsonType::JSON, alloc);
+    if (!result.ok) return;
+    if (definition["gui"].Size() == 0) {
+        result.ok = false;
+        result.msg = "The size of [\"gui\"] should NOT be zero.";
+    }
+
+    int i = 0;
+    for (rapidjson::Value& sub_d : definition["gui"].GetArray()) {
+        if (!result.ok) return;
+        CheckSubDefinition(result, sub_d, i, alloc);
+        i++;
+    }
+}
+
+void CheckHelpURLs(JsonResult& result, rapidjson::Document& definition) noexcept {
+    if (!definition.HasMember("help")) return;
+    CheckJsonArrayType(result, definition, "help", JsonType::JSON, definition.GetAllocator());
+    if (!result.ok) return;
+    for (const rapidjson::Value& h : definition["help"].GetArray()) {
+        CheckJsonType(result, h, "type", JsonType::STRING);
+        CheckJsonType(result, h, "label", JsonType::STRING);
+        if (!result.ok) return;
+        const char* type = h["type"].GetString();
+        if (strcmp(type, "url") == 0) {
+            CheckJsonType(result, h, "url", JsonType::STRING);
+        } else if (strcmp(type, "file") == 0) {
+            CheckJsonType(result, h, "path", JsonType::STRING);
+        } else {
+            result.ok = false;
+            result.msg = noex::string("Unsupported help type: ") + type;
+            return;
+        }
+    }
+}
+
 }  // namespace json_utils

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,7 +54,7 @@ json_utils::JsonResult Merge(const noex::string& exe_path, const noex::string& j
     json_utils::JsonResult result = json_utils::LoadJson(json_path, json);
     if (!result.ok) return result;
 
-    if (json.Size() == 0) {
+    if (!json.IsObject() || json.MemberEnd() - json.MemberBegin() <= 0) {
         PrintFmt("JSON file loaded but it has no data.\n");
         return JSON_RESULT_OK;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -240,7 +240,7 @@ int main(int argc, char* argv[]) noexcept {
     int cmd_int = CmdToInt(cmd_str);
     if (cmd_int == CMD_UNKNOWN) {
         PrintUsage();
-        fprintf(stderr, "Error: Unknown command detected. (%s)", cmd_str);
+        FprintFmt(stderr, "Error: Unknown command detected. (%s)", cmd_str);
         return 1;
     }
 
@@ -254,11 +254,11 @@ int main(int argc, char* argv[]) noexcept {
         int opt_int = OptToInt(opt_str);
         if ((opt_int == OPT_JSON || opt_int == OPT_EXE) && args.size() <= i + 1) {
             PrintUsage();
-            fprintf(stderr, "Error: This option requires a file path. (%s)\n", opt_str);
+            FprintFmt(stderr, "Error: This option requires a file path. (%s)\n", opt_str);
             return 1;
         } else if (opt_int == OPT_UNKNOWN) {
             PrintUsage();
-            fprintf(stderr, "Error: Unknown option detected. (%s)\n", opt_str);
+            FprintFmt(stderr, "Error: Unknown option detected. (%s)\n", opt_str);
             return 1;
         } else if (opt_int == OPT_JSON) {
             i++;
@@ -303,7 +303,7 @@ int main(int argc, char* argv[]) noexcept {
         PrintUsage();
 
     if (!err.empty()) {
-        fprintf(stderr, "Error: %s\n", err.c_str());
+        FprintFmt(stderr, "Error: %s\n", err.c_str());
         return 1;
     }
     return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,12 +50,12 @@ bool AskOverwrite(const char *path) noexcept {
 
 noex::string Merge(const noex::string& exe_path, const noex::string& json_path,
                     const noex::string& new_path, const bool force) noexcept {
-    rapidjson::Document json;
+    tuwjson::Value json;
     noex::string err;
     err = json_utils::LoadJson(json_path, json);
     if (!err.empty()) return err;
 
-    if (!json.IsObject() || json.ObjectEmpty()) {
+    if (!json.IsObject() || json.IsEmpty()) {
         PrintFmt("JSON file loaded but it has no data.\n");
         return "";
     }
@@ -92,7 +92,7 @@ noex::string Split(const noex::string& exe_path, const noex::string& json_path,
         return "";
     }
     PrintFmt("Extracting JSON data from the executable...\n");
-    rapidjson::Document json;
+    tuwjson::Value json;
     exe.GetJson(json);
     exe.RemoveJson();
     if (!force && (!AskOverwrite(new_path.c_str()) || !AskOverwrite(json_path.c_str()))) {
@@ -290,7 +290,6 @@ int main(int argc, char* argv[]) noexcept {
         return 1;
     }
 
-    rapidjson::Document json(rapidjson::kObjectType);
     noex::string err;
 
     if (cmd_int == CMD_MERGE)

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -254,7 +254,7 @@ static bool IsValidURL(const noex::string &url) noexcept {
     return true;
 }
 
-void MainFrame::OpenURL(int id) noexcept {
+noex::string MainFrame::OpenURL(int id) noexcept {
     rapidjson::Value& help = m_definition["help"].GetArray()[id];
     const char* type = help["type"].GetString();
     noex::string url;
@@ -273,13 +273,13 @@ void MainFrame::OpenURL(int id) noexcept {
                                 url + ")";
                 PrintFmt("%sError: %s\n", tag, msg.c_str());
                 ShowErrorDialog(msg);
-                return;
+                return msg;
             } else if (scheme != "https" && scheme != "http") {
                 noex::string msg = "Unsupported scheme detected. "
                                 "It should be http or https. (" + scheme + ")";
                 PrintFmt("%sError: %s\n", tag, msg.c_str());
                 ShowErrorDialog(msg);
-                return;
+                return msg;
             }
         } else {
             url = "https://" + url;
@@ -295,7 +295,7 @@ void MainFrame::OpenURL(int id) noexcept {
             noex::string msg = "File does not exist. (" + url + ")";
             PrintFmt("%sError: %s\n", tag, msg.c_str());
             ShowErrorDialog(msg);
-            return;
+            return msg;
         }
     }
 
@@ -310,7 +310,7 @@ void MainFrame::OpenURL(int id) noexcept {
                           "URL: " + url;
         PrintFmt("%sError: %s\n", tag, msg.c_str());
         ShowErrorDialog(msg.c_str());
-        return;
+        return msg;
     }
 
     if (IsSafeMode()) {
@@ -319,6 +319,7 @@ void MainFrame::OpenURL(int id) noexcept {
                            "\n"
                            "URL: " + url;
         ShowSuccessDialog(msg, "Safe Mode");
+        return msg;
     } else {
         if (noex::get_error_no() != noex::OK) {
             // Reject the URL as it might have an unexpected value.
@@ -328,6 +329,7 @@ void MainFrame::OpenURL(int id) noexcept {
                 "Please reboot the application.";
             PrintFmt("%sError: %s\n", tag, msg);
             ShowErrorDialog(msg);
+            return msg;
         } else {
             ExecuteResult result = LaunchDefaultApp(url);
             if (result.exit_code != 0) {
@@ -335,9 +337,11 @@ void MainFrame::OpenURL(int id) noexcept {
                                    type + " by an unexpected error.";
                 PrintFmt("%sError: %s\n", tag, msg.c_str());
                 ShowErrorDialog(msg.c_str());
+                return msg;
             }
         }
     }
+    return "";
 }
 
 static void OnClicked(uiButton *sender, void *data) noexcept {

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -368,6 +368,13 @@ void MainFrame::UpdatePanel(unsigned definition_id) noexcept {
     Component* new_comp = nullptr;
     if (sub_definition["components"].Size() > 0) {
         for (rapidjson::Value& c : sub_definition["components"].GetArray()) {
+            if (c["type_int"].GetInt() != COMP_STATIC_TEXT && !c.HasMember("id")) {
+                PrintFmt(
+                    "[UpdatePanel] DeprecationWarning: "
+                    "\"id\" is missing in [\"components\"][%d]. "
+                    "Support for components without \"id\" will be removed in a future version.\n",
+                    m_components.size());
+            }
             uiBox* priv_box = uiNewVerticalBox();
             uiBoxSetSpacing(priv_box, tuw_constants::BOX_SUB_SPACE);
             new_comp = Component::PutComponent(priv_box, c);

--- a/src/noex/string.cpp
+++ b/src/noex/string.cpp
@@ -154,7 +154,7 @@ void basic_string<charT>::append(const charT* str, size_t size) noexcept {
     if (!m_str || !str)
         return;
 
-    memcpy(m_str + m_size, str, size * sizeof(charT));
+    memcpy(m_str + m_size * sizeof(charT), str, size * sizeof(charT));
     m_str[new_size] = 0;
     m_size = new_size;
 }
@@ -297,7 +297,9 @@ void basic_string<charT>::erase(size_t pos, size_t n) noexcept {
         set_error_no(STR_BOUNDARY_ERROR);
         return;
     }
-    memcpy(m_str + pos, m_str + pos + n, m_size - pos - n);
+    memmove(m_str + pos * sizeof(charT),
+            m_str + (pos + n) * sizeof(charT),
+            (m_size - pos - n) * sizeof(charT));
     m_size -= n;
     m_str[m_size] = 0;
 }

--- a/src/noex/string.cpp
+++ b/src/noex/string.cpp
@@ -311,18 +311,70 @@ const charT& basic_string<charT>::operator[](size_t id) const noexcept {
     return c_str()[id];
 }
 
+template class basic_string<char>;
+template class basic_string<wchar_t>;
+
 template <typename charT>
 basic_string<charT> operator+(const charT* str1, const basic_string<charT>& str2) noexcept {
-    basic_string<charT> new_str(str1);
-    new_str += str2;
-    return new_str;
+    return concat_cstr(str1, str2.c_str());
 }
 template
 basic_string<char> operator+(const char* str1, const basic_string<char>& str2) noexcept;
 template
 basic_string<wchar_t> operator+(const wchar_t* str1, const basic_string<wchar_t>& str2) noexcept;
 
-template class basic_string<char>;
-template class basic_string<wchar_t>;
+template <typename charT>
+basic_string<charT> concat_cstr(const charT* str1, const charT* str2) noexcept {
+    if (!str1)
+        str1 = reinterpret_cast<const charT*>(dummy);
+    if (!str2)
+        str2 = reinterpret_cast<const charT*>(dummy);
+    size_t len1 = get_strlen(str1);
+    size_t len2 = get_strlen(str2);
+    basic_string<charT> str(len1 + len2);
+    charT* data = str.data();
+    if (!data)
+        return str;
+    memcpy(data, str1, len1 * sizeof(charT));
+    data += len1 * sizeof(charT);
+    memcpy(data, str2, len2 * sizeof(charT));
+    return str;
+}
+
+template
+basic_string<char> concat_cstr(const char* str1, const char* str2) noexcept;
+template
+basic_string<wchar_t> concat_cstr(const wchar_t* str1, const wchar_t* str2) noexcept;
+
+template <typename charT>
+basic_string<charT> concat_cstr(const charT* str1, const charT* str2, const charT* str3) noexcept {
+    if (!str1)
+        str1 = reinterpret_cast<const charT*>(dummy);
+    if (!str2)
+        str2 = reinterpret_cast<const charT*>(dummy);
+    if (!str3)
+        str3 = reinterpret_cast<const charT*>(dummy);
+    size_t len1 = get_strlen(str1);
+    size_t len2 = get_strlen(str2);
+    size_t len3 = get_strlen(str3);
+    basic_string<charT> str(len1 + len2 + len3);
+    charT* data = str.data();
+    if (!data)
+        return str;
+    memcpy(data, str1, len1 * sizeof(charT));
+    data += len1 * sizeof(charT);
+    memcpy(data, str2, len2 * sizeof(charT));
+    data += len2 * sizeof(charT);
+    memcpy(data, str3, len3 * sizeof(charT));
+    return str;
+}
+
+template
+basic_string<char> concat_cstr(
+    const char* str1, const char* str2, const char* str3) noexcept;
+template
+basic_string<wchar_t> concat_cstr(
+    const wchar_t* str1, const wchar_t* str2, const wchar_t* str3) noexcept;
+
 
 }  // namespace noex

--- a/src/noex/string.cpp
+++ b/src/noex/string.cpp
@@ -199,10 +199,11 @@ inline int snprintf_wrap(wchar_t* buf, size_t size, const char* fmt, \
 } \
 template <typename charT> \
 basic_string<charT> basic_string<charT>::to_string(num_type num) noexcept { \
-    charT buf[21]; /* assume that the max value of num has 20 digits (2^64). */ \
-    buf[20] = 0; \
-    int num_size = snprintf_wrap(buf, 21, "%" num_fmt, L"%" num_fmt, num); \
-    if (num_size <= 0 || num_size > 20) { \
+    /* assume that the max value of num has 24 characters (e.g. -1.7976931348623157e+308). */ \
+    charT buf[25]; \
+    buf[24] = 0; \
+    int num_size = snprintf_wrap(buf, 25, "%" num_fmt, L"%" num_fmt, num); \
+    if (num_size <= 0 || num_size > 24) { \
         set_error_no(STR_FORMAT_ERROR); \
         return basic_string<charT>(); \
     } \
@@ -217,6 +218,7 @@ basic_string<charT> basic_string<charT>::operator+(num_type num) const noexcept 
 DEFINE_TO_STRING(int, "d")
 DEFINE_TO_STRING(size_t, "zu")
 DEFINE_TO_STRING(uint32_t, PRIu32)
+DEFINE_TO_STRING(double, "lf")
 
 inline bool streq(const char* str1, const char* str2) noexcept {
     return strcmp(str1, str2) == 0;

--- a/src/noex/vector.cpp
+++ b/src/noex/vector.cpp
@@ -45,7 +45,7 @@ trivial_vector_base::trivial_vector_base(const trivial_vector_base& vec) noexcep
 trivial_vector_base::trivial_vector_base(trivial_vector_base&& vec) noexcept :
         m_data(nullptr), m_size(0), m_capacity(0),
         m_sizeof_type(vec.m_sizeof_type) {
-    assign(vec);
+    assign(static_cast<trivial_vector_base&&>(vec));
 }
 
 void trivial_vector_base::reserve(size_t capacity) noexcept {

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -85,15 +85,9 @@ noex::string ANSItoUTF8(const noex::string& str) noexcept {
 void FprintFmt(FILE* out, const char* fmt, ...) noexcept {
     va_list va;
     va_start(va, fmt);
-
-    va_list va2;
-    va_copy(va2, va);
-    size_t n = _vscprintf(fmt, va2);
-    va_end(va2);
-    n++;
-
+    size_t n = _vscprintf(fmt, va);
     noex::string buf = noex::string(n);
-    vsprintf_s(buf.data(), buf.size(), fmt, va);
+    vsprintf_s(buf.data(), buf.size() + 1, fmt, va);
     va_end(va);
 
     noex::wstring wbuf = UTF8toUTF16(buf.c_str());
@@ -203,10 +197,10 @@ void FprintFmt(FILE* out, const char* fmt, ...) noexcept {
     va_start(va, fmt);
     va_list va2;
     va_copy(va2, va);
-    size_t size = vsnprintf(NULL, 0, fmt, va2);
+    size_t n = vsnprintf(NULL, 0, fmt, va2);
     va_end(va2);
-    noex::string buf = noex::string(size + 1);
-    vsnprintf(buf.data(), buf.size(), fmt, va);
+    noex::string buf = noex::string(n);
+    vsnprintf(buf.data(), buf.size() + 1, fmt, va);
     g_logger.Log(buf.c_str());
     fprintf(out, "%s", buf.c_str());
     va_end(va);

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -37,9 +37,12 @@ noex::string envuStr(char *cstr) noexcept {
 static const uint32_t FNV_OFFSET_BASIS_32 = 2166136261U;
 static const uint32_t FNV_PRIME_32 = 16777619U;
 
-uint32_t Fnv1Hash32(const noex::string& str) noexcept {
+uint32_t Fnv1Hash32(const char* str) noexcept {
     uint32_t hash = FNV_OFFSET_BASIS_32;
-    for (const char c : str) hash = (FNV_PRIME_32 * hash) ^ c;
+    while (*str) {
+        hash = (FNV_PRIME_32 * hash) ^ *str;
+        str++;
+    }
     return hash;
 }
 

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -10,9 +10,11 @@ void Validator::Initialize(const rapidjson::Value& j) noexcept {
     m_wildcard = json_utils::GetString(j, "wildcard", "");
     m_wildcard_error = json_utils::GetString(j, "wildcard_error", "");
     m_not_empty = json_utils::GetBool(j, "not_empty", false);
-    m_not_empty_error = json_utils::GetString(j, "not_empty_error", "");
+    m_not_empty_error = json_utils::GetString(
+        j, "not_empty_error", "Empty string is NOT allowed.");
     m_exist = json_utils::GetBool(j, "exist", false);
-    m_exist_error = json_utils::GetString(j, "exist_error", "");
+    m_exist_error = json_utils::GetString(
+        j, "exist_error", "Path does NOT exist.");
     m_error_msg = "";
 }
 
@@ -35,10 +37,7 @@ static int IsUnsupportedPattern(const char *pattern) noexcept {
 
 bool Validator::Validate(const noex::string& str) noexcept {
     if (m_not_empty && str.empty()) {
-        if (m_not_empty_error.empty())
-            m_error_msg = "Empty string is NOT allowed.";
-        else
-            m_error_msg = m_not_empty_error;
+        m_error_msg = m_not_empty_error;
         return false;
     }
     if (!m_wildcard.empty()) {
@@ -69,10 +68,7 @@ bool Validator::Validate(const noex::string& str) noexcept {
         }
     }
     if (m_exist && !envuPathExists(str.c_str())) {
-        if (m_exist_error.empty())
-            m_error_msg = "Path does NOT exist.";
-        else
-            m_error_msg = m_exist_error;
+        m_error_msg = m_exist_error;
         return false;
     }
     m_error_msg = "";

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -4,7 +4,7 @@
 #include "env_utils.h"
 #include "string_utils.h"
 
-void Validator::Initialize(const rapidjson::Value& j) noexcept {
+void Validator::Initialize(const tuwjson::Value& j) noexcept {
     m_regex = json_utils::GetString(j, "regex", "");
     m_regex_error = json_utils::GetString(j, "regex_error", "");
     m_wildcard = json_utils::GetString(j, "wildcard", "");

--- a/subprojects/env_utils.wrap
+++ b/subprojects/env_utils.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/matyalatte/c-env-utils.git
-revision = v0.3.1
+revision = 07257be6d3aa41de8f39e0d721b60850ee8b198d
 depth = 1
 
 [provide]

--- a/subprojects/packagefiles/rapidjson/meson.build
+++ b/subprojects/packagefiles/rapidjson/meson.build
@@ -1,4 +1,0 @@
-project('rapidjson', 'cpp', version: '1.1.0', license: 'MIT')
-
-rapidjson_inc = include_directories('include')
-rapidjson_dep = declare_dependency(include_directories: rapidjson_inc)

--- a/subprojects/rapidjson.wrap
+++ b/subprojects/rapidjson.wrap
@@ -1,8 +1,0 @@
-[wrap-git]
-url = https://github.com/Tencent/rapidjson.git
-revision = 476ffa2fd272243275a74c36952f210267dc3088
-depth=1
-patch_directory = rapidjson
-
-[provide]
-rapidjson = rapidjson_dep

--- a/subprojects/tiny_str_match.wrap
+++ b/subprojects/tiny_str_match.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/matyalatte/tiny-str-match.git
-revision = b0d341188c3461d9b0ce302757b8bef8a0f79c17
+revision = 62bcb1659d4ffde539316203e5e6ee8bda8caed1
 depth = 1
 
 [provide]

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,0 +1,53 @@
+"""Tests for command-line features of Tuw"""
+import os
+import subprocess
+import difflib
+
+def run_command(command, should_succeed=True):
+    """Runs a shell command."""
+    print(f"Running: {command}")
+    result = subprocess.run(command, shell=True, capture_output=True, text=True)
+    if should_succeed and result.returncode != 0:
+        raise RuntimeError(f"Error running command: {command}\n{result.stderr}")
+    return result
+
+
+def load_text(file_path):
+    """Loads a file as text."""
+    with open(file_path, "r", encoding="utf-8") as f:
+        return f.readlines()
+
+
+def compare_text(text1, text2):
+    """Compares two text files and prints differences."""
+    diff = list(difflib.unified_diff(text1, text2, fromfile="test.json", tofile="test2.json", lineterm=""))
+
+    if diff:
+        print("Differences found:")
+        for line in diff:
+            print(line, end="")
+        raise RuntimeError("Failed to embed JSON.")
+    else:
+        print("Succeed in embedding JSON.")
+
+
+if __name__ == "__main__":
+    # Test if merge and split commands preserve JSON.
+    if os.name == "nt":
+        ext = ".exe"
+        sep = "\\"
+    else:
+        ext = ""
+        sep = "/"
+    json_path = f"json{sep}help.json"
+    json_out_path = f"out.json"
+
+    run_command(f"..{sep}Tuw{ext} merge -j {json_path} -e Tuw.new{ext} -f")
+    run_command(f".{sep}Tuw.new{ext} split -j {json_out_path} -e Tuw.orig{ext} -f")
+
+    # Check if both files were the same or not
+    json1 = load_text(json_path)
+    json2 = load_text(json_out_path)
+    if json2[-1][-1] != "\n":
+        json2[-1] += "\n"
+    compare_text(json1, json2)

--- a/tests/exe_container_test.cpp
+++ b/tests/exe_container_test.cpp
@@ -9,13 +9,11 @@ TEST(JsonEmbeddingTest, Embed) {
         test_json.SetObject();
         GetTestJson(test_json);
         ExeContainer exe;
-        json_utils::JsonResult result = exe.Read(JSON_ALL_KEYS);
-        EXPECT_TRUE(result.ok);
-        EXPECT_STREQ("", result.msg.c_str());
+        noex::string result = exe.Read(JSON_ALL_KEYS);
+        EXPECT_STREQ("", result.c_str());
         exe.SetJson(test_json);
         result = exe.Write("embedded.json");
-        EXPECT_TRUE(result.ok);
-        EXPECT_STREQ("", result.msg.c_str());
+        EXPECT_STREQ("", result.c_str());
     }
     {
         rapidjson::Document test_json;
@@ -24,9 +22,8 @@ TEST(JsonEmbeddingTest, Embed) {
         rapidjson::Document embedded_json;
         embedded_json.SetObject();
         ExeContainer exe;
-        json_utils::JsonResult result = exe.Read("embedded.json");
-        EXPECT_TRUE(result.ok);
-        EXPECT_STREQ("", result.msg.c_str());
+        noex::string result = exe.Read("embedded.json");
+        EXPECT_STREQ("", result.c_str());
         exe.GetJson(embedded_json);
         EXPECT_EQ(embedded_json, test_json);
     }

--- a/tests/exe_container_test.cpp
+++ b/tests/exe_container_test.cpp
@@ -5,7 +5,7 @@
 
 TEST(JsonEmbeddingTest, Embed) {
     {
-        rapidjson::Document test_json;
+        tuwjson::Value test_json;
         test_json.SetObject();
         GetTestJson(test_json);
         ExeContainer exe;
@@ -16,10 +16,10 @@ TEST(JsonEmbeddingTest, Embed) {
         EXPECT_STREQ("", result.c_str());
     }
     {
-        rapidjson::Document test_json;
+        tuwjson::Value test_json;
         test_json.SetObject();
         GetTestJson(test_json);
-        rapidjson::Document embedded_json;
+        tuwjson::Value embedded_json;
         embedded_json.SetObject();
         ExeContainer exe;
         noex::string result = exe.Read("embedded.json");

--- a/tests/json/meson.build
+++ b/tests/json/meson.build
@@ -12,8 +12,15 @@ foreach f : files
         copy: true)
 endforeach
 
-# copy an example file for testing
-configure_file(input : meson.project_source_root() +
-                       '/examples/all_keys/gui_definition.json',
-        output : 'gui_definition.json',
-        copy: true)
+# copy example files for testing
+configure_file(
+    input : meson.project_source_root() +
+            '/examples/all_keys/gui_definition.json',
+    output : 'gui_definition.json',
+    copy: true)
+
+configure_file(
+    input : meson.project_source_root() +
+            '/examples/other_features/help/gui_definition.json',
+    output : 'help.json',
+    copy: true)

--- a/tests/json/meson.build
+++ b/tests/json/meson.build
@@ -13,14 +13,14 @@ foreach f : files
 endforeach
 
 # copy example files for testing
-configure_file(
-    input : meson.project_source_root() +
-            '/examples/all_keys/gui_definition.json',
-    output : 'gui_definition.json',
-    copy: true)
-
-configure_file(
-    input : meson.project_source_root() +
-            '/examples/other_features/help/gui_definition.json',
-    output : 'help.json',
-    copy: true)
+examples = [
+    ['all_keys/gui_definition.json', 'gui_definition.json'],
+    ['other_features/help/gui_definition.json', 'help.json'],
+    ['other_features/cross_platform/gui_definition.json', 'platform.json'],
+]
+foreach e : examples
+    configure_file(
+        input : meson.project_source_root() + '/examples/' + e[0],
+        output : e[1],
+        copy: true)
+endforeach

--- a/tests/json_check_test.cpp
+++ b/tests/json_check_test.cpp
@@ -5,26 +5,24 @@
 
 TEST(JsonCheckTest, LoadJsonFail) {
     rapidjson::Document test_json;
-    json_utils::JsonResult result = json_utils::LoadJson("fake.json", test_json);
+    noex::string err = json_utils::LoadJson("fake.json", test_json);
     const char* expected = "Failed to open fake.json";
-    EXPECT_FALSE(result.ok);
-    EXPECT_STREQ(expected, result.msg.c_str());
+    EXPECT_STREQ(expected, err.c_str());
 }
 
 TEST(JsonCheckTest, LoadJsonFail2) {
     rapidjson::Document test_json;
-    json_utils::JsonResult result = json_utils::LoadJson(JSON_BROKEN, test_json);
+    noex::string err = json_utils::LoadJson(JSON_BROKEN, test_json);
     const char* expected = "Failed to parse JSON: Missing a comma or '}'"
                            " after an object member.";
-    EXPECT_FALSE(result.ok);
-    EXPECT_STREQ(expected, result.msg.substr(0, 68).c_str());
+    EXPECT_STREQ(expected, err.substr(0, 68).c_str());
 }
 
 TEST(JsonCheckTest, LoadJsonWithComments) {
     // Check if json parser supports c-style comments and trailing commas.
     rapidjson::Document test_json;
-    json_utils::JsonResult result = json_utils::LoadJson(JSON_RELAXED, test_json);
-    EXPECT_TRUE(result.ok);
+    noex::string err = json_utils::LoadJson(JSON_RELAXED, test_json);
+    EXPECT_TRUE(err.empty());
 }
 
 TEST(JsonCheckTest, LoadJsonSuccess) {
@@ -71,8 +69,9 @@ TEST(JsonCheckTest, checkGUISuccess4) {
 
 TEST(JsonCheckTest, checkGUISuccessRelaxed) {
     rapidjson::Document test_json;
-    json_utils::JsonResult result = json_utils::LoadJson(JSON_RELAXED, test_json);
-    EXPECT_TRUE(result.ok);
+    noex::string err = json_utils::LoadJson(JSON_RELAXED, test_json);
+    EXPECT_TRUE(err.empty());
+    json_utils::JsonResult result = JSON_RESULT_OK;
     json_utils::CheckDefinition(result, test_json);
     EXPECT_TRUE(result.ok);
 }
@@ -144,8 +143,8 @@ TEST(JsonCheckTest, checkGUIFail7) {
 
 TEST(JsonCheckTest, checkGUIFailRelaxed) {
     rapidjson::Document test_json;
-    json_utils::JsonResult result = json_utils::LoadJson(JSON_RELAXED, test_json);
-    EXPECT_TRUE(result.ok);
+    noex::string err = json_utils::LoadJson(JSON_RELAXED, test_json);
+    EXPECT_TRUE(err.empty());
     test_json.AddMember("exit_success", "a", test_json.GetAllocator());
     CheckGUIError(test_json, "['exit_success'] should be an int.");
 }

--- a/tests/json_check_test.cpp
+++ b/tests/json_check_test.cpp
@@ -140,6 +140,15 @@ TEST(JsonCheckTest, checkGUIFail7) {
         " & echo textbox: __comp7__ & echo int: __comp8__ & echo float: __comp9__");
 }
 
+TEST(JsonCheckTest, checkGUIFail8) {
+    tuwjson::Value test_json;
+    GetTestJson(test_json);
+    test_json["gui"][0]["components"][0]["id"].SetString("aaa");
+    test_json["gui"][0]["components"][1]["id"].SetString("aaa");
+    CheckGUIError(test_json,
+        "Found a duplicated id: \"aaa\" (line: 15, column: 27)");
+}
+
 TEST(JsonCheckTest, checkGUIFailRelaxed) {
     tuwjson::Value test_json;
     noex::string err = json_utils::LoadJson(JSON_RELAXED, test_json);

--- a/tests/json_check_test.cpp
+++ b/tests/json_check_test.cpp
@@ -6,7 +6,7 @@
 TEST(JsonCheckTest, LoadJsonFail) {
     rapidjson::Document test_json;
     noex::string err = json_utils::LoadJson("fake.json", test_json);
-    const char* expected = "Failed to open fake.json";
+    const char* expected = "No such file or directory: fake.json";
     EXPECT_STREQ(expected, err.c_str());
 }
 

--- a/tests/json_check_test.cpp
+++ b/tests/json_check_test.cpp
@@ -4,34 +4,35 @@
 #include "test_utils.h"
 
 TEST(JsonCheckTest, LoadJsonFail) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     noex::string err = json_utils::LoadJson("fake.json", test_json);
     const char* expected = "No such file or directory: fake.json";
     EXPECT_STREQ(expected, err.c_str());
 }
 
 TEST(JsonCheckTest, LoadJsonFail2) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     noex::string err = json_utils::LoadJson(JSON_BROKEN, test_json);
-    const char* expected = "Failed to parse JSON: Missing a comma or '}'"
-                           " after an object member.";
-    EXPECT_STREQ(expected, err.substr(0, 68).c_str());
+    const char* expected =
+        "Failed to parse JSON: comma ',' or closing brace '}' is missing"
+        " (line: 7, column: 5)";
+    EXPECT_STREQ(expected, err.c_str());
 }
 
 TEST(JsonCheckTest, LoadJsonWithComments) {
     // Check if json parser supports c-style comments and trailing commas.
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     noex::string err = json_utils::LoadJson(JSON_RELAXED, test_json);
     EXPECT_TRUE(err.empty());
 }
 
 TEST(JsonCheckTest, LoadJsonSuccess) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
 }
 
 TEST(JsonCheckTest, checkGUISuccess) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     json_utils::JsonResult result = JSON_RESULT_OK;
     json_utils::CheckDefinition(result, test_json);
@@ -39,18 +40,17 @@ TEST(JsonCheckTest, checkGUISuccess) {
 }
 
 TEST(JsonCheckTest, checkGUISuccess2) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
-    rapidjson::Value& comp = test_json["gui"][0]["components"][6];
-    comp.AddMember("item_array", comp["items"], test_json.GetAllocator());
-    comp.RemoveMember("items");
+    tuwjson::Value& comp = test_json["gui"][0]["components"][6];
+    comp.ReplaceKey("items", "item_array");
     json_utils::JsonResult result = JSON_RESULT_OK;
     json_utils::CheckDefinition(result, test_json);
     EXPECT_TRUE(result.ok);
 }
 
 TEST(JsonCheckTest, checkGUISuccess3) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"][0].Swap(test_json["gui"][1]);
     json_utils::JsonResult result = JSON_RESULT_OK;
@@ -59,7 +59,7 @@ TEST(JsonCheckTest, checkGUISuccess3) {
 }
 
 TEST(JsonCheckTest, checkGUISuccess4) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"][0].Swap(test_json["gui"][2]);
     json_utils::JsonResult result = JSON_RESULT_OK;
@@ -68,7 +68,7 @@ TEST(JsonCheckTest, checkGUISuccess4) {
 }
 
 TEST(JsonCheckTest, checkGUISuccessRelaxed) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     noex::string err = json_utils::LoadJson(JSON_RELAXED, test_json);
     EXPECT_TRUE(err.empty());
     json_utils::JsonResult result = JSON_RESULT_OK;
@@ -76,7 +76,7 @@ TEST(JsonCheckTest, checkGUISuccessRelaxed) {
     EXPECT_TRUE(result.ok);
 }
 
-void CheckGUIError(rapidjson::Document& test_json, const char* expected) {
+void CheckGUIError(tuwjson::Value& test_json, const char* expected) {
     json_utils::JsonResult result = JSON_RESULT_OK;
     json_utils::CheckDefinition(result, test_json);
     EXPECT_FALSE(result.ok);
@@ -84,44 +84,44 @@ void CheckGUIError(rapidjson::Document& test_json, const char* expected) {
 }
 
 TEST(JsonCheckTest, checkGUIFail) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
-    test_json.RemoveMember("gui");
-    CheckGUIError(test_json, "['components'] not found.");
+    test_json.ReplaceKey("gui", "g");
+    CheckGUIError(test_json, "gui definition requires \"components\"");
 }
 
 TEST(JsonCheckTest, checkGUIFail2) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
-    test_json["gui"][0]["components"][6].RemoveMember("items");
-    CheckGUIError(test_json, "['options']['items'] not found.");
+    test_json["gui"][0]["components"][6].ReplaceKey("items", "notitems");
+    CheckGUIError(test_json, "check array requires \"items\" (line: 60, column: 17)");
 }
 
 TEST(JsonCheckTest, checkGUIFail3) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"].SetInt(1);
-    CheckGUIError(test_json, "['gui'] should be an array of json objects.");
+    CheckGUIError(test_json, "\"gui\" should be an array of json objects (line: 4, column: 12)");
 }
 
 TEST(JsonCheckTest, checkGUIFail4) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"][0]["components"][0]["label"].SetInt(1);
-    CheckGUIError(test_json, "['components']['label'] should be a string.");
+    CheckGUIError(test_json, "\"label\" should be a string (line: 11, column: 30)");
 }
 
 TEST(JsonCheckTest, checkGUIFail5) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"][2]["show_last_line"].SetString("test");
-    CheckGUIError(test_json, "['show_last_line'] should be a boolean.");
+    CheckGUIError(test_json, "\"show_last_line\" should be a boolean (line: 267, column: 31)");
 }
 
 TEST(JsonCheckTest, checkGUIFail6) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
-    test_json["gui"][0]["components"].PopBack();
+    test_json["gui"][0]["components"].GetArray()->pop_back();
     CheckGUIError(test_json,
         "The command requires more components for arguments;"
         " echo file: __comp1__ & echo folder: __comp2__ & echo combo: __comp3__ &"
@@ -130,34 +130,33 @@ TEST(JsonCheckTest, checkGUIFail6) {
 }
 
 TEST(JsonCheckTest, checkGUIFail7) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
-    test_json["gui"][0]["components"][1].RemoveMember("id");
-    test_json["gui"][0]["components"][1].AddMember("id", "aaa", test_json.GetAllocator());
+    test_json["gui"][0]["components"][1]["id"].SetString("aaa");
     CheckGUIError(test_json,
-        "The ID of [\"components\"][1] is unused in the command;"
+        "component id \"aaa\" (line: 15, column: 27) is unused in the command;"
         " echo file: __comp???__ & echo folder: __comp2__ & echo combo: __comp3__"
         " & echo radio: __comp4__ & echo check: __comp5__ & echo check_array: __comp6__"
         " & echo textbox: __comp7__ & echo int: __comp8__ & echo float: __comp9__");
 }
 
 TEST(JsonCheckTest, checkGUIFailRelaxed) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     noex::string err = json_utils::LoadJson(JSON_RELAXED, test_json);
     EXPECT_TRUE(err.empty());
-    test_json.AddMember("exit_success", "a", test_json.GetAllocator());
-    CheckGUIError(test_json, "['exit_success'] should be an int.");
+    test_json["exit_success"].SetString("a");
+    CheckGUIError(test_json, "\"exit_success\" should be an int");
 }
 
 TEST(JsonCheckTest, checkHelpSuccess) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     json_utils::JsonResult result = JSON_RESULT_OK;
     json_utils::CheckHelpURLs(result, test_json);
     EXPECT_TRUE(result.ok);
 }
 
-void CheckHelpError(rapidjson::Document& test_json, const char* expected) {
+void CheckHelpError(tuwjson::Value& test_json, const char* expected) {
     json_utils::JsonResult result = JSON_RESULT_OK;
     json_utils::CheckHelpURLs(result, test_json);
     EXPECT_FALSE(result.ok);
@@ -165,21 +164,21 @@ void CheckHelpError(rapidjson::Document& test_json, const char* expected) {
 }
 
 TEST(JsonCheckTest, checkHelpFail) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
-    test_json["help"][0].RemoveMember("label");
-    CheckHelpError(test_json, "['label'] not found.");
+    test_json["help"][0].ReplaceKey("label", "notlabel");
+    CheckHelpError(test_json, "help document requires \"label\" (line: 280, column: 9)");
 }
 
 TEST(JsonCheckTest, checkHelpFail2) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["help"][0]["label"].SetInt(3);
-    CheckHelpError(test_json, "['label'] should be a string.");
+    CheckHelpError(test_json, "\"label\" should be a string (line: 282, column: 22)");
 }
 
 TEST(JsonCheckTest, checkVersionSuccess) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["recommended"].SetString(tuw_constants::VERSION);
     json_utils::JsonResult result = JSON_RESULT_OK;
@@ -189,7 +188,7 @@ TEST(JsonCheckTest, checkVersionSuccess) {
 }
 
 TEST(JsonCheckTest, checkVersionFail) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["recommended"].SetString("0.2.3");
     json_utils::JsonResult result = JSON_RESULT_OK;
@@ -199,7 +198,7 @@ TEST(JsonCheckTest, checkVersionFail) {
 }
 
 TEST(JsonCheckTest, checkVersionFail2) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["recommended"].SetString("foo");
     json_utils::JsonResult result = JSON_RESULT_OK;
@@ -209,7 +208,7 @@ TEST(JsonCheckTest, checkVersionFail2) {
 }
 
 TEST(JsonCheckTest, checkVersionSuccess2) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["minimum_required"].SetString(tuw_constants::VERSION);
     json_utils::JsonResult result = JSON_RESULT_OK;
@@ -218,7 +217,7 @@ TEST(JsonCheckTest, checkVersionSuccess2) {
 }
 
 TEST(JsonCheckTest, checkVersionFail3) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["minimum_required"].SetString("1.0.0");
     json_utils::JsonResult result = JSON_RESULT_OK;
@@ -228,7 +227,7 @@ TEST(JsonCheckTest, checkVersionFail3) {
 }
 
 TEST(JsonCheckTest, checkVersionFail4) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["minimum_required"].SetString("foo");
     json_utils::JsonResult result = JSON_RESULT_OK;

--- a/tests/json_test.cpp
+++ b/tests/json_test.cpp
@@ -1,0 +1,484 @@
+#include "test_utils.h"
+
+class JsonParseTest : public ::testing::Test {
+ protected:
+    tuwjson::Value root;
+    tuwjson::Parser parser;
+};
+
+static double eps = 0.00001;
+
+TEST_F(JsonParseTest, ParseEmpty) {
+    tuwjson::Error err = parser.ParseJson("  ", &root);
+    EXPECT_EQ(err, tuwjson::JSON_OK);
+    EXPECT_TRUE(root.IsNull());
+}
+
+TEST_F(JsonParseTest, ParseNull) {
+    tuwjson::Error err = parser.ParseJson("  null  ", &root);
+    EXPECT_EQ(err, tuwjson::JSON_OK);
+    EXPECT_TRUE(root.IsNull());
+}
+
+TEST_F(JsonParseTest, ParseTrue) {
+    tuwjson::Error err = parser.ParseJson("  true  ", &root);
+    EXPECT_EQ(err, tuwjson::JSON_OK);
+    EXPECT_TRUE(root.IsBool());
+    EXPECT_TRUE(root.GetBool());
+}
+
+TEST_F(JsonParseTest, ParseFalse) {
+    tuwjson::Error err = parser.ParseJson("  false  ", &root);
+    EXPECT_EQ(err, tuwjson::JSON_OK);
+    EXPECT_TRUE(root.IsBool());
+    EXPECT_FALSE(root.GetBool());
+}
+
+TEST_F(JsonParseTest, ParseInt) {
+    tuwjson::Error err = parser.ParseJson("  123  ", &root);
+    EXPECT_EQ(err, tuwjson::JSON_OK);
+    EXPECT_TRUE(root.IsInt());
+    EXPECT_EQ(root.GetInt(), 123);
+    EXPECT_TRUE(root.IsDouble());
+    EXPECT_NEAR(root.GetDouble(), 123.0, eps);
+}
+
+TEST_F(JsonParseTest, ParseDouble) {
+    tuwjson::Error err = parser.ParseJson("  -12.3e-1  ", &root);
+    EXPECT_EQ(err, tuwjson::JSON_OK);
+    EXPECT_TRUE(root.IsDouble());
+    EXPECT_NEAR(root.GetDouble(), -1.23, eps);
+}
+
+TEST_F(JsonParseTest, ParseString) {
+    tuwjson::Error err = parser.ParseJson("  \"abcdefg\"  ", &root);
+    EXPECT_EQ(err, tuwjson::JSON_OK);
+    EXPECT_TRUE(root.IsString());
+    EXPECT_STREQ(root.GetString(), "abcdefg");
+}
+
+TEST_F(JsonParseTest, ParseStringEscape) {
+    tuwjson::Error err = parser.ParseJson("  \"\\\"\\\\\\/\\b\\f\\n\\r\\t\"  ", &root);
+    EXPECT_EQ(err, tuwjson::JSON_OK);
+    EXPECT_TRUE(root.IsString());
+    EXPECT_STREQ(root.GetString(), "\"\\/\b\f\n\r\t");
+}
+
+TEST_F(JsonParseTest, ParseStringUTF) {
+    tuwjson::Error err = parser.ParseJson("  \"\xc2\x80\xe0\x80\xbf\xf0\x80\xbf\xa0\"  ", &root);
+    EXPECT_EQ(err, tuwjson::JSON_OK);
+    EXPECT_TRUE(root.IsString());
+    EXPECT_STREQ(root.GetString(), "\xc2\x80\xe0\x80\xbf\xf0\x80\xbf\xa0");
+}
+
+TEST_F(JsonParseTest, ParseArray) {
+    tuwjson::Error err = parser.ParseJson("  [\"abcdefg\", 1,true,]  ", &root);
+    EXPECT_EQ(err, tuwjson::JSON_OK);
+    EXPECT_TRUE(root.IsArray());
+    EXPECT_FALSE(root.IsEmpty());
+    EXPECT_EQ(root.Size(), 3);
+    EXPECT_TRUE(root[0].IsString());
+    EXPECT_STREQ(root[0].GetString(), "abcdefg");
+    EXPECT_TRUE(root[1].IsInt());
+    EXPECT_EQ(root[1].GetInt(), 1);
+    EXPECT_TRUE(root[2].IsBool());
+    EXPECT_TRUE(root[2].GetBool());
+}
+
+TEST_F(JsonParseTest, ParseObject) {
+    tuwjson::Error err = parser.ParseJson(" { \"key\" : \"val\",\"key2\":2.3} ", &root);
+    EXPECT_EQ(err, tuwjson::JSON_OK);
+    EXPECT_TRUE(root.IsObject());
+    EXPECT_FALSE(root.IsEmpty());
+    EXPECT_EQ(root.Size(), 2);
+    EXPECT_TRUE(root["key"].IsString());
+    EXPECT_STREQ(root["key"].GetString(), "val");
+    EXPECT_TRUE(root["key2"].IsDouble());
+    EXPECT_NEAR(root["key2"].GetDouble(), 2.3, eps);
+}
+
+TEST_F(JsonParseTest, ParseLargeObject) {
+    tuwjson::Error err = parser.ParseJson(
+        "{\r\n"
+        "// comment\n"
+        "    \"key\" : \"val\", // comment\r\n"
+        "    \"key2\": 2.3, \r\n"
+        "    \"ary\": [\n"
+        "        true, false, -10001, \"str\", null,\n"
+        "    ], /* comment\n"
+        "hoo bar */ }\n",
+        &root);
+    EXPECT_EQ(err, tuwjson::JSON_OK);
+    EXPECT_TRUE(root.IsObject());
+    EXPECT_FALSE(root.IsEmpty());
+    EXPECT_EQ(root.Size(), 3);
+    EXPECT_TRUE(root["key"].IsString());
+    EXPECT_STREQ(root["key"].GetString(), "val");
+    EXPECT_TRUE(root["key2"].IsDouble());
+    EXPECT_NEAR(root["key2"].GetDouble(), 2.3, eps);
+    tuwjson::Value& ary = root["ary"];
+    EXPECT_TRUE(ary.IsArray());
+    EXPECT_EQ(ary.Size(), 5);
+    EXPECT_TRUE(ary[0].IsBool());
+    EXPECT_TRUE(ary[0].GetBool());
+    EXPECT_TRUE(ary[1].IsBool());
+    EXPECT_FALSE(ary[1].GetBool());
+    EXPECT_TRUE(ary[2].IsInt());
+    EXPECT_EQ(ary[2].GetInt(), -10001);
+    EXPECT_TRUE(ary[3].IsString());
+    EXPECT_STREQ(ary[3].GetString(), "str");
+    EXPECT_TRUE(ary[4].IsNull());
+}
+
+struct ParseFailCase {
+    const char* json;
+    tuwjson::Error err;
+    const char* err_msg;
+};
+
+class ParseFailTest : public ::testing::TestWithParam<ParseFailCase> {
+ protected:
+    tuwjson::Value root;
+    tuwjson::Parser parser;
+};
+
+const ParseFailCase parse_fail_cases[] = {
+    {
+        "{\r\n\"a\": NaN\r\n}",
+        tuwjson::JSON_ERR_UNKNOWN_LITERAL,
+        "unknown literal detected (line: 2, column: 6)"
+    },
+    {
+        "1.a",
+        tuwjson::JSON_ERR_UNKNOWN_LITERAL,
+        "unknown literal detected (line: 1, column: 1)"
+    },
+    {
+        "{\"\xc2\xbe" "abc\xbf" "\": true}",
+        tuwjson::JSON_ERR_INVALID_UTF,
+        "invalid UTF8 character detected (line: 1, column: 8)"
+    },
+    {
+        "\xc2\x32}",
+        tuwjson::JSON_ERR_INVALID_UTF,
+        "invalid UTF8 character detected (line: 1, column: 2)"
+    },
+    {
+        "\xf5\xbe\xbe\xbe",
+        tuwjson::JSON_ERR_INVALID_UTF,
+        "invalid UTF8 character detected (line: 1, column: 1)"
+    },
+    {
+        "1111111111111111111111111",
+        tuwjson::JSON_ERR_INVALID_INT,
+        "failed to parse an integer (line: 1, column: 1)"
+    },
+    {
+        "1.9123749837249827349e-10938903810",
+        tuwjson::JSON_ERR_INVALID_DOUBLE,
+        "failed to parse a double number (line: 1, column: 1)"
+    },
+    {
+        "[\ntrue,\n,false]",
+        tuwjson::JSON_ERR_INVALID_COMMA,
+        "there is a comma in the wrong position (line: 3, column: 1)"
+    },
+    {
+        "{\"\ba\": true}",
+        tuwjson::JSON_ERR_CONTROL_CHAR,
+        "there is a control character in a string (line: 1, column: 3)"
+    },
+    {
+        "\"\\\ta\"",
+        tuwjson::JSON_ERR_CONTROL_CHAR,
+        "there is a control character in a string (line: 1, column: 3)"
+    },
+    {
+        "\"\\a\"",
+        tuwjson::JSON_ERR_INVALID_ESCAPE,
+        "invalid escaped character: \\a (line: 1, column: 3)"
+    },
+    {
+        "\"\\u0034\"",
+        tuwjson::JSON_ERR_UNICODE_ESCAPE,
+        "unicode escape (\\uXXXX) is not supported. "
+        "use UTF-8 characters instead (line: 1, column: 3)"
+    },
+    {
+        "\"abcd",
+        tuwjson::JSON_ERR_UNCLOSED_STR,
+        "string is not closed with '\"' (line: 1, column: 5)"
+    },
+    {
+        "\"abc\nd\"",
+        tuwjson::JSON_ERR_UNCLOSED_STR,
+        "string is not closed with '\"' (line: 1, column: 4)"
+    },
+    {
+        "[\ntrue, false /* \n]",
+        tuwjson::JSON_ERR_UNCLOSED_COMMENT,
+        "multiline comment is not closed (line: 3, column: 2)"
+    },
+    {
+        "[\ntrue, /* false\n]",
+        tuwjson::JSON_ERR_UNCLOSED_COMMENT,
+        "multiline comment is not closed (line: 3, column: 2)"
+    },
+    {
+        "[\ntrue /* , false\n]",
+        tuwjson::JSON_ERR_UNCLOSED_COMMENT,
+        "multiline comment is not closed (line: 3, column: 2)"
+    },
+    {
+        "{\n\"key\": \"val\" /* \n}",
+        tuwjson::JSON_ERR_UNCLOSED_COMMENT,
+        "multiline comment is not closed (line: 3, column: 2)"
+    },
+    {
+        "{\n\"key\": /* \"val\" \n}",
+        tuwjson::JSON_ERR_UNCLOSED_COMMENT,
+        "multiline comment is not closed (line: 3, column: 2)"
+    },
+    {
+        "{\n\"key\"/* : \"val\" \n}",
+        tuwjson::JSON_ERR_UNCLOSED_COMMENT,
+        "multiline comment is not closed (line: 3, column: 2)"
+    },
+    {
+        "{\n/* \"key\": \"val\" \n}",
+        tuwjson::JSON_ERR_UNCLOSED_COMMENT,
+        "multiline comment is not closed (line: 3, column: 2)"
+    },
+    {
+        "[true, false",
+        tuwjson::JSON_ERR_UNCLOSED_ARRAY,
+        "comma ',' or closing bracket ']' is missing (line: 1, column: 13)"
+    },
+    {
+        "[true, false false]",
+        tuwjson::JSON_ERR_UNCLOSED_ARRAY,
+        "comma ',' or closing bracket ']' is missing (line: 1, column: 14)"
+    },
+    {
+        "{\"a\":true",
+        tuwjson::JSON_ERR_UNCLOSED_OBJECT,
+        "comma ',' or closing brace '}' is missing (line: 1, column: 10)"
+    },
+    {
+        "{\"a\":true \"b\":true}",
+        tuwjson::JSON_ERR_UNCLOSED_OBJECT,
+        "comma ',' or closing brace '}' is missing (line: 1, column: 11)"
+    },
+    {
+        "{\"a\", true}",
+        tuwjson::JSON_ERR_EXPECTED_COLON,
+        "colon ':' is missing (line: 1, column: 5)"
+    },
+    {
+        "{1: true}",
+        tuwjson::JSON_ERR_INVALID_KEY,
+        "string key is missing (line: 1, column: 2)"
+    },
+    {
+        "{\n\"a\": true,\n\"a\": false}",
+        tuwjson::JSON_ERR_DUPLICATED_KEY,
+        "there is a duplicated key (line: 3, column: 1)"
+    },
+};
+
+INSTANTIATE_TEST_SUITE_P(ParseFailTestInstantiation,
+    ParseFailTest,
+    ::testing::ValuesIn(parse_fail_cases));
+
+TEST_P(ParseFailTest, ParseFail) {
+    const ParseFailCase test_case = GetParam();
+    tuwjson::Error err = parser.ParseJson(test_case.json, &root);
+    noex::string json_str = test_case.json;
+    if (json_str.size() > 20)
+        json_str = json_str.substr(0, 20) + "...";
+    EXPECT_EQ(err, test_case.err)  <<
+        "  json: " << json_str.c_str();
+    EXPECT_STREQ(parser.GetErrMsg(), test_case.err_msg) <<
+        "  json: " << json_str.c_str();
+}
+
+class JsonWriteTest : public ::testing::Test {
+ protected:
+    tuwjson::Value root;
+    tuwjson::Writer writer;
+};
+
+TEST_F(JsonWriteTest, WriteEmpty) {
+    char buffer[10];
+    char* end = writer.WriteJson(&root, buffer, 10);
+    EXPECT_EQ(end, buffer + 4);
+    EXPECT_STREQ(buffer, "null");
+}
+
+TEST_F(JsonWriteTest, WriteNull) {
+    root.SetNull();
+    char buffer[10];
+    char* end = writer.WriteJson(&root, buffer, 10);
+    EXPECT_EQ(end, buffer + 4);
+    EXPECT_STREQ(buffer, "null");
+}
+
+TEST_F(JsonWriteTest, WriteTrue) {
+    root.SetBool(true);
+    char buffer[10];
+    char* end = writer.WriteJson(&root, buffer, 10);
+    EXPECT_EQ(end, buffer + 4);
+    EXPECT_STREQ(buffer, "true");
+}
+
+TEST_F(JsonWriteTest, WriteFalse) {
+    root.SetBool(false);
+    char buffer[10];
+    char* end = writer.WriteJson(&root, buffer, 10);
+    EXPECT_EQ(end, buffer + 5);
+    EXPECT_STREQ(buffer, "false");
+}
+
+TEST_F(JsonWriteTest, WriteInt) {
+    root.SetInt(-929192);
+    char buffer[10];
+    char* end = writer.WriteJson(&root, buffer, 10);
+    EXPECT_EQ(end, buffer + 7);
+    EXPECT_STREQ(buffer, "-929192");
+}
+
+TEST_F(JsonWriteTest, WriteDouble) {
+    root.SetDouble(-10.233);
+    char buffer[30];
+    char* end = writer.WriteJson(&root, buffer, 30);
+    EXPECT_TRUE(end >= buffer + 6);
+    buffer[6] = '\0';
+    EXPECT_STREQ(buffer, "-10.23");
+}
+
+TEST_F(JsonWriteTest, WriteString) {
+    root.SetString("abcdefg");
+    char buffer[10];
+    char* end = writer.WriteJson(&root, buffer, 10);
+    EXPECT_EQ(end, buffer + 9);
+    EXPECT_STREQ(buffer, "\"abcdefg\"");
+}
+
+TEST_F(JsonWriteTest, WriteEscape) {
+    root.SetString("\"\\/\b\f\n\r\t");
+    char buffer[20];
+    char* end = writer.WriteJson(&root, buffer, 20);
+    EXPECT_EQ(end, buffer + 17);
+    EXPECT_STREQ(buffer, "\"\\\"\\\\/\\b\\f\\n\\r\\t\"");
+}
+
+TEST_F(JsonWriteTest, WriteStringUTF) {
+    root.SetString("\xc2\x80\xe0\x80\xbf\xf0\x80\xbf\xa0");
+    char buffer[20];
+    char* end = writer.WriteJson(&root, buffer, 20);
+    EXPECT_EQ(end, buffer + 11);
+    EXPECT_STREQ(buffer, "\"\xc2\x80\xe0\x80\xbf\xf0\x80\xbf\xa0\"");
+}
+
+TEST_F(JsonWriteTest, WriteArray) {
+    root.SetArray();
+    tuwjson::Value v;
+    v.SetBool(true);
+    root.MoveAndPush(v);
+    v.SetInt(-10);
+    root.MoveAndPush(v);
+    v.SetString("abc");
+    root.MoveAndPush(v);
+    char buffer[20];
+    char* end = writer.WriteJson(&root, buffer, 20);
+    EXPECT_EQ(end, buffer + 16);
+    EXPECT_STREQ(buffer, "[true,-10,\"abc\"]");
+}
+
+TEST_F(JsonWriteTest, WriteArrayWithIndent) {
+    root.SetArray();
+    tuwjson::Value v;
+    v.SetBool(true);
+    root.MoveAndPush(v);
+    v.SetInt(-10);
+    root.MoveAndPush(v);
+    v.SetString("abc");
+    root.MoveAndPush(v);
+    char buffer[30];
+    writer.Init("  ", 2, true);
+    char* end = writer.WriteJson(&root, buffer, 30);
+    EXPECT_EQ(end, buffer + 27);
+    EXPECT_STREQ(buffer,
+        "[\n"
+        "  true,\n"
+        "  -10,\n"
+        "  \"abc\"\n"
+        "]\n");
+}
+
+TEST_F(JsonWriteTest, WriteObject) {
+    root.SetObject();
+    root["a"].SetString("abc");
+    root["b"].SetBool(true);
+    root["key"].SetInt(3);
+    char buffer[40];
+    char* end = writer.WriteJson(&root, buffer, 40);
+    EXPECT_EQ(end, buffer + 31);
+    EXPECT_STREQ(buffer, "{\"a\": \"abc\",\"b\": true,\"key\": 3}");
+}
+
+TEST_F(JsonWriteTest, WriteObjectWithIndent) {
+    root.SetObject();
+    root["a"].SetString("abc");
+    root["b"].SetBool(true);
+    root["key"].SetInt(3);
+    char buffer[50];
+    writer.Init("    ", 4, true);
+    char* end = writer.WriteJson(&root, buffer, 50);
+    EXPECT_EQ(end, buffer + 48);
+    EXPECT_STREQ(buffer,
+        "{\n"
+        "    \"a\": \"abc\",\n"
+        "    \"b\": true,\n"
+        "    \"key\": 3\n"
+        "}\n");
+}
+
+TEST_F(JsonWriteTest, WriteLargeObject) {
+    root.SetObject();
+    root["a"].SetString("abc");
+    root["b"].SetBool(true);
+    root["key"].SetArray();
+    tuwjson::Value& ary = root["key"];
+    tuwjson::Value v;
+    v.SetInt(1);
+    ary.MoveAndPush(v);
+    v.SetObject();
+    ary.MoveAndPush(v);
+    tuwjson::Value& obj = ary[1];
+    obj["foo"].SetNull();
+    char buffer[100];
+    writer.Init("  ", 2, true);
+    char* end = writer.WriteJson(&root, buffer, 100);
+    EXPECT_EQ(end, buffer + 83);
+    EXPECT_STREQ(buffer,
+        "{\n"
+        "  \"a\": \"abc\",\n"
+        "  \"b\": true,\n"
+        "  \"key\": [\n"
+        "    1,\n"
+        "    {\n"
+        "      \"foo\": null\n"
+        "    }\n"
+        "  ]\n"
+        "}\n");
+}
+
+TEST_F(JsonWriteTest, WriteFailSmallBuffer) {
+    char buffer[2];
+    char* end = writer.WriteJson(&root, buffer, 2);
+    char* null = nullptr;
+    EXPECT_EQ(end, null);
+    EXPECT_TRUE(writer.HasError());
+    EXPECT_STREQ(writer.GetErrMsg(), "JSON writer requires a larger buffer");
+}

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -36,6 +36,7 @@ int main(int argc, char* argv[]) {
 #ifdef USE_BROWSER
     ::testing::Environment* const foo_env =
         ::testing::AddGlobalTestEnvironment(new BrowserCloser);
+    (void) foo_env;
 #endif
     return RUN_ALL_TESTS();
 }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -2,6 +2,23 @@
 
 // test json files
 #include "test_utils.h"
+#include "process_utils.h"
+
+#ifdef USE_BROWSER
+// Some tests launch browsers. We close them after testing.
+class BrowserCloser : public ::testing::Environment {
+ private:
+    std::vector<PidType> ids;
+
+ public:
+    virtual void SetUp() {
+        ids = GetProcessIDs();
+    }
+    virtual void TearDown() {
+        CloseNewBrowser(ids);
+    }
+};
+#endif
 
 #ifdef _WIN32
 int wmain(int argc, wchar_t* argv[]) {
@@ -16,5 +33,9 @@ int main(int argc, char* argv[]) {
 
     MainFrameDisableDialog();
 
+#ifdef USE_BROWSER
+    ::testing::Environment* const foo_env =
+        ::testing::AddGlobalTestEnvironment(new BrowserCloser);
+#endif
     return RUN_ALL_TESTS();
 }

--- a/tests/main_frame_test.cpp
+++ b/tests/main_frame_test.cpp
@@ -30,51 +30,51 @@ class MainFrameTest : public ::testing::Test {
         EXPECT_EQ(noex::OK, noex::get_error_no());
     }
 
-    void TestConfig(rapidjson::Document& test_json, noex::string config) {
-        rapidjson::Document test_config;
+    void TestConfig(tuwjson::Value& test_json, noex::string config) {
+        tuwjson::Value test_config;
         noex::string err = json_utils::LoadJson(config, test_config);
-        EXPECT_TRUE(err.empty());
+        EXPECT_TRUE(err.empty()) << ("err: " + err).c_str();
         main_frame = new MainFrame(test_json, test_config);
         main_frame->SaveConfig();
-        rapidjson::Document saved_config;
+        tuwjson::Value saved_config;
         err = json_utils::LoadJson("gui_config.json", saved_config);
-        EXPECT_TRUE(err.empty());
+        EXPECT_TRUE(err.empty()) << ("err: " + err).c_str();
         EXPECT_EQ(test_config, saved_config);
     }
 };
 
 TEST_F(MainFrameTest, MakeDefaultMainFrame) {
     main_frame = new MainFrame();
-    rapidjson::Document json1;
-    rapidjson::Document json2;
+    tuwjson::Value json1;
+    tuwjson::Value json2;
     json_utils::GetDefaultDefinition(json1);
     main_frame->GetDefinition(json2);
     EXPECT_EQ(json1, json2);
 }
 
-void GetDummyConfig(rapidjson::Document& dummy_config) {
+void GetDummyConfig(tuwjson::Value& dummy_config) {
     dummy_config.SetObject();
-    dummy_config.AddMember("test", 0, dummy_config.GetAllocator());
+    dummy_config["test"].SetInt(0);
 }
 
 TEST_F(MainFrameTest, InvalidDefinition) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"][1]["components"][4]["default"].SetString("number");
-    rapidjson::Document dummy_config;
+    tuwjson::Value dummy_config;
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
     json_utils::GetDefaultDefinition(test_json);
-    rapidjson::Document actual_json;
+    tuwjson::Value actual_json;
     main_frame->GetDefinition(actual_json);
     EXPECT_EQ(test_json, actual_json);
 }
 
 TEST_F(MainFrameTest, InvalidHelp) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["help"][0]["url"].SetInt(1);
-    rapidjson::Document dummy_config;
+    tuwjson::Value dummy_config;
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
     main_frame->GetDefinition(test_json);
@@ -82,21 +82,21 @@ TEST_F(MainFrameTest, InvalidHelp) {
 }
 
 TEST_F(MainFrameTest, GetCommand1) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     json_utils::GetDefaultDefinition(test_json);
     test_json["gui"][0]["command"].SetString("command!");
-    rapidjson::Document dummy_config;
+    tuwjson::Value dummy_config;
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
     EXPECT_STREQ("command!", main_frame->GetCommand().c_str());
 }
 
 TEST_F(MainFrameTest, GetCommand2) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"][0].Swap(test_json["gui"][1]);
-    rapidjson::Document dummy_config;
+    tuwjson::Value dummy_config;
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
     noex::string expected = "echo file: \"test.txt\" & echo folder: \"testdir\"";
@@ -107,9 +107,9 @@ TEST_F(MainFrameTest, GetCommand2) {
 }
 
 TEST_F(MainFrameTest, GetCommand3) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
-    rapidjson::Document dummy_config;
+    tuwjson::Value dummy_config;
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
     noex::string expected = "echo file:  & echo folder:  & echo combo: value1 & echo radio: value1";
@@ -119,13 +119,13 @@ TEST_F(MainFrameTest, GetCommand3) {
 }
 
 TEST_F(MainFrameTest, RunCommandSuccess) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
-    rapidjson::Document dummy_config;
+    tuwjson::Value dummy_config;
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
 
-    rapidjson::Document actual_json;
+    tuwjson::Value actual_json;
     main_frame->GetDefinition(actual_json);
     ASSERT_EQ(test_json["help"], actual_json["help"]);
 
@@ -136,11 +136,11 @@ TEST_F(MainFrameTest, RunCommandSuccess) {
 }
 
 TEST_F(MainFrameTest, RunCommandFail) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     json_utils::GetDefaultDefinition(test_json);
     test_json["gui"][0]["command"].SetString("I'll fail");
-    rapidjson::Document dummy_config;
+    tuwjson::Value dummy_config;
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
 
@@ -151,9 +151,9 @@ TEST_F(MainFrameTest, RunCommandFail) {
 }
 
 TEST_F(MainFrameTest, UpdateFrame) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
-    rapidjson::Document dummy_config;
+    tuwjson::Value dummy_config;
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
     main_frame->UpdatePanel(1);
@@ -163,9 +163,9 @@ TEST_F(MainFrameTest, UpdateFrame) {
 }
 
 TEST_F(MainFrameTest, RunCommandShowLast) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
-    rapidjson::Document dummy_config;
+    tuwjson::Value dummy_config;
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
     main_frame->UpdatePanel(2);
@@ -178,27 +178,27 @@ TEST_F(MainFrameTest, RunCommandShowLast) {
 }
 
 TEST_F(MainFrameTest, LoadSaveConfigAscii) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"][0].Swap(test_json["gui"][1]);
     TestConfig(test_json, JSON_CONFIG_ASCII);
 }
 
 TEST_F(MainFrameTest, LoadSaveConfigUTF) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"][0].Swap(test_json["gui"][1]);
     noex::string cmd = test_json["gui"][0]["command"].GetString();
     memcpy(cmd.data() + 12, "ファイル", 4);
-    test_json["gui"][0]["command"].SetString(rapidjson::StringRef(cmd.c_str()));
+    test_json["gui"][0]["command"].SetString(cmd);
     test_json["gui"][0]["components"][1]["id"].SetString("ファイル");
     TestConfig(test_json, JSON_CONFIG_UTF);
 }
 
 TEST_F(MainFrameTest, CrossPlatform) {
-    rapidjson::Document test_json;
+    tuwjson::Value test_json;
     GetTestJson(test_json, JSON_CROSS_PLATFORM);
-    rapidjson::Document dummy_config;
+    tuwjson::Value dummy_config;
     GetDummyConfig(dummy_config);
     main_frame = new MainFrame(test_json, dummy_config);
     main_frame->UpdatePanel(1);
@@ -206,8 +206,8 @@ TEST_F(MainFrameTest, CrossPlatform) {
 
 class OpenURLTest : public MainFrameTest {
  protected:
-    rapidjson::Document definition;
-    rapidjson::Document config;
+    tuwjson::Value definition;
+    tuwjson::Value config;
 
     void SetUp() override {
         MainFrameTest::SetUp();
@@ -216,10 +216,7 @@ class OpenURLTest : public MainFrameTest {
     }
 
     void ReplaceURL(const char* url) {
-        definition["help"][0].RemoveMember("url");
-        rapidjson::Value urlValue;
-        urlValue.SetString(url, definition.GetAllocator());
-        definition["help"][0].AddMember("url", urlValue, definition.GetAllocator());
+        definition["help"][0]["url"].SetString(url);
     }
 };
 

--- a/tests/main_frame_test.cpp
+++ b/tests/main_frame_test.cpp
@@ -256,3 +256,23 @@ TEST_F(OpenURLTest, OpenUrlWithSpace) {
         "URL: https://example .com";
     EXPECT_STREQ(msg.c_str(), expected);
 }
+
+TEST(FilterListTest, EmptyFilter) {
+    FilterList list;
+    list.MakeFilters("");
+    EXPECT_EQ(list.GetSize(), 0);
+}
+
+TEST(FilterListTest, MultipleFilters) {
+    FilterList list;
+    list.MakeFilters("BMP and GIF files (*.bmp;*.gif)|*.bmp;*.gif|PNG files (*.png)|*.png");
+    EXPECT_EQ(list.GetSize(), 2);
+    uiFileDialogParamsFilter* filters = list.ToLibuiFilterList();
+    EXPECT_STREQ(filters[0].name, "BMP and GIF files (*.bmp;*.gif)");
+    EXPECT_EQ(filters[0].patternCount, 2);
+    EXPECT_STREQ(filters[0].patterns[0], "*.bmp");
+    EXPECT_STREQ(filters[0].patterns[1], "*.gif");
+    EXPECT_STREQ(filters[1].name, "PNG files (*.png)");
+    EXPECT_EQ(filters[1].patternCount, 1);
+    EXPECT_STREQ(filters[1].patterns[0], "*.png");
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -11,6 +11,7 @@ test_sources = [
     'string_test.cpp',
     'vector_test.cpp',
     'process_utils.cpp',
+    'ring_buffer_test.cpp',
 ]
 
 # build tests

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -10,6 +10,7 @@ test_sources = [
     'validator_test.cpp',
     'string_test.cpp',
     'vector_test.cpp',
+    'json_test.cpp',
     'process_utils.cpp',
     'ring_buffer_test.cpp',
 ]

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -10,6 +10,7 @@ test_sources = [
     'validator_test.cpp',
     'string_test.cpp',
     'vector_test.cpp',
+    'process_utils.cpp',
 ]
 
 # build tests
@@ -21,3 +22,11 @@ test_exe = executable('unit_test',
     install : false)
 
 test('unit_test', test_exe)
+
+python = import('python').find_installation()
+configure_file(input : 'cli_test.py', output : 'cli_test.py', copy: true)
+test('cli_test',
+    python,
+    args: ['cli_test.py'],
+    workdir: meson.current_build_dir(),
+)

--- a/tests/process_utils.cpp
+++ b/tests/process_utils.cpp
@@ -1,0 +1,177 @@
+#include "process_utils.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#include <tlhelp32.h>
+#include <psapi.h>
+#include <shlwapi.h>
+#include "string_utils.h"
+#pragma comment(lib, "Shlwapi.lib")
+#else  // _WIN32
+#include <dirent.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <signal.h>
+#include <fstream>
+#include <algorithm>
+#endif  // _WIN32
+
+bool ichar_equals(char a, char b) {
+    return std::tolower(static_cast<unsigned char>(a)) ==
+           std::tolower(static_cast<unsigned char>(b));
+}
+
+// Case insensitive comparison
+bool iequals(const std::string& a, const std::string& b) {
+    return a.size() == b.size() &&
+           std::equal(a.begin(), a.end(), b.begin(), ichar_equals);
+}
+
+void CloseNewBrowser(const std::vector<PidType>& old_ids) {
+    std::vector<PidType> new_ids = GetProcessIDs();
+    std::vector<std::string> browsers = {
+        "chrome", "firefox", "msedge", "brave", "opera", "safari",
+        GetDefaultBrowser(),
+    };
+
+    for (PidType pid : new_ids) {
+        if (std::find(old_ids.begin(), old_ids.end(), pid) != old_ids.end()) continue;
+        std::string name = GetProcessName(pid);
+        if (std::find_if(
+                browsers.begin(), browsers.end(), [&name](const std::string& browser) {
+                    return iequals(browser, name);
+                }) != browsers.end()) {
+            KillProcess(pid, name);
+        }
+    }
+}
+
+#ifdef _WIN32
+
+std::vector<PidType> GetProcessIDs() {
+    std::vector<PidType> ids = {};
+    HANDLE hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+
+    if (hSnapshot == INVALID_HANDLE_VALUE) return ids;
+
+    PROCESSENTRY32 pe;
+    pe.dwSize = sizeof(PROCESSENTRY32);
+
+    if (Process32First(hSnapshot, &pe)) {
+        do {
+            ids.push_back(pe.th32ProcessID);
+        } while (Process32Next(hSnapshot, &pe));
+    }
+    CloseHandle(hSnapshot);
+    return ids;
+}
+
+std::string GetAfterBackslash(const std::string& path) {
+    size_t pos = path.find_last_of("\\/");
+    return (pos != std::string::npos) ? path.substr(pos + 1) : path;
+}
+
+std::string GetProcessName(PidType pid) {
+    HANDLE hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+    if (!hProcess)
+        return "";
+
+    // Get module name
+    std::string name = "";
+    DWORD size = MAX_PATH;
+    while (true) {
+        std::vector<wchar_t> buffer(size + 1);
+        DWORD size_tmp = size;
+        if (QueryFullProcessImageNameW(hProcess, 0, buffer.data(), &size_tmp)) {
+            noex::string utf8 = UTF16toUTF8(&buffer[0]);
+            if (utf8.size() > 4) {
+                name = std::string(utf8.data(), utf8.data() + utf8.size() - 4);
+                name = GetAfterBackslash(name);
+            }
+            break;
+        }
+        if (ERROR_INSUFFICIENT_BUFFER != GetLastError() || size > 16640)
+            break;
+        size *= 2;
+    }
+    CloseHandle(hProcess);
+    return name;
+}
+
+std::string GetDefaultBrowser() {
+    std::string browser = "unknown";
+    DWORD size = MAX_PATH;
+    while (true) {
+        std::vector<wchar_t> buffer(size + 1);
+        DWORD size_tmp = size;
+        if (AssocQueryStringW(
+                ASSOCF_NONE, ASSOCSTR_EXECUTABLE,
+                L"https", nullptr, buffer.data(), &size_tmp) == S_OK) {
+            noex::string utf8 = UTF16toUTF8(&buffer[0]);
+            if (utf8.size() > 4) {
+                browser = std::string(utf8.data(), utf8.data() + utf8.size() - 4);
+                browser = GetAfterBackslash(browser);
+            }
+            break;
+        }
+        if (ERROR_INSUFFICIENT_BUFFER != GetLastError() || size > 16640)
+            break;
+        size *= 2;
+    }
+    return browser;
+}
+
+void KillProcess(PidType pid, const std::string& name) {
+    HANDLE hProcess = OpenProcess(PROCESS_TERMINATE, FALSE, pid);
+    if (hProcess == nullptr)
+        return;
+
+    if (TerminateProcess(hProcess, 0))
+        printf("Closed a browser: %s\n", name.c_str());
+    CloseHandle(hProcess);
+}
+
+#else  // _WIN32
+
+void KillProcess(PidType pid, const std::string& name) {
+    if (kill(pid, SIGTERM) == 0)
+        printf("Closed a browser: %s\n", name.c_str());
+}
+
+std::string GetDefaultBrowser() { return "unknown"; }
+
+#ifdef __linux__
+
+std::vector<PidType> GetProcessIDs() {
+    std::vector<PidType> ids;
+    DIR* dir = opendir("/proc");
+    if (!dir) return ids;
+
+    struct dirent* entry;
+    while ((entry = readdir(dir)) != nullptr) {
+        if (entry->d_type == DT_DIR) {
+            std::string dirName(entry->d_name);
+            if (std::all_of(dirName.begin(), dirName.end(), ::isdigit)) {
+                ids.push_back(static_cast<PidType>(std::stoi(dirName)));
+            }
+        }
+    }
+    closedir(dir);
+    return ids;
+}
+
+std::string GetProcessName(PidType pid) {
+    std::ifstream file("/proc/" + std::to_string(pid) + "/comm");
+    if (!file) return "";
+    std::string name;
+    std::getline(file, name);
+    return name;
+}
+
+#else  // __linux__
+
+std::vector<PidType> GetProcessIDs() { return {}; }
+std::string GetProcessName(PidType pid) {}
+
+#endif  // __linux__
+#endif  // _WIN32

--- a/tests/process_utils.h
+++ b/tests/process_utils.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <windows.h>
+typedef DWORD PidType;
+#else  // _WIN32
+#include <unistd.h>
+typedef pid_t PidType;
+#endif  // _WIN32
+
+std::vector<PidType> GetProcessIDs();
+std::string GetProcessName(PidType pid);
+void KillProcess(PidType pid, const std::string& name);
+std::string GetDefaultBrowser();
+void CloseNewBrowser(const std::vector<PidType>& old_ids);
+
+#ifndef USE_BROWSER
+#define USE_BROWSER 1
+#endif

--- a/tests/ring_buffer_test.cpp
+++ b/tests/ring_buffer_test.cpp
@@ -1,0 +1,73 @@
+// Tests for string utils
+// Todo: Write more tests
+
+#include "test_utils.h"
+
+// Test RingStrBuffer
+TEST(RingStrBufferTest, Construct) {
+    RingStrBuffer<10> buf;
+    EXPECT_TRUE(buf.IsEmpty());
+    EXPECT_FALSE(buf.IsFull());
+    EXPECT_STREQ("", buf.ToString().c_str());
+}
+
+TEST(RingStrBufferTest, PushBackChar) {
+    RingStrBuffer<10> buf;
+    buf.PushBack('c');
+    EXPECT_FALSE(buf.IsEmpty());
+    EXPECT_FALSE(buf.IsFull());
+    EXPECT_STREQ("c", buf.ToString().c_str());
+}
+
+TEST(RingStrBufferTest, PushBackStr) {
+    RingStrBuffer<10> buf;
+    buf.PushBack("test", 4);
+    EXPECT_FALSE(buf.IsEmpty());
+    EXPECT_FALSE(buf.IsFull());
+    EXPECT_STREQ("test", buf.ToString().c_str());
+}
+
+TEST(RingStrBufferTest, PushBackLongStr) {
+    RingStrBuffer<10> buf;
+    buf.PushBack("0123456789test", 14);
+    EXPECT_FALSE(buf.IsEmpty());
+    EXPECT_TRUE(buf.IsFull());
+    EXPECT_STREQ("456789test", buf.ToString().c_str());
+}
+
+TEST(RingStrBufferTest, PushBackTwoStr) {
+    RingStrBuffer<10> buf;
+    buf.PushBack("0123456", 7);
+    buf.PushBack("789test", 7);
+    EXPECT_FALSE(buf.IsEmpty());
+    EXPECT_TRUE(buf.IsFull());
+    EXPECT_STREQ("456789test", buf.ToString().c_str());
+}
+
+TEST(RingStrBufferTest, PushBackStrAndChar) {
+    RingStrBuffer<10> buf;
+    buf.PushBack("0123456789", 10);
+    EXPECT_FALSE(buf.IsEmpty());
+    EXPECT_TRUE(buf.IsFull());
+    buf.PushBack('c');
+    EXPECT_STREQ("123456789c", buf.ToString().c_str());
+}
+
+TEST(RingStrBufferTest, PushBackStrAndLongStr) {
+    RingStrBuffer<10> buf;
+    buf.PushBack("0123456", 7);
+    const char* str = "abcdefghijklmnopqrstuvwxyz0123456789";
+    buf.PushBack(str, strlen(str));
+    EXPECT_FALSE(buf.IsEmpty());
+    EXPECT_TRUE(buf.IsFull());
+    EXPECT_STREQ("0123456789", buf.ToString().c_str());
+}
+
+TEST(RingStrBufferTest, PushBackNull) {
+    RingStrBuffer<10> buf;
+    const char* null = nullptr;
+    buf.PushBack(null, 4);
+    EXPECT_TRUE(buf.IsEmpty());
+    EXPECT_FALSE(buf.IsFull());
+    EXPECT_STREQ("", buf.ToString().c_str());
+}

--- a/tests/string_test.cpp
+++ b/tests/string_test.cpp
@@ -357,6 +357,42 @@ TEST(StringTest, EraseError) {
     expect_tuwstr("testfoobar", str);
 }
 
+TEST(StringTest, ConcatCstrTwo) {
+    noex::string str;
+    str = noex::concat_cstr("foo", "bar");
+    expect_tuwstr("foobar", str);
+    str = noex::concat_cstr("", "bar");
+    expect_tuwstr("bar", str);
+    str = noex::concat_cstr("foo", "");
+    expect_tuwstr("foo", str);
+    char* null = nullptr;
+    str = noex::concat_cstr(null, "bar");
+    expect_tuwstr("bar", str);
+    str = noex::concat_cstr("foo", null);
+    expect_tuwstr("foo", str);
+    EXPECT_EQ(noex::OK, noex::get_error_no());
+}
+
+TEST(StringTest, ConcatCstrThree) {
+    noex::string str;
+    str = noex::concat_cstr("test", "foo", "bar");
+    expect_tuwstr("testfoobar", str);
+    str = noex::concat_cstr("", "foo", "bar");
+    expect_tuwstr("foobar", str);
+    str = noex::concat_cstr("test", "", "bar");
+    expect_tuwstr("testbar", str);
+    str = noex::concat_cstr("test", "foo", "");
+    expect_tuwstr("testfoo", str);
+    char* null = nullptr;
+    str = noex::concat_cstr(null, "foo", "bar");
+    expect_tuwstr("foobar", str);
+    str = noex::concat_cstr("test", null, "bar");
+    expect_tuwstr("testbar", str);
+    str = noex::concat_cstr("test", "foo", null);
+    expect_tuwstr("testfoo", str);
+    EXPECT_EQ(noex::OK, noex::get_error_no());
+}
+
 // Test noex::wstring
 void expect_nullwstr(const noex::wstring& str) {
     EXPECT_TRUE(str.empty());

--- a/tests/string_test.cpp
+++ b/tests/string_test.cpp
@@ -334,6 +334,29 @@ TEST(StringTest, IterForNull) {
     EXPECT_EQ(&str.c_str()[0], str.end());
 }
 
+// Test erase()
+TEST(StringTest, Erase) {
+    noex::string str = "testfoobar";
+    expect_tuwstr("testfoobar", str);
+    str.erase(4, 3);
+    expect_tuwstr("testbar", str);
+    str.erase(4, noex::string::npos);
+    expect_tuwstr("test", str);
+    EXPECT_EQ(noex::OK, noex::get_error_no());
+}
+
+TEST(StringTest, EraseError) {
+    noex::string str = "testfoobar";
+    expect_tuwstr("testfoobar", str);
+    str.erase(100, 0);
+    EXPECT_EQ(noex::STR_BOUNDARY_ERROR, noex::get_error_no());
+    noex::clear_error_no();
+    str.erase(0, 100);
+    EXPECT_EQ(noex::STR_BOUNDARY_ERROR, noex::get_error_no());
+    noex::clear_error_no();
+    expect_tuwstr("testfoobar", str);
+}
+
 // Test noex::wstring
 void expect_nullwstr(const noex::wstring& str) {
     EXPECT_TRUE(str.empty());
@@ -358,4 +381,14 @@ TEST(WstringTest, ConstructWithCstr) {
     noex::wstring str(L"test");
     EXPECT_FALSE(str.empty());
     expect_tuwwstr(L"test", str);
+}
+
+TEST(WstringTest, EqualToStr) {
+    noex::wstring str = L"test";
+    wchar_t* null = nullptr;
+    EXPECT_TRUE(str != null);
+    EXPECT_EQ(str, L"test");
+    EXPECT_EQ(str, noex::wstring(L"test"));
+    EXPECT_NE(str, L"task");
+    EXPECT_NE(str, noex::wstring(L"task"));
 }

--- a/tests/string_test.cpp
+++ b/tests/string_test.cpp
@@ -336,10 +336,10 @@ TEST(StringTest, IterForNull) {
 
 // Test erase()
 TEST(StringTest, Erase) {
-    noex::string str = "testfoobar";
-    expect_tuwstr("testfoobar", str);
+    noex::string str = "testfoobar!!!";
+    expect_tuwstr("testfoobar!!!", str);
     str.erase(4, 3);
-    expect_tuwstr("testbar", str);
+    expect_tuwstr("testbar!!!", str);
     str.erase(4, noex::string::npos);
     expect_tuwstr("test", str);
     EXPECT_EQ(noex::OK, noex::get_error_no());

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -19,9 +19,16 @@ constexpr char JSON_BROKEN[] = "./json/broken.json";
 constexpr char JSON_CONFIG_ASCII[] = "./json/config_ascii.json";
 constexpr char JSON_CONFIG_UTF[] = "./json/config_utf.json";
 constexpr char JSON_RELAXED[] = "./json/relaxed.jsonc";
+constexpr char JSON_CROSS_PLATFORM[] = "./json/platform.json";
 
 inline void GetTestJson(rapidjson::Document& json) {
-    json_utils::JsonResult result = json_utils::LoadJson(JSON_ALL_KEYS, json);
-    EXPECT_TRUE(result.ok);
+    noex::string err = json_utils::LoadJson(JSON_ALL_KEYS, json);
+    EXPECT_TRUE(err.empty());
+    EXPECT_FALSE(json.ObjectEmpty());
+}
+
+inline void GetTestJson(rapidjson::Document& json, const char* file) {
+    noex::string err = json_utils::LoadJson(file, json);
+    EXPECT_TRUE(err.empty());
     EXPECT_FALSE(json.ObjectEmpty());
 }

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -10,6 +10,7 @@
 #include "validator.h"
 #include "env_utils.h"
 #include "noex/vector.hpp"
+#include "json.h"
 
 // you need to copy it from examples/all_keys to the json folder
 constexpr char JSON_ALL_KEYS[] = "./json/gui_definition.json";
@@ -21,14 +22,14 @@ constexpr char JSON_CONFIG_UTF[] = "./json/config_utf.json";
 constexpr char JSON_RELAXED[] = "./json/relaxed.jsonc";
 constexpr char JSON_CROSS_PLATFORM[] = "./json/platform.json";
 
-inline void GetTestJson(rapidjson::Document& json) {
+inline void GetTestJson(tuwjson::Value& json) {
     noex::string err = json_utils::LoadJson(JSON_ALL_KEYS, json);
     EXPECT_TRUE(err.empty());
-    EXPECT_FALSE(json.ObjectEmpty());
+    EXPECT_FALSE(json.IsEmpty());
 }
 
-inline void GetTestJson(rapidjson::Document& json, const char* file) {
+inline void GetTestJson(tuwjson::Value& json, const char* file) {
     noex::string err = json_utils::LoadJson(file, json);
     EXPECT_TRUE(err.empty());
-    EXPECT_FALSE(json.ObjectEmpty());
+    EXPECT_FALSE(json.IsEmpty());
 }

--- a/tests/validator_test.cpp
+++ b/tests/validator_test.cpp
@@ -4,8 +4,9 @@
 #include "test_utils.h"
 
 Validator GetValidator(const char* config_str) {
-    rapidjson::Document config(rapidjson::kObjectType);
-    config.Parse(config_str);
+    tuwjson::Value config;
+    tuwjson::Parser parser;
+    parser.ParseJson(config_str, &config);
     Validator validator;
     validator.Initialize(config);
     return validator;

--- a/tests/vector_test.cpp
+++ b/tests/vector_test.cpp
@@ -117,3 +117,31 @@ TEST(VectorTest, StructVec) {
     EXPECT_EQ(6, vec[2].b);
     EXPECT_EQ(noex::OK, noex::get_error_no());
 }
+
+TEST(VectorTest, Assign) {
+    noex::vector<int> vec;
+    vec.push_back(1);
+    vec.push_back(2);
+    vec.push_back(3);
+    vec.push_back(4);
+    EXPECT_EQ(4, vec.size());
+    EXPECT_EQ(4, vec[3]);
+    noex::vector<int> vec2(vec);
+    EXPECT_EQ(4, vec2.size());
+    EXPECT_EQ(4, vec2[3]);
+    EXPECT_EQ(noex::OK, noex::get_error_no());
+}
+
+TEST(VectorTest, Move) {
+    noex::vector<int> vec;
+    vec.push_back(1);
+    vec.push_back(2);
+    vec.push_back(3);
+    vec.push_back(4);
+    EXPECT_EQ(4, vec.size());
+    EXPECT_EQ(4, vec[3]);
+    noex::vector<int> vec2(std::move(vec));
+    EXPECT_EQ(4, vec2.size());
+    EXPECT_EQ(4, vec2[3]);
+    EXPECT_EQ(noex::OK, noex::get_error_no());
+}


### PR DESCRIPTION
### New JSON Module (#108)

- Replaced rapidjson with a custom JSON module, which reduced binary size (about 16% for Windows10 build.)
- Tuw now shows error messages with line and column of a JSON file.
  e.g. `"id" should be a string (line: 4, column: 5)`
- Revised some error messages.

### Bug Fixes

- Fixed a Windows-specific issue where `merge` and `split` commands were not able to show UTF8 strings. (#106)
- Fixed an issue where the default value of `inc` for float pickers was wrong. (#104)
- Fixed an assertion error on debug build. (#100)

### Other Changes

- Tuw now shows a deprecation warning when a component has no id. (#107)
- Added `windows10-arm64.zip` to the release packages. (#111)
- Optimized for binary size more. (#101, #102, #103 and #110)
