### PR TITLE
fix out-of-bounds error when executing an empty command

### DIFF
--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -116,6 +116,9 @@ void DestroyProcess(subprocess_s &process,
 
 ExecuteResult Execute(const noex::string& cmd,
                       bool use_utf8_on_windows) noexcept {
+    if (cmd.empty())
+        return { 0, "", "" };
+
 #ifdef _WIN32
     noex::wstring wcmd = UTF8toUTF16(cmd.c_str());
 

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -446,6 +446,9 @@ noex::string MainFrame::GetCommand() noexcept {
     tuwjson::Value& cmd_ary = sub_definition["command_splitted"];
     tuwjson::Value& cmd_ids = sub_definition["command_ids"];
 
+    if (cmd_ary.IsEmpty())
+        return "";
+
     noex::string cmd = cmd_ary[0].GetString();
     for (size_t i = 0; i < cmd_ids.Size(); i++) {
         int id = cmd_ids[i].GetInt();

--- a/tests/main_frame_test.cpp
+++ b/tests/main_frame_test.cpp
@@ -118,6 +118,17 @@ TEST_F(MainFrameTest, GetCommand3) {
     EXPECT_STREQ(expected.c_str(), main_frame->GetCommand().c_str());
 }
 
+TEST_F(MainFrameTest, GetCommandEmpty) {
+    tuwjson::Value test_json;
+    GetTestJson(test_json);
+    json_utils::GetDefaultDefinition(test_json);
+    test_json["gui"][0]["command"].SetString("");
+    tuwjson::Value dummy_config;
+    GetDummyConfig(dummy_config);
+    main_frame = new MainFrame(test_json, dummy_config);
+    EXPECT_STREQ("", main_frame->GetCommand().c_str());
+}
+
 TEST_F(MainFrameTest, RunCommandSuccess) {
     tuwjson::Value test_json;
     GetTestJson(test_json);


### PR DESCRIPTION
Tuw throws the out-of-bounds error when executing an empty command. `GetCommand()` and `Execute()` now do nothing if the command is an empty string.

Minimal reproducible example
```
{
    "command": "",
    "components": []
}
```