### PR TITLE
JSON errors for number picker options (`inc`, `min`, and `max`)

### DIFF
--- a/src/component.cpp
+++ b/src/component.cpp
@@ -520,11 +520,6 @@ IntPicker::IntPicker(uiBox* box, const tuwjson::Value& j) noexcept
     : StringComponentBase(box, j) {
     int min = json_utils::GetInt(j, "min", 0);
     int max = json_utils::GetInt(j, "max", 100);
-    if (min > max) {
-        int x = min;
-        min = max;
-        max = x;
-    }
     int inc = json_utils::GetInt(j, "inc", 1);
     int val = json_utils::GetInt(j, "default", min);
     bool wrap = json_utils::GetBool(j, "wrap", false);
@@ -563,11 +558,6 @@ FloatPicker::FloatPicker(uiBox* box, const tuwjson::Value& j) noexcept
     : StringComponentBase(box, j) {
     double min = json_utils::GetDouble(j, "min", 0.0);
     double max = json_utils::GetDouble(j, "max", 100.0);
-    if (min > max) {
-        double x = min;
-        min = max;
-        max = x;
-    }
     double inc = json_utils::GetDouble(j, "inc", 0.1);
     int digits = json_utils::GetInt(j, "digits", 1);
     double val = json_utils::GetDouble(j, "default", min);

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -526,10 +526,6 @@ IntPicker::IntPicker(uiBox* box, const tuwjson::Value& j) noexcept
         max = x;
     }
     int inc = json_utils::GetInt(j, "inc", 1);
-    if (inc < 0)
-        inc = -inc;
-    else if (inc == 0)
-        inc = 1;
     int val = json_utils::GetInt(j, "default", min);
     bool wrap = json_utils::GetBool(j, "wrap", false);
     uiSpinbox* picker = uiNewSpinboxDoubleEx(
@@ -573,10 +569,6 @@ FloatPicker::FloatPicker(uiBox* box, const tuwjson::Value& j) noexcept
         max = x;
     }
     double inc = json_utils::GetDouble(j, "inc", 0.1);
-    if (inc < 0)
-        inc = -inc;
-    else if (inc == 0)
-        inc = 1.0;
     int digits = json_utils::GetInt(j, "digits", 1);
     double val = json_utils::GetDouble(j, "default", min);
     bool wrap = json_utils::GetBool(j, "wrap", false);

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -465,6 +465,7 @@ void CheckSubDefinition(JsonResult& result, tuwjson::Value& sub_definition,
         c["type_int"].SetInt(type);
         CorrectKey(c, "item", "items");
         CorrectKey(c, "item_array", "items");
+        double min, max;
         switch (type) {
             case COMP_FILE:
                 CheckJsonType(result, c, "extension", JsonType::STRING);
@@ -518,8 +519,18 @@ void CheckSubDefinition(JsonResult& result, tuwjson::Value& sub_definition,
                     }
                 }
                 CheckJsonType(result, c, "default", jtype);
+                // Check min and max
                 CheckJsonType(result, c, "min", jtype);
-                CheckJsonType(result, c, "max", jtype);
+                json_ptr = CheckJsonType(result, c, "max", jtype);
+                if (!result.ok) return;
+                min = json_utils::GetDouble(c, "min", 0);
+                max = json_utils::GetDouble(c, "max", 100.0);
+                if (min > max) {
+                    result.ok = false;
+                    result.msg = "\"max\" should be greater than \"min\"."
+                                + json_ptr->GetLineColumnStr();
+                }
+                // Check inc
                 json_ptr = CheckJsonType(result, c, "inc", jtype);
                 if (!result.ok) return;
                 if (json_ptr && json_ptr->GetDouble() <= 0) {

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -520,7 +520,13 @@ void CheckSubDefinition(JsonResult& result, tuwjson::Value& sub_definition,
                 CheckJsonType(result, c, "default", jtype);
                 CheckJsonType(result, c, "min", jtype);
                 CheckJsonType(result, c, "max", jtype);
-                CheckJsonType(result, c, "inc", jtype);
+                json_ptr = CheckJsonType(result, c, "inc", jtype);
+                if (!result.ok) return;
+                if (json_ptr && json_ptr->GetDouble() <= 0) {
+                    result.ok = false;
+                    result.msg = "\"inc\" should be a positive number."
+                                + json_ptr->GetLineColumnStr();
+                }
                 CheckJsonType(result, c, "wrap", JsonType::BOOLEAN);
                 break;
             case COMP_UNKNOWN:

--- a/tests/json_check_test.cpp
+++ b/tests/json_check_test.cpp
@@ -260,3 +260,11 @@ TEST(JsonCheckTest, checkGUIFloatInc2) {
     CheckGUIError(test_json,
         "\"inc\" should be a positive number. (line: 253, column: 28)");
 }
+
+TEST(JsonCheckTest, checkGUIMinMax) {
+    tuwjson::Value test_json;
+    GetTestJson(test_json);
+    test_json["gui"][1]["components"][9]["min"].SetDouble(2);
+    CheckGUIError(test_json,
+        "\"max\" should be greater than \"min\". (line: 251, column: 28)");
+}

--- a/tests/json_check_test.cpp
+++ b/tests/json_check_test.cpp
@@ -244,3 +244,19 @@ TEST(JsonCheckTest, checkVersionFail4) {
     EXPECT_FALSE(result.ok);
     EXPECT_STREQ("Can NOT convert 'foo' to int.", result.msg.c_str());
 }
+
+TEST(JsonCheckTest, checkGUIIntInc) {
+    tuwjson::Value test_json;
+    GetTestJson(test_json);
+    test_json["gui"][1]["components"][8]["inc"].SetInt(-1);
+    CheckGUIError(test_json,
+        "\"inc\" should be a positive number. (line: 240, column: 28)");
+}
+
+TEST(JsonCheckTest, checkGUIFloatInc2) {
+    tuwjson::Value test_json;
+    GetTestJson(test_json);
+    test_json["gui"][1]["components"][9]["inc"].SetDouble(-0.1);
+    CheckGUIError(test_json,
+        "\"inc\" should be a positive number. (line: 253, column: 28)");
+}


### PR DESCRIPTION
Added two JSON errors: `'inc' should be a potitive number` and `'max' should be greater than 'min'`.