### PR TITLE
Fix `GetExecutablePath` for Windows 8 or older

### DIFF
--- a/subprojects/env_utils.wrap
+++ b/subprojects/env_utils.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/matyalatte/c-env-utils.git
-revision = 07257be6d3aa41de8f39e0d721b60850ee8b198d
+revision = 51e5b90aeb0e967ced181ffb5739d5551026bc18
 depth = 1
 
 [provide]


### PR DESCRIPTION
Related to https://github.com/matyalatte/tuw/issues/126.

`envuGetExecutablePath()` failed with `ERROR_INVALID_FLAGS` on Windows 8 or older. This PR applies https://github.com/matyalatte/c-env-utils/pull/7 to fix the issue.