### PR TITLE
Add `use_save_dialog` to file picker options

### DIFF
--- a/examples/all_keys/gui_definition.json
+++ b/examples/all_keys/gui_definition.json
@@ -105,6 +105,7 @@
                     "id": "file",
                     "extension": "png or jpg (*.png;*.jpg)|*.png;*.jpg",
                     "placeholder": "Drop a file here!",
+                    "use_save_dialog": false,
                     "button": "...",
                     "default": "test.txt",
                     "add_quotes": true,

--- a/examples/components/path_pickers/README.md
+++ b/examples/components/path_pickers/README.md
@@ -45,3 +45,25 @@ Each component should be defined as a dictionary.
 Tuw injects inputs of components into `command` when executing the command.
 You can specify where they should be injected with `%*%`.
 In the example, the file path will be injected at `%img%`, and the folder path will be at `%out%`.  
+
+## Save Dialog
+
+File pickers include a `use_save_dialog` option that allows users to select a new file through a save dialog.
+
+```json
+{
+    "gui": {
+        "window_name": "Save dialog sample",
+        "command": "echo test > %out%",
+        "components": [
+            {
+                "type": "file",
+                "id": "out",
+                "label": "Output file",
+                "add_quotes": true,
+                "use_save_dialog": true
+            }
+        ]
+    }
+}
+```

--- a/examples/components/path_pickers/gui_definition.json
+++ b/examples/components/path_pickers/gui_definition.json
@@ -1,22 +1,37 @@
 {
-    "gui": {
-        "window_name": "Picker sample",
-        "command": "copy %img% %out%",
-        "button": "copy",
-        "components": [
-            {
-                "type": "file",
-                "id": "img",
-                "label": "Image file you want to copy",
-                "extension": "BMP and GIF files (*.bmp;*.gif)|*.bmp;*.gif|PNG files (*.png)|*.png",
-                "add_quotes": true
-            },
-            {
-                "type": "folder",
-                "id": "out",
-                "label": "Output path",
-                "add_quotes": true
-            }
-        ]
-    }
+    "gui": [
+        {
+            "window_name": "Picker sample",
+            "command": "copy %img% %out%",
+            "button": "copy",
+            "components": [
+                {
+                    "type": "file",
+                    "id": "img",
+                    "label": "Image file you want to copy",
+                    "extension": "BMP and GIF files (*.bmp;*.gif)|*.bmp;*.gif|PNG files (*.png)|*.png",
+                    "add_quotes": true
+                },
+                {
+                    "type": "folder",
+                    "id": "out",
+                    "label": "Output path",
+                    "add_quotes": true
+                }
+            ]
+        },
+        {
+            "window_name": "Save dialog sample",
+            "command": "echo test > %out%",
+            "components": [
+                {
+                    "type": "file",
+                    "id": "out",
+                    "label": "Output file",
+                    "add_quotes": true,
+                    "use_save_dialog": true
+                }
+            ]
+        }
+    ]
 }

--- a/include/component.h
+++ b/include/component.h
@@ -84,6 +84,7 @@ class FilterList {
 class FilePicker : public StringComponentBase {
  private:
     const char* m_ext;
+    bool m_use_save_dialog;
 
  public:
     noex::string GetRawString() noexcept override;

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -254,7 +254,8 @@
             "placeholder": { "type": "string" },
             "button": { "type": "string" },
             "default": { "type": "string" },
-            "tooltip": { "type": "string" }
+            "tooltip": { "type": "string" },
+            "use_save_dialog": { "type": "boolean" }
           }
         }
       },

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -180,6 +180,7 @@ FilePicker::FilePicker(uiBox* box, const tuwjson::Value& j) noexcept
     : StringComponentBase(box, j) {
     m_is_wide = true;
     m_ext = json_utils::GetString(j, "extension", "any files (*.*)|*.*");
+    m_use_save_dialog = json_utils::GetBool(j, "use_save_dialog", false);
     m_widget = putPathPicker(this, box, j, onOpenFileClicked);
 }
 
@@ -275,10 +276,13 @@ void FilePicker::OpenFile() noexcept {
     params.filterCount = filter_list.GetSize();
     params.filters = filter_list.ToLibuiFilterList();
 
-    filename = uiOpenFileWithParams(GetToplevel(uiControl(entry)), &params);
-    if (filename == NULL) {
+    uiWindow* top = GetToplevel(uiControl(entry));
+    if (m_use_save_dialog)
+        filename = uiSaveFileWithParams(top, &params);
+    else
+        filename = uiOpenFileWithParams(top, &params);
+    if (filename == NULL)
         return;
-    }
 
     uiEntrySetText(entry, filename);
     uiFreeText(filename);

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -468,6 +468,7 @@ void CheckSubDefinition(JsonResult& result, tuwjson::Value& sub_definition,
         switch (type) {
             case COMP_FILE:
                 CheckJsonType(result, c, "extension", JsonType::STRING);
+                CheckJsonType(result, c, "use_save_dialog", JsonType::BOOLEAN);
                 /* Falls through. */
             case COMP_FOLDER:
                 CheckJsonType(result, c, "button", JsonType::STRING);

--- a/subprojects/libui.wrap
+++ b/subprojects/libui.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/matyalatte/libui-ng.git
-revision = 46a44d14696e67545434116221f00a1f9e4c2919
+revision = 2c00241c36a57b76e410779482015a8426051e6d
 depth = 1
 
 [provide]

--- a/tests/json_check_test.cpp
+++ b/tests/json_check_test.cpp
@@ -115,7 +115,7 @@ TEST(JsonCheckTest, checkGUIFail5) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"][2]["show_last_line"].SetString("test");
-    CheckGUIError(test_json, "\"show_last_line\" should be a boolean (line: 267, column: 31)");
+    CheckGUIError(test_json, "\"show_last_line\" should be a boolean (line: 268, column: 31)");
 }
 
 TEST(JsonCheckTest, checkGUIFail6) {
@@ -176,14 +176,14 @@ TEST(JsonCheckTest, checkHelpFail) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["help"][0].ReplaceKey("label", "notlabel");
-    CheckHelpError(test_json, "help document requires \"label\" (line: 280, column: 9)");
+    CheckHelpError(test_json, "help document requires \"label\" (line: 281, column: 9)");
 }
 
 TEST(JsonCheckTest, checkHelpFail2) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["help"][0]["label"].SetInt(3);
-    CheckHelpError(test_json, "\"label\" should be a string (line: 282, column: 22)");
+    CheckHelpError(test_json, "\"label\" should be a string (line: 283, column: 22)");
 }
 
 TEST(JsonCheckTest, checkVersionSuccess) {


### PR DESCRIPTION
Related to https://github.com/matyalatte/tuw/issues/75.

You can use `use_save_dialog` to open a save dialog from a file picker and select a new file.
It can also display an overwrite confirmation if the selected path already exists.

```json
{
    "gui": {
        "window_name": "Save dialog sample",
        "command": "echo test > %out%",
        "components": [
            {
                "type": "file",
                "id": "out",
                "label": "Output file",
                "add_quotes": true,
                "use_save_dialog": true
            }
        ]
    }
}
```