### PR TITLE
add more tests, some tweaks for error messages

### DIFF
--- a/include/noex/vector.hpp
+++ b/include/noex/vector.hpp
@@ -313,7 +313,12 @@ class trivial_vector : public trivial_vector_base {
     }
 
     T& at(size_t id) const noexcept {
-        return *static_cast<T*>(at_base(id));
+        T* ptr = static_cast<T*>(at_base(id));
+        if (ptr == nullptr) {
+            static T dummy{};
+            return dummy;
+        }
+        return *ptr;
     }
 
     T& operator[](size_t id) const noexcept {

--- a/tests/vector_test.cpp
+++ b/tests/vector_test.cpp
@@ -145,3 +145,40 @@ TEST(VectorTest, Move) {
     EXPECT_EQ(4, vec2[3]);
     EXPECT_EQ(noex::OK, noex::get_error_no());
 }
+
+TEST(VectorTest, TrivialAt) {
+    noex::vector<int> vec;
+    int a;
+    a = vec.at(0);
+    EXPECT_EQ(noex::VEC_BOUNDARY_ERROR, noex::get_error_no());
+    noex::clear_error_no();
+    vec.push_back(1);
+    vec.push_back(2);
+    vec.push_back(3);
+    vec.push_back(4);
+    a = vec.at(4);
+    EXPECT_EQ(noex::VEC_BOUNDARY_ERROR, noex::get_error_no());
+    noex::clear_error_no();
+    a = vec.at(-1);
+    EXPECT_EQ(noex::VEC_BOUNDARY_ERROR, noex::get_error_no());
+    noex::clear_error_no();
+}
+
+TEST(VectorTest, NonTrivialAt) {
+    noex::vector<noex::vector<int>> vec;
+    noex::vector<int>& a = vec.at(0);
+    EXPECT_EQ(noex::VEC_BOUNDARY_ERROR, noex::get_error_no());
+    noex::clear_error_no();
+
+    noex::vector<int> vec2;
+    noex::vector<int> vec3;
+    vec.push_back(vec2);
+    vec.push_back(vec3);
+    EXPECT_EQ(2, vec.size());
+    noex::vector<int>& b = vec.at(2);
+    EXPECT_EQ(noex::VEC_BOUNDARY_ERROR, noex::get_error_no());
+    noex::clear_error_no();
+    noex::vector<int>& c = vec.at(-1);
+    EXPECT_EQ(noex::VEC_BOUNDARY_ERROR, noex::get_error_no());
+    noex::clear_error_no();
+}


### PR DESCRIPTION
I added more unit tests for future updates, and fixed nits.

- Fixed a bug where an error message for unknown codepages did not have line and column.
- `static_text` now does not throw errors for duplicated IDs.
- An error message for unknown component types is now prioritized over other component errors.
- Fixed a crash when `noex::vector` threw the out of bounds error.
   (Tuw does not throw the out of bounds error tho.)

> [!note]
> This patch just changes some JSON error messages. There is nothing you should inform to users.