### PR TITLE
add an error for large JSON file

### DIFF
--- a/include/json_utils.h
+++ b/include/json_utils.h
@@ -45,6 +45,7 @@ namespace json_utils {
 
 // Max binary size for JSON files.
 #define JSON_SIZE_MAX 128 * 1024
+#define JSON_SIZE_MAX_STR "128KB"
 
 // Returns an empty string if succeed. An error message otherwise.
 noex::string LoadJson(const noex::string& file, tuwjson::Value& json) noexcept;

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -55,7 +55,9 @@ noex::string LoadJson(const noex::string& file, tuwjson::Value& json) noexcept {
     char buffer[JSON_SIZE_MAX];
     size_t size = fread(buffer, sizeof(char), JSON_SIZE_MAX - 1, fp);
     fclose(fp);
-    if (size > 0)
+    if (size >= JSON_SIZE_MAX - 1)
+        return "JSON file should be smaller than " JSON_SIZE_MAX_STR ".";
+    else if (size > 0)
         buffer[size] = 0;
     else
         buffer[0] = 0;

--- a/tests/json_check_test.cpp
+++ b/tests/json_check_test.cpp
@@ -19,6 +19,20 @@ TEST(JsonCheckTest, LoadJsonFail2) {
     EXPECT_STREQ(expected, err.c_str());
 }
 
+TEST(JsonCheckTest, LoadJsonFailLarge) {
+    // Generate a large .json file.
+    FILE* f = FileOpen(JSON_LARGE, FILE_MODE_WRITE);
+    ASSERT_NE(f, nullptr);
+    for (int i = 0; i < JSON_SIZE_MAX; i++)
+        fwrite(" ", 1, 1, f);
+    fclose(f);
+    tuwjson::Value test_json;
+    noex::string err = json_utils::LoadJson(JSON_LARGE, test_json);
+    const char* expected =
+        "JSON file should be smaller than " JSON_SIZE_MAX_STR ".";
+    EXPECT_STREQ(expected, err.c_str());
+}
+
 TEST(JsonCheckTest, LoadJsonWithComments) {
     // Check if json parser supports c-style comments and trailing commas.
     tuwjson::Value test_json;

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -17,6 +17,7 @@ constexpr char JSON_ALL_KEYS[] = "./json/gui_definition.json";
 
 // you need to copy the json folder to build dir.
 constexpr char JSON_BROKEN[] = "./json/broken.json";
+constexpr char JSON_LARGE[] = "./json/large.json";
 constexpr char JSON_CONFIG_ASCII[] = "./json/config_ascii.json";
 constexpr char JSON_CONFIG_UTF[] = "./json/config_utf.json";
 constexpr char JSON_RELAXED[] = "./json/relaxed.jsonc";


### PR DESCRIPTION
Tuw only reads the first 128kb to prevent unexpected issues. It now shows an error: `JSON file should be smaller than 128KB.` with large files.

> [!note]
> Old versions of tuw have no security issue because they take the large JSON as broken files and show other errors.