### PR TITLE
More code optimization

### DIFF
--- a/include/json_utils.h
+++ b/include/json_utils.h
@@ -43,13 +43,6 @@ noex::string GetFileError(const noex::string& path) noexcept;
 
 namespace json_utils {
 
-struct JsonResult {
-    bool ok;
-    noex::string msg;
-};
-
-#define JSON_RESULT_OK { true, "" }
-
 // Max binary size for JSON files.
 #define JSON_SIZE_MAX 128 * 1024
 
@@ -63,10 +56,10 @@ int GetInt(const tuwjson::Value& json, const char* key, int def) noexcept;
 double GetDouble(const tuwjson::Value& json, const char* key, double def) noexcept;
 
 void GetDefaultDefinition(tuwjson::Value& definition) noexcept;
-void CheckVersion(JsonResult& result, tuwjson::Value& definition) noexcept;
-void CheckDefinition(JsonResult& result, tuwjson::Value& definition) noexcept;
-void CheckSubDefinition(JsonResult& result, tuwjson::Value& sub_definition,
+void CheckVersion(noex::string& err_msg, tuwjson::Value& definition) noexcept;
+void CheckDefinition(noex::string& err_msg, tuwjson::Value& definition) noexcept;
+void CheckSubDefinition(noex::string& err_msg, tuwjson::Value& sub_definition,
                         int index) noexcept;
-void CheckHelpURLs(JsonResult& result, tuwjson::Value& definition) noexcept;
+void CheckHelpURLs(noex::string& err_msg, tuwjson::Value& definition) noexcept;
 
 }  // namespace json_utils

--- a/include/main_frame.h
+++ b/include/main_frame.h
@@ -32,7 +32,7 @@ class MainFrame {
 
     void CreateFrame() noexcept;
     void CreateMenu() noexcept;
-    json_utils::JsonResult CheckDefinition(tuwjson::Value& definition) noexcept;
+    noex::string CheckDefinition(tuwjson::Value& definition) noexcept;
     void UpdateConfig() noexcept;
     void ShowSuccessDialog(const char* msg, const char* title = "Success") noexcept;
     void ShowErrorDialog(const char* msg, const char* title = "Error") noexcept;

--- a/include/noex/string.hpp
+++ b/include/noex/string.hpp
@@ -38,7 +38,7 @@ class basic_string {
     inline size_t capacity() const noexcept { return m_capacity; }
 
     inline bool empty() const noexcept {
-        return !m_str || m_size == 0;
+        return m_size == 0;
     }
 
     // Returns an immutable C string. This can't be null.

--- a/include/noex/vector.hpp
+++ b/include/noex/vector.hpp
@@ -79,7 +79,7 @@ class non_trivial_vector {
     size_t capacity() const noexcept { return m_capacity; }
 
     bool empty() const noexcept {
-        return m_data == nullptr || m_size == 0;
+        return m_size == 0;
     }
 
     // Returns a pointer to the actual buffer.
@@ -232,7 +232,7 @@ class trivial_vector_base {
     size_t capacity() const noexcept { return m_capacity; }
 
     bool empty() const noexcept {
-        return m_data == nullptr || m_size == 0;
+        return m_size == 0;
     }
 
     void clear() noexcept;

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -126,13 +126,13 @@ enum class JsonType {
 
 static const bool REQUIRED = false;
 
-static tuwjson::Value* CheckJsonType(JsonResult& result, const tuwjson::Value& j, const char* key,
+static tuwjson::Value* CheckJsonType(
+        noex::string& err_msg, const tuwjson::Value& j, const char* key,
         const JsonType& type, const char* name = "", const bool& optional = true) noexcept {
     tuwjson::Value* ptr = j.GetMemberPtr(key);
     if (!ptr) {
         if (optional) return nullptr;
-        result.ok = false;
-        result.msg = noex::concat_cstr(name, " requires \"", key) + "\"" + j.GetLineColumnStr();
+        err_msg = noex::concat_cstr(name, " requires \"", key) + "\"" + j.GetLineColumnStr();
         return nullptr;
     }
     bool valid = false;
@@ -186,8 +186,7 @@ static tuwjson::Value* CheckJsonType(JsonResult& result, const tuwjson::Value& j
         break;
     }
     if (!valid) {
-        result.ok = false;
-        result.msg = noex::concat_cstr("\"", key, "\" should be ") + type_name
+        err_msg = noex::concat_cstr("\"", key, "\" should be ") + type_name
             + ptr->GetLineColumnStr();
     }
     return ptr;
@@ -209,9 +208,9 @@ void GetDefaultDefinition(tuwjson::Value& definition) noexcept {
     tuwjson::Error ok = parser.ParseJson(def_str, &definition);
     assert(ok == tuwjson::JSON_OK);
     (void) ok;  // GCC says it's unused even if you use it for assertion.
-    JsonResult result = JSON_RESULT_OK;
-    CheckDefinition(result, definition);
-    assert(result.ok);
+    noex::string err_msg;
+    CheckDefinition(err_msg, definition);
+    assert(err_msg.empty());
 }
 
 static void CorrectKey(
@@ -242,7 +241,7 @@ SplitString(const char* str, const char delimiter) noexcept {
 }
 
 // split command by "%" symbol, and calculate which component should be inserted there.
-static void CompileCommand(JsonResult& result,
+static void CompileCommand(noex::string& err_msg,
                             tuwjson::Value& sub_definition,
                             const noex::vector<noex::string>& comp_ids) noexcept {
     noex::vector<noex::string> cmd = SplitString(sub_definition["command"].GetString(), '%');
@@ -327,22 +326,19 @@ static void CompileCommand(JsonResult& result,
                 break;
             }
         if (!found) {
-            result.ok = false;
-
             if (comp_ids[j].empty() || !v.HasMember("id")) {
-                result.msg = noex::concat_cstr("[\"components\"][", noex::to_string(j).c_str(), "]")
+                err_msg = noex::concat_cstr("[\"components\"][", noex::to_string(j).c_str(), "]")
                     + v.GetLineColumnStr() + " is unused in the command; " + cmd_str;
             } else {
                 tuwjson::Value& vid = v["id"];
-                result.msg = noex::concat_cstr("component id \"", vid.GetString(), "\"")
+                err_msg = noex::concat_cstr("component id \"", vid.GetString(), "\"")
                     + vid.GetLineColumnStr() + " is unused in the command; " + cmd_str;
             }
             return;
         }
     }
     if (non_id_comp > comp_size) {
-        result.ok = false;
-        result.msg =
+        err_msg =
             "The command requires more components for arguments; " + cmd_str;
         return;
     }
@@ -387,47 +383,46 @@ int ComptypeToInt(const char* comptype) noexcept {
     return COMP_UNKNOWN;
 }
 
-void CheckValidator(JsonResult& result, tuwjson::Value& validator) noexcept {
-    CheckJsonType(result, validator, "regex", JsonType::STRING);
-    CheckJsonType(result, validator, "regex_error", JsonType::STRING);
-    CheckJsonType(result, validator, "wildcard", JsonType::STRING);
-    CheckJsonType(result, validator, "wildcard_error", JsonType::STRING);
-    CheckJsonType(result, validator, "exist", JsonType::BOOLEAN);
-    CheckJsonType(result, validator, "exist_error", JsonType::STRING);
-    CheckJsonType(result, validator, "not_empty", JsonType::BOOLEAN);
-    CheckJsonType(result, validator, "not_empty_error", JsonType::STRING);
+void CheckValidator(noex::string& err_msg, tuwjson::Value& validator) noexcept {
+    CheckJsonType(err_msg, validator, "regex", JsonType::STRING);
+    CheckJsonType(err_msg, validator, "regex_error", JsonType::STRING);
+    CheckJsonType(err_msg, validator, "wildcard", JsonType::STRING);
+    CheckJsonType(err_msg, validator, "wildcard_error", JsonType::STRING);
+    CheckJsonType(err_msg, validator, "exist", JsonType::BOOLEAN);
+    CheckJsonType(err_msg, validator, "exist_error", JsonType::STRING);
+    CheckJsonType(err_msg, validator, "not_empty", JsonType::BOOLEAN);
+    CheckJsonType(err_msg, validator, "not_empty_error", JsonType::STRING);
 }
 
 // validate one of definitions (["gui"][i]) and store parsed info
-void CheckSubDefinition(JsonResult& result, tuwjson::Value& sub_definition,
+void CheckSubDefinition(noex::string& err_msg, tuwjson::Value& sub_definition,
                         int index) noexcept {
     tuwjson::Value* json_ptr = nullptr;
 
     CorrectKey(sub_definition, "window_title", "window_name");
     CorrectKey(sub_definition, "title", "window_name");
-    CheckJsonType(result, sub_definition, "window_name", JsonType::STRING);
+    CheckJsonType(err_msg, sub_definition, "window_name", JsonType::STRING);
 
     if (!sub_definition.HasMember("label")) {
         noex::string default_label = "GUI " + noex::to_string(index);
         const char* label = GetString(sub_definition, "window_name", default_label.c_str());
         sub_definition["label"].SetString(label);
     }
-    CheckJsonType(result, sub_definition, "label", JsonType::STRING, "gui definition", REQUIRED);
+    CheckJsonType(err_msg, sub_definition, "label", JsonType::STRING, "gui definition", REQUIRED);
 
-    CheckJsonType(result, sub_definition, "button", JsonType::STRING);
+    CheckJsonType(err_msg, sub_definition, "button", JsonType::STRING);
 
-    CheckJsonType(result, sub_definition, "check_exit_code", JsonType::BOOLEAN);
-    CheckJsonType(result, sub_definition, "exit_success", JsonType::INTEGER);
-    CheckJsonType(result, sub_definition, "show_last_line", JsonType::BOOLEAN);
-    CheckJsonType(result, sub_definition,
+    CheckJsonType(err_msg, sub_definition, "check_exit_code", JsonType::BOOLEAN);
+    CheckJsonType(err_msg, sub_definition, "exit_success", JsonType::INTEGER);
+    CheckJsonType(err_msg, sub_definition, "show_last_line", JsonType::BOOLEAN);
+    CheckJsonType(err_msg, sub_definition,
                     "show_success_dialog", JsonType::BOOLEAN);
-    json_ptr = CheckJsonType(result, sub_definition, "codepage", JsonType::STRING);
+    json_ptr = CheckJsonType(err_msg, sub_definition, "codepage", JsonType::STRING);
     if (json_ptr) {
         const char* codepage = json_ptr->GetString();
         if (strcmp(codepage, "utf8") != 0 && strcmp(codepage, "utf-8") != 0 &&
                 strcmp(codepage, "default") != 0) {
-            result.ok = false;
-            result.msg = noex::concat_cstr("Unknown codepage: ", codepage);
+            err_msg = noex::concat_cstr("Unknown codepage: ", codepage);
             return;
         }
     }
@@ -435,19 +430,19 @@ void CheckSubDefinition(JsonResult& result, tuwjson::Value& sub_definition,
     CorrectKey(sub_definition, "component", "components");
     CorrectKey(sub_definition, "component_array", "components");
     tuwjson::Value* comp_array_ptr =
-        CheckJsonType(result, sub_definition, "components",
+        CheckJsonType(err_msg, sub_definition, "components",
             JsonType::JSON_ARRAY, "gui definition", REQUIRED);
 
-    if (!result.ok) return;
+    if (!err_msg.empty()) return;
 
     // check components
     noex::vector<noex::string> comp_ids;
     for (tuwjson::Value& c : *comp_array_ptr) {
         // check if type and label exist
-        CheckJsonType(result, c, "label", JsonType::STRING, "component", REQUIRED);
+        CheckJsonType(err_msg, c, "label", JsonType::STRING, "component", REQUIRED);
         tuwjson::Value* type_ptr =
-            CheckJsonType(result, c, "type", JsonType::STRING, "component", REQUIRED);
-        if (!result.ok) return;
+            CheckJsonType(err_msg, c, "type", JsonType::STRING, "component", REQUIRED);
+        if (!err_msg.empty()) return;
 
         // convert ["type"] from string to enum.
         const char* type_str = type_ptr->GetString();
@@ -468,39 +463,39 @@ void CheckSubDefinition(JsonResult& result, tuwjson::Value& sub_definition,
         double min, max;
         switch (type) {
             case COMP_FILE:
-                CheckJsonType(result, c, "extension", JsonType::STRING);
-                CheckJsonType(result, c, "use_save_dialog", JsonType::BOOLEAN);
+                CheckJsonType(err_msg, c, "extension", JsonType::STRING);
+                CheckJsonType(err_msg, c, "use_save_dialog", JsonType::BOOLEAN);
                 /* Falls through. */
             case COMP_FOLDER:
-                CheckJsonType(result, c, "button", JsonType::STRING);
+                CheckJsonType(err_msg, c, "button", JsonType::STRING);
                 /* Falls through. */
             case COMP_TEXT:
-                CheckJsonType(result, c, "default", JsonType::STRING);
+                CheckJsonType(err_msg, c, "default", JsonType::STRING);
                 break;
             case COMP_COMBO:
             case COMP_RADIO:
-                json_ptr = CheckJsonType(result, c, "items",
+                json_ptr = CheckJsonType(err_msg, c, "items",
                     JsonType::JSON_ARRAY, "radio type component", REQUIRED);
-                if (!result.ok) return;
+                if (!err_msg.empty()) return;
                 for (tuwjson::Value& i : *json_ptr) {
-                    CheckJsonType(result, i, "label", JsonType::STRING, "radio item", REQUIRED);
-                    CheckJsonType(result, i, "value", JsonType::STRING);
+                    CheckJsonType(err_msg, i, "label", JsonType::STRING, "radio item", REQUIRED);
+                    CheckJsonType(err_msg, i, "value", JsonType::STRING);
                 }
-                CheckJsonType(result, c, "default", JsonType::INTEGER);
+                CheckJsonType(err_msg, c, "default", JsonType::INTEGER);
                 break;
             case COMP_CHECK:
-                CheckJsonType(result, c, "value", JsonType::STRING);
-                CheckJsonType(result, c, "default", JsonType::BOOLEAN);
+                CheckJsonType(err_msg, c, "value", JsonType::STRING);
+                CheckJsonType(err_msg, c, "default", JsonType::BOOLEAN);
                 break;
             case COMP_CHECK_ARRAY:
-                json_ptr = CheckJsonType(result, c, "items",
+                json_ptr = CheckJsonType(err_msg, c, "items",
                     JsonType::JSON_ARRAY, "check array", REQUIRED);
-                if (!result.ok) return;
+                if (!err_msg.empty()) return;
                 for (tuwjson::Value& i : *json_ptr) {
-                    CheckJsonType(result, i, "label", JsonType::STRING, "check box", REQUIRED);
-                    CheckJsonType(result, i, "value", JsonType::STRING);
-                    CheckJsonType(result, i, "default", JsonType::BOOLEAN);
-                    CheckJsonType(result, i, "tooltip", JsonType::STRING);
+                    CheckJsonType(err_msg, i, "label", JsonType::STRING, "check box", REQUIRED);
+                    CheckJsonType(err_msg, i, "value", JsonType::STRING);
+                    CheckJsonType(err_msg, i, "default", JsonType::BOOLEAN);
+                    CheckJsonType(err_msg, i, "tooltip", JsonType::STRING);
                 }
                 break;
             case COMP_INT:
@@ -510,72 +505,67 @@ void CheckSubDefinition(JsonResult& result, tuwjson::Value& sub_definition,
                     jtype = JsonType::INTEGER;
                 } else {
                     jtype = JsonType::FLOAT;
-                    json_ptr = CheckJsonType(result, c, "digits", JsonType::INTEGER);
-                    if (!result.ok) return;
+                    json_ptr = CheckJsonType(err_msg, c, "digits", JsonType::INTEGER);
+                    if (!err_msg.empty()) return;
                     if (json_ptr && json_ptr->GetInt() < 0) {
-                        result.ok = false;
-                        result.msg = "\"digits\" should be a non-negative integer."
+                        err_msg = "\"digits\" should be a non-negative integer."
                                     + json_ptr->GetLineColumnStr();
                     }
                 }
-                CheckJsonType(result, c, "default", jtype);
+                CheckJsonType(err_msg, c, "default", jtype);
                 // Check min and max
-                CheckJsonType(result, c, "min", jtype);
-                json_ptr = CheckJsonType(result, c, "max", jtype);
-                if (!result.ok) return;
+                CheckJsonType(err_msg, c, "min", jtype);
+                json_ptr = CheckJsonType(err_msg, c, "max", jtype);
+                if (!err_msg.empty()) return;
                 min = json_utils::GetDouble(c, "min", 0);
                 max = json_utils::GetDouble(c, "max", 100.0);
                 if (min > max) {
-                    result.ok = false;
-                    result.msg = "\"max\" should be greater than \"min\"."
+                    err_msg = "\"max\" should be greater than \"min\"."
                                 + json_ptr->GetLineColumnStr();
                 }
                 // Check inc
-                json_ptr = CheckJsonType(result, c, "inc", jtype);
-                if (!result.ok) return;
+                json_ptr = CheckJsonType(err_msg, c, "inc", jtype);
+                if (!err_msg.empty()) return;
                 if (json_ptr && json_ptr->GetDouble() <= 0) {
-                    result.ok = false;
-                    result.msg = "\"inc\" should be a positive number."
+                    err_msg = "\"inc\" should be a positive number."
                                 + json_ptr->GetLineColumnStr();
                 }
-                CheckJsonType(result, c, "wrap", JsonType::BOOLEAN);
+                CheckJsonType(err_msg, c, "wrap", JsonType::BOOLEAN);
                 break;
             case COMP_UNKNOWN:
-                result.ok = false;
-                result.msg = noex::concat_cstr("Unknown component type: ",
+                err_msg = noex::concat_cstr("Unknown component type: ",
                     type_str, type_ptr->GetLineColumnStr().c_str());
                 break;
         }
-        if (!result.ok) return;
+        if (!err_msg.empty()) return;
 
-        json_ptr = CheckJsonType(result, c, "validator", JsonType::JSON);
+        json_ptr = CheckJsonType(err_msg, c, "validator", JsonType::JSON);
         if (json_ptr) {
             if (type == COMP_STATIC_TEXT) {
-                result.ok = false;
-                result.msg = "Static text does not support validator."
+                err_msg = "Static text does not support validator."
                     + json_ptr->GetLineColumnStr();
                 return;
             }
-            CheckValidator(result, *json_ptr);
-            if (!result.ok) return;
+            CheckValidator(err_msg, *json_ptr);
+            if (!err_msg.empty()) return;
         }
 
         CorrectKey(c, "add_quote", "add_quotes");
-        CheckJsonType(result, c, "add_quotes", JsonType::BOOLEAN);
+        CheckJsonType(err_msg, c, "add_quotes", JsonType::BOOLEAN);
         CorrectKey(c, "empty_message", "placeholder");
-        CheckJsonType(result, c, "placeholder", JsonType::STRING);
-        CheckJsonType(result, c, "id", JsonType::STRING);
-        CheckJsonType(result, c, "tooltip", JsonType::STRING);
+        CheckJsonType(err_msg, c, "placeholder", JsonType::STRING);
+        CheckJsonType(err_msg, c, "id", JsonType::STRING);
+        CheckJsonType(err_msg, c, "tooltip", JsonType::STRING);
 
-        CheckJsonType(result, c, "optional", JsonType::BOOLEAN);
-        CheckJsonType(result, c, "prefix", JsonType::STRING);
-        CheckJsonType(result, c, "suffix", JsonType::STRING);
+        CheckJsonType(err_msg, c, "optional", JsonType::BOOLEAN);
+        CheckJsonType(err_msg, c, "prefix", JsonType::STRING);
+        CheckJsonType(err_msg, c, "suffix", JsonType::STRING);
 
         bool ignore = false;
         CorrectKey(c, "platform", "platforms");
         CorrectKey(c, "platform_array", "platforms");
-        json_ptr = CheckJsonType(result, c, "platforms", JsonType::STRING_ARRAY);
-        if (!result.ok) return;
+        json_ptr = CheckJsonType(err_msg, c, "platforms", JsonType::STRING_ARRAY);
+        if (!err_msg.empty()) return;
         if (json_ptr) {
             ignore = true;
             for (tuwjson::Value& v : *json_ptr) {
@@ -590,19 +580,16 @@ void CheckSubDefinition(JsonResult& result, tuwjson::Value& sub_definition,
         if (c.HasMember("id")) {
             noex::string linecol = c["id"].GetLineColumnStr();
             if (id[0] == '\0') {
-                result.ok = false;
-                result.msg = "\"id\" should NOT be an empty string."
+                err_msg = "\"id\" should NOT be an empty string."
                             + linecol;
             } else if (id[0] == '_') {
-                result.ok = false;
-                result.msg = "\"id\" should NOT start with '_'."
+                err_msg = "\"id\" should NOT start with '_'."
                             + linecol;
             }
             if (!ignore) {
                 for (const noex::string& str : comp_ids) {
                     if (id == str) {
-                        result.ok = false;
-                        result.msg =
+                        err_msg =
                             noex::concat_cstr("Found a duplicated id: \"", id, "\"")
                             + linecol;
                     }
@@ -612,7 +599,7 @@ void CheckSubDefinition(JsonResult& result, tuwjson::Value& sub_definition,
             uint32_t hash = Fnv1Hash32(c["label"].GetString());
             c["id"].SetString("_" + noex::to_string(hash));
         }
-        if (!result.ok) return;
+        if (!err_msg.empty()) return;
 
         if (ignore) {
             comp_ids.emplace_back("");
@@ -624,28 +611,27 @@ void CheckSubDefinition(JsonResult& result, tuwjson::Value& sub_definition,
 
     // Overwrite ["command"] with ["command_'os'"] if exists.
     const char* command_os_key = "command_" TUW_CONSTANTS_OS;
-    json_ptr = CheckJsonType(result, sub_definition, command_os_key, JsonType::STRING);
-    if (result.ok && json_ptr) {
+    json_ptr = CheckJsonType(err_msg, sub_definition, command_os_key, JsonType::STRING);
+    if (err_msg.empty() && json_ptr) {
         const char* command_os = json_ptr->GetString();
         sub_definition["command"].SetString(command_os);
     }
 
     // check sub_definition["command"] and convert it to more useful format.
-    CheckJsonType(result, sub_definition, "command", JsonType::STRING, "gui definition", REQUIRED);
-    if (!result.ok) return;
-    CompileCommand(result, sub_definition, comp_ids);
+    CheckJsonType(err_msg, sub_definition, "command", JsonType::STRING, "gui definition", REQUIRED);
+    if (!err_msg.empty()) return;
+    CompileCommand(err_msg, sub_definition, comp_ids);
 }
 
 // vX.Y.Z -> 10000*X + 100 * Y + Z
-static int VersionStringToInt(JsonResult& result, const char* string) noexcept {
+static int VersionStringToInt(noex::string& err_msg, const char* string) noexcept {
     noex::vector<noex::string> version_strings =
         SplitString(string, '.');
     int digit = 10000;
     int version_int = 0;
     for (const noex::string& str : version_strings) {
         if (str.length() == 0 || str.length() > 2) {
-            result.ok = false;
-            result.msg = noex::concat_cstr("Can NOT convert '", string, "' to int.");
+            err_msg = noex::concat_cstr("Can NOT convert '", string, "' to int.");
             return 0;
         }
         if (str.length() == 1) {
@@ -661,64 +647,61 @@ static int VersionStringToInt(JsonResult& result, const char* string) noexcept {
     return version_int;
 }
 
-void CheckVersion(JsonResult& result, tuwjson::Value& definition) noexcept {
+void CheckVersion(noex::string& err_msg, tuwjson::Value& definition) noexcept {
     tuwjson::Value* json_ptr = nullptr;
     CorrectKey(definition, "recommended_version", "recommended");
-    json_ptr = CheckJsonType(result, definition, "recommended", JsonType::STRING);
-    if (result.ok && json_ptr) {
-        int recom_int = VersionStringToInt(result, json_ptr->GetString());
+    json_ptr = CheckJsonType(err_msg, definition, "recommended", JsonType::STRING);
+    if (err_msg.empty() && json_ptr) {
+        int recom_int = VersionStringToInt(err_msg, json_ptr->GetString());
         definition["not_recommended"].SetBool(tuw_constants::VERSION_INT != recom_int);
     }
     CorrectKey(definition, "minimum_required_version", "minimum_required");
-    json_ptr = CheckJsonType(result, definition, "minimum_required", JsonType::STRING);
-    if (result.ok && json_ptr) {
+    json_ptr = CheckJsonType(err_msg, definition, "minimum_required", JsonType::STRING);
+    if (err_msg.empty() && json_ptr) {
         const char* required = json_ptr->GetString();
-        int required_int = VersionStringToInt(result, required);
+        int required_int = VersionStringToInt(err_msg, required);
         if (tuw_constants::VERSION_INT < required_int) {
-            result.ok = false;
-            result.msg = noex::concat_cstr("Version ", required, " is required.");
+            err_msg = noex::concat_cstr("Version ", required, " is required.");
         }
     }
 }
 
-void CheckDefinition(JsonResult& result, tuwjson::Value& definition) noexcept {
+void CheckDefinition(noex::string& err_msg, tuwjson::Value& definition) noexcept {
     if (!definition.HasMember("gui")) {
         // definition["gui"] = definition
         definition.ConvertToObject("gui");
     }
     tuwjson::Value* gui_json_ptr =
-        CheckJsonType(result, definition, "gui", JsonType::JSON_ARRAY);
-    if (!result.ok) return;
+        CheckJsonType(err_msg, definition, "gui", JsonType::JSON_ARRAY);
+    if (!err_msg.empty()) return;
     if (gui_json_ptr->Size() == 0) {
-        result.ok = false;
-        result.msg = "The size of [\"gui\"] should NOT be zero."
+        err_msg = "The size of [\"gui\"] should NOT be zero."
             + gui_json_ptr->GetLineColumnStr();
     }
 
     int i = 0;
     for (tuwjson::Value& sub_d : *gui_json_ptr) {
-        if (!result.ok) return;
-        CheckSubDefinition(result, sub_d, i);
+        if (!err_msg.empty()) return;
+        CheckSubDefinition(err_msg, sub_d, i);
         i++;
     }
 }
 
-void CheckHelpURLs(JsonResult& result, tuwjson::Value& definition) noexcept {
-    tuwjson::Value* json_ptr = CheckJsonType(result, definition, "help", JsonType::JSON_ARRAY);
-    if (!result.ok || !json_ptr) return;
+void CheckHelpURLs(noex::string& err_msg, tuwjson::Value& definition) noexcept {
+    tuwjson::Value* json_ptr = CheckJsonType(err_msg, definition, "help", JsonType::JSON_ARRAY);
+    if (!err_msg.empty() || !json_ptr) return;
     for (const tuwjson::Value& h : *json_ptr) {
         tuwjson::Value* help_type_ptr =
-            CheckJsonType(result, h, "type", JsonType::STRING, "help document", REQUIRED);
-        CheckJsonType(result, h, "label", JsonType::STRING, "help document", REQUIRED);
-        if (!result.ok) return;
+            CheckJsonType(err_msg, h, "type", JsonType::STRING, "help document", REQUIRED);
+        CheckJsonType(err_msg, h, "label", JsonType::STRING, "help document", REQUIRED);
+        if (!err_msg.empty()) return;
         const char* type = help_type_ptr->GetString();
         if (strcmp(type, "url") == 0) {
-            CheckJsonType(result, h, "url", JsonType::STRING, "URL type document", REQUIRED);
+            CheckJsonType(err_msg, h, "url", JsonType::STRING, "URL type document", REQUIRED);
         } else if (strcmp(type, "file") == 0) {
-            CheckJsonType(result, h, "path", JsonType::STRING, "file type document", REQUIRED);
+            CheckJsonType(err_msg, h, "path", JsonType::STRING, "file type document", REQUIRED);
         } else {
-            result.ok = false;
-            result.msg = noex::concat_cstr("Unsupported help type: ", type,
+            err_msg = noex::concat_cstr("Unsupported help type: ", type,
                 help_type_ptr->GetLineColumnStr().c_str());
             return;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,10 +67,10 @@ noex::string Merge(const noex::string& exe_path, const noex::string& json_path,
     // Check JSON format before embedding
     tuwjson::Value tmp_json;
     tmp_json.CopyFrom(json);
-    json_utils::JsonResult res = JSON_RESULT_OK;
-    json_utils::CheckDefinition(res, tmp_json);
-    if (!res.ok)
-        return res.msg;
+    noex::string err_msg;
+    json_utils::CheckDefinition(err_msg, tmp_json);
+    if (!err_msg.empty())
+        return err_msg;
 
     ExeContainer exe;
     err = exe.Read(exe_path);

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -100,9 +100,9 @@ void MainFrame::Initialize(const tuwjson::Value& definition,
     }
 
     if (loaded) {
-        json_utils::JsonResult result = CheckDefinition(m_definition);
-        loaded = result.ok;
-        err = result.msg;
+        noex::string err_msg = CheckDefinition(m_definition);
+        loaded = err_msg.empty();
+        err = err_msg;
     }
 
     if (!loaded)
@@ -548,10 +548,10 @@ void MainFrame::RunCommand() noexcept {
 }
 
 // read gui_definition.json
-json_utils::JsonResult MainFrame::CheckDefinition(tuwjson::Value& definition) noexcept {
-    json_utils::JsonResult result = JSON_RESULT_OK;
-    json_utils::CheckVersion(result, definition);
-    if (!result.ok) return result;
+noex::string MainFrame::CheckDefinition(tuwjson::Value& definition) noexcept {
+    noex::string err_msg;
+    json_utils::CheckVersion(err_msg, definition);
+    if (!err_msg.empty()) return err_msg;
 
     tuwjson::Value* ptr = definition.GetMemberPtr("recommended");
     if (ptr) {
@@ -561,11 +561,11 @@ json_utils::JsonResult MainFrame::CheckDefinition(tuwjson::Value& definition) no
         }
     }
 
-    json_utils::CheckDefinition(result, definition);
-    if (!result.ok) return result;
+    json_utils::CheckDefinition(err_msg, definition);
+    if (!err_msg.empty()) return err_msg;
 
-    json_utils::CheckHelpURLs(result, definition);
-    return result;
+    json_utils::CheckHelpURLs(err_msg, definition);
+    return err_msg;
 }
 
 void MainFrame::UpdateConfig() noexcept {

--- a/tests/json_check_test.cpp
+++ b/tests/json_check_test.cpp
@@ -34,9 +34,9 @@ TEST(JsonCheckTest, LoadJsonSuccess) {
 TEST(JsonCheckTest, checkGUISuccess) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
-    json_utils::JsonResult result = JSON_RESULT_OK;
-    json_utils::CheckDefinition(result, test_json);
-    EXPECT_TRUE(result.ok);
+    noex::string err_msg;
+    json_utils::CheckDefinition(err_msg, test_json);
+    EXPECT_TRUE(err_msg.empty());
 }
 
 TEST(JsonCheckTest, checkGUISuccess2) {
@@ -44,43 +44,43 @@ TEST(JsonCheckTest, checkGUISuccess2) {
     GetTestJson(test_json);
     tuwjson::Value& comp = test_json["gui"][0]["components"][6];
     comp.ReplaceKey("items", "item_array");
-    json_utils::JsonResult result = JSON_RESULT_OK;
-    json_utils::CheckDefinition(result, test_json);
-    EXPECT_TRUE(result.ok);
+    noex::string err_msg;
+    json_utils::CheckDefinition(err_msg, test_json);
+    EXPECT_TRUE(err_msg.empty());
 }
 
 TEST(JsonCheckTest, checkGUISuccess3) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"][0].Swap(test_json["gui"][1]);
-    json_utils::JsonResult result = JSON_RESULT_OK;
-    json_utils::CheckDefinition(result, test_json);
-    EXPECT_TRUE(result.ok);
+    noex::string err_msg;
+    json_utils::CheckDefinition(err_msg, test_json);
+    EXPECT_TRUE(err_msg.empty());
 }
 
 TEST(JsonCheckTest, checkGUISuccess4) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["gui"][0].Swap(test_json["gui"][2]);
-    json_utils::JsonResult result = JSON_RESULT_OK;
-    json_utils::CheckDefinition(result, test_json);
-    EXPECT_TRUE(result.ok);
+    noex::string err_msg;
+    json_utils::CheckDefinition(err_msg, test_json);
+    EXPECT_TRUE(err_msg.empty());
 }
 
 TEST(JsonCheckTest, checkGUISuccessRelaxed) {
     tuwjson::Value test_json;
     noex::string err = json_utils::LoadJson(JSON_RELAXED, test_json);
     EXPECT_TRUE(err.empty());
-    json_utils::JsonResult result = JSON_RESULT_OK;
-    json_utils::CheckDefinition(result, test_json);
-    EXPECT_TRUE(result.ok);
+    noex::string err_msg;
+    json_utils::CheckDefinition(err_msg, test_json);
+    EXPECT_TRUE(err_msg.empty());
 }
 
 void CheckGUIError(tuwjson::Value& test_json, const char* expected) {
-    json_utils::JsonResult result = JSON_RESULT_OK;
-    json_utils::CheckDefinition(result, test_json);
-    EXPECT_FALSE(result.ok);
-    EXPECT_STREQ(expected, result.msg.c_str());
+    noex::string err_msg;
+    json_utils::CheckDefinition(err_msg, test_json);
+    EXPECT_FALSE(err_msg.empty());
+    EXPECT_STREQ(expected, err_msg.c_str());
 }
 
 TEST(JsonCheckTest, checkGUIFail) {
@@ -160,16 +160,16 @@ TEST(JsonCheckTest, checkGUIFailRelaxed) {
 TEST(JsonCheckTest, checkHelpSuccess) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
-    json_utils::JsonResult result = JSON_RESULT_OK;
-    json_utils::CheckHelpURLs(result, test_json);
-    EXPECT_TRUE(result.ok);
+    noex::string err_msg;
+    json_utils::CheckHelpURLs(err_msg, test_json);
+    EXPECT_TRUE(err_msg.empty());
 }
 
 void CheckHelpError(tuwjson::Value& test_json, const char* expected) {
-    json_utils::JsonResult result = JSON_RESULT_OK;
-    json_utils::CheckHelpURLs(result, test_json);
-    EXPECT_FALSE(result.ok);
-    EXPECT_STREQ(expected, result.msg.c_str());
+    noex::string err_msg;
+    json_utils::CheckHelpURLs(err_msg, test_json);
+    EXPECT_FALSE(err_msg.empty());
+    EXPECT_STREQ(expected, err_msg.c_str());
 }
 
 TEST(JsonCheckTest, checkHelpFail) {
@@ -190,9 +190,9 @@ TEST(JsonCheckTest, checkVersionSuccess) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["recommended"].SetString(tuw_constants::VERSION);
-    json_utils::JsonResult result = JSON_RESULT_OK;
-    json_utils::CheckVersion(result, test_json);
-    EXPECT_TRUE(result.ok);
+    noex::string err_msg;
+    json_utils::CheckVersion(err_msg, test_json);
+    EXPECT_TRUE(err_msg.empty());
     EXPECT_FALSE(test_json["not_recommended"].GetBool());
 }
 
@@ -200,9 +200,9 @@ TEST(JsonCheckTest, checkVersionFail) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["recommended"].SetString("0.2.3");
-    json_utils::JsonResult result = JSON_RESULT_OK;
-    json_utils::CheckVersion(result, test_json);
-    EXPECT_TRUE(result.ok);
+    noex::string err_msg;
+    json_utils::CheckVersion(err_msg, test_json);
+    EXPECT_TRUE(err_msg.empty());
     EXPECT_TRUE(test_json["not_recommended"].GetBool());
 }
 
@@ -210,39 +210,39 @@ TEST(JsonCheckTest, checkVersionFail2) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["recommended"].SetString("foo");
-    json_utils::JsonResult result = JSON_RESULT_OK;
-    json_utils::CheckVersion(result, test_json);
-    EXPECT_FALSE(result.ok);
-    EXPECT_STREQ("Can NOT convert 'foo' to int.", result.msg.c_str());
+    noex::string err_msg;
+    json_utils::CheckVersion(err_msg, test_json);
+    EXPECT_FALSE(err_msg.empty());
+    EXPECT_STREQ("Can NOT convert 'foo' to int.", err_msg.c_str());
 }
 
 TEST(JsonCheckTest, checkVersionSuccess2) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["minimum_required"].SetString(tuw_constants::VERSION);
-    json_utils::JsonResult result = JSON_RESULT_OK;
-    json_utils::CheckVersion(result, test_json);
-    EXPECT_TRUE(result.ok);
+    noex::string err_msg;
+    json_utils::CheckVersion(err_msg, test_json);
+    EXPECT_TRUE(err_msg.empty());
 }
 
 TEST(JsonCheckTest, checkVersionFail3) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["minimum_required"].SetString("1.0.0");
-    json_utils::JsonResult result = JSON_RESULT_OK;
-    json_utils::CheckVersion(result, test_json);
-    EXPECT_FALSE(result.ok);
-    EXPECT_STREQ("Version 1.0.0 is required.", result.msg.c_str());
+    noex::string err_msg;
+    json_utils::CheckVersion(err_msg, test_json);
+    EXPECT_FALSE(err_msg.empty());
+    EXPECT_STREQ("Version 1.0.0 is required.", err_msg.c_str());
 }
 
 TEST(JsonCheckTest, checkVersionFail4) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json["minimum_required"].SetString("foo");
-    json_utils::JsonResult result = JSON_RESULT_OK;
-    json_utils::CheckVersion(result, test_json);
-    EXPECT_FALSE(result.ok);
-    EXPECT_STREQ("Can NOT convert 'foo' to int.", result.msg.c_str());
+    noex::string err_msg;
+    json_utils::CheckVersion(err_msg, test_json);
+    EXPECT_FALSE(err_msg.empty());
+    EXPECT_STREQ("Can NOT convert 'foo' to int.", err_msg.c_str());
 }
 
 TEST(JsonCheckTest, checkGUIIntInc) {


### PR DESCRIPTION
Removed unnecessary codes more to reduce binary size.

- Replaced `JsonResult` with string.
  (We can replace `result.ok` with `str.empty()`)
- Simplified `string::empty()` and `vector::empty()`.
  (We don't need null check since `m_size` is zero when `m_str` is null)
- Replaced `SplitString` with `SubstrToChar`.
  (We don't need to store substrings in a vector.)