### PR TITLE
[Breaking Change] Make `id` required

### DIFF
--- a/examples/comp_options/id/README.md
+++ b/examples/comp_options/id/README.md
@@ -22,35 +22,6 @@ You can use the defined ids as variable names in commands.
 }
 ```
 
-## Undefined IDs
-
-> [!warning]
-> Undifined ids are deprecated. Please define an id for each component.
-
-When you put an undefined id in `%*%`, it'll use one of the components that have no id.
-
-```json
-{
-    "command": "echo x: %-% & echo y: %y% & echo z: %foo%",
-    "button": "Echo!",
-    "components": [
-        {
-            "type": "text",
-            "label": "Value of y",
-            "id": "y"
-        },
-        {
-            "type": "text",
-            "label": "Value of x"
-        },
-        {
-            "type": "text",
-            "label": "Value of z"
-        }
-    ]
-}
-```
-
 ## Predefined IDs
 
 There are some predefined ids.  

--- a/examples/comp_options/id/gui_definition.json
+++ b/examples/comp_options/id/gui_definition.json
@@ -18,26 +18,6 @@
             ]
         },
         {
-            "label": "Undefined IDs",
-            "command": "echo x: %-% & echo y: %y% & echo z: %foo%",
-            "button": "Echo!",
-            "components": [
-                {
-                    "type": "text",
-                    "label": "Value of y",
-                    "id": "y"
-                },
-                {
-                    "type": "text",
-                    "label": "Value of x"
-                },
-                {
-                    "type": "text",
-                    "label": "Value of z"
-                }
-            ]
-        },
-        {
             "label": "Reserved IDs",
             "command": "echo percent: %% & echo cwd: %__CWD__% & echo home: %__HOME__%",
             "button": "Echo!",

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -341,7 +341,7 @@ void MainFrame::UpdatePanel(size_t definition_id) noexcept {
         const char* label = sub_definition["label"].GetString();
         Log("UpdatePanel", "Label", label);
     }
-    const char* cmd_str = sub_definition["command_str"].GetString();
+    const char* cmd_str = sub_definition["command"].GetString();
     Log("UpdatePanel", "Command", cmd_str);
     const char* window_name = json_utils::GetString(sub_definition,
                                                     "window_name", tuw_constants::TOOL_NAME);

--- a/tests/json_check_test.cpp
+++ b/tests/json_check_test.cpp
@@ -123,30 +123,32 @@ TEST(JsonCheckTest, checkGUIFail6) {
     GetTestJson(test_json);
     test_json["gui"][0]["components"].GetArray()->pop_back();
     CheckGUIError(test_json,
-        "The command requires more components for arguments;"
-        " echo file: __comp1__ & echo folder: __comp2__ & echo combo: __comp3__ &"
-        " echo radio: __comp4__ & echo check: __comp5__ & echo check_array: __comp6__ &"
-        " echo textbox: __comp7__ & echo int: __comp8__ & echo float: __comp???__");
+        "There is undefined id \"double\" in the command. (line: 7, column: 24)");
 }
 
 TEST(JsonCheckTest, checkGUIFail7) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
-    test_json["gui"][0]["components"][1]["id"].SetString("aaa");
+    test_json["gui"][0]["command"].SetString("echo hello");
     CheckGUIError(test_json,
-        "component id \"aaa\" (line: 15, column: 27) is unused in the command;"
-        " echo file: __comp???__ & echo folder: __comp2__ & echo combo: __comp3__"
-        " & echo radio: __comp4__ & echo check: __comp5__ & echo check_array: __comp6__"
-        " & echo textbox: __comp7__ & echo int: __comp8__ & echo float: __comp9__");
+        "component id \"file\" (line: 15, column: 27) is unused in the command."
+        " (line: 7, column: 24)");
 }
 
 TEST(JsonCheckTest, checkGUIFail8) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
-    test_json["gui"][0]["components"][0]["id"].SetString("aaa");
-    test_json["gui"][0]["components"][1]["id"].SetString("aaa");
+    test_json["gui"][0]["components"][0].CopyFrom(test_json["gui"][0]["components"][1]);
     CheckGUIError(test_json,
-        "Found a duplicated id: \"aaa\" (line: 15, column: 27)");
+        "Found a duplicated id: \"file\" (line: 15, column: 27)");
+}
+
+TEST(JsonCheckTest, checkGUIFail9) {
+    tuwjson::Value test_json;
+    GetTestJson(test_json);
+    test_json["gui"][0]["components"][1].ReplaceKey("id", "id_");
+    CheckGUIError(test_json,
+        "component requires \"id\" (line: 13, column: 17)");
 }
 
 TEST(JsonCheckTest, checkGUIFailRelaxed) {


### PR DESCRIPTION
As announced in #96, all components (except for `static_text`) now require `id`. You will get errors when there are undefined ids in the command or when there are components which have no id.

This change makes json validator and its error messages more simpler.