### PR TITLE
Colored emojis for static controls on Windows

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -52,6 +52,7 @@ There are more features you can use.
 -   [Alternate Spellings](./other_features/alternate_spellings/): Tuw supports multiple spellings for some JSON keys and values.
 -   [Skip Success Dialog](./other_features/skip_dialog/): You can skip the success dialog.
 -   [UTF-8 Outputs on Windows](./other_features/codepage/): Tuw requires an option when using UTF-8 outputs on Windows.
+-   [Legacy Renderer on Windows](./other_features/legacy_renderer/): You can use GDI-besed renderer on Windows.
 
 ![help](https://github.com/matyalatte/tuw/assets/69258547/e408a179-6f9f-4769-ab3d-57f87d392a4f)  
 

--- a/examples/all_keys/gui_definition.json
+++ b/examples/all_keys/gui_definition.json
@@ -8,7 +8,7 @@
             "components": [
                 {
                     "type": "static_text",
-                    "label": "All components with their required keys."
+                    "label": "All components with their required keys.🙂"
                 },
                 {
                     "type": "file",
@@ -288,7 +288,8 @@
             "label": "open gui_definition.json",
             "path": "gui_definition.json"
         }
-    ],  // Trailing comma
+    ],
+    "legacy_renderer": false, // Trailing comma
 }
 // Single-line comment
 /*

--- a/examples/other_features/legacy_renderer/README.md
+++ b/examples/other_features/legacy_renderer/README.md
@@ -1,0 +1,29 @@
+# Legacy Renderer on Windows
+
+Static controls (most of the component labels) use Direct2D to draw colored emojis on Windows 8.1 or later.
+
+<img width="393" height="149" alt="new_renderer" src="https://github.com/user-attachments/assets/99c59e7e-6ae9-4fe8-ad74-b689354cfa40" /><br>
+<br>
+If you don't like the new renderer, you can use `"legacy_renderer": true` to enable the old (GDI-based) renderer.
+
+<img width="392" height="148" alt="legacy_renderer" src="https://github.com/user-attachments/assets/c9b4f15b-f189-4547-9b40-c25e9dfb1de2" />
+
+```json
+{
+    "legacy_renderer": true,
+    "gui": {
+        "command": "echo %entry%",
+        "components": [
+            {
+                "type": "text",
+                "id": "entry",
+                "label": "The legacy renderer uses colorless emojis. 🙂👏"
+            }
+        ]
+    }
+}
+```
+
+You can also switch the renderer from `Use Legacy Renderer` in the debug menu.
+
+<img width="395" height="149" alt="legacy_renderer_menu" src="https://github.com/user-attachments/assets/5b329927-4ca9-4f36-8b74-581f7556fac2" />

--- a/examples/other_features/legacy_renderer/gui_definition.json
+++ b/examples/other_features/legacy_renderer/gui_definition.json
@@ -1,0 +1,13 @@
+{
+    "legacy_renderer": true,
+    "gui": {
+        "command": "echo %entry%",
+        "components": [
+            {
+                "type": "text",
+                "id": "entry",
+                "label": "The legacy renderer uses colorless emojis. 🙂👏"
+            }
+        ]
+    }
+}

--- a/include/main_frame.h
+++ b/include/main_frame.h
@@ -28,7 +28,7 @@ class MainFrame {
     noex::vector<Component*> m_components;
     uiGrid* m_grid;
     uiButton* m_run_button;
-    uiMenuItem* m_menu_item;
+    uiMenuItem* m_menu_safe_mode;
 
     void CreateFrame() noexcept;
     void CreateMenu() noexcept;
@@ -100,7 +100,10 @@ class MainFrame {
     #endif
     }
     int IsSafeMode() noexcept {
-        return uiMenuItemChecked(m_menu_item);
+        return uiMenuItemChecked(m_menu_safe_mode);
+    }
+    size_t GetDefinitionID() noexcept {
+        return m_definition_id;
     }
 };
 

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -10,6 +10,7 @@
       "recommended_version": { "$ref": "#/definitions/types/version" },
       "minimum_required": { "$ref": "#/definitions/types/version" },
       "minimum_required_version": { "$ref": "#/definitions/types/version" },
+      "legacy_renderer": { "type": "boolean" },
       "gui": { "$ref": "#/definitions/types/gui_array" },
       "help": { "$ref": "#/definitions/types/help_array" }
     }
@@ -23,6 +24,7 @@
           "recommended_version": { "$ref": "#/definitions/types/version" },
           "minimum_required": { "$ref": "#/definitions/types/version" },
           "minimum_required_version": { "$ref": "#/definitions/types/version" },
+          "legacy_renderer": { "type": "boolean" },
           "help": { "$ref": "#/definitions/types/help_array" }
         }
       }

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -639,6 +639,7 @@ void CheckVersion(noex::string& err_msg, tuwjson::Value& definition) noexcept {
 }
 
 void CheckDefinition(noex::string& err_msg, tuwjson::Value& definition) noexcept {
+    CheckJsonType(err_msg, definition, "legacy_renderer", JsonType::BOOLEAN);
     if (!definition.HasMember("gui")) {
         // definition["gui"] = definition
         definition.ConvertToObject("gui");

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -27,7 +27,7 @@ void MainFrame::Initialize(const tuwjson::Value& definition,
     PrintFmt(tuw_constants::LOGO);
 
     m_grid = NULL;
-    m_menu_item = NULL;
+    m_menu_safe_mode = NULL;
     noex::string exe_path = envuStr(envuGetExecutablePath());
 
     m_definition.CopyFrom(definition);
@@ -202,6 +202,16 @@ static void OnOpenURL(uiMenuItem *item, uiWindow *w, void *data) noexcept {
     UNUSED(w);
 }
 
+#ifdef _WIN32
+static void OnUpdateRenderer(uiMenuItem *item, uiWindow *w, void *data) noexcept {
+    int checked = uiMenuItemChecked(item);
+    uiWindowsSetUseLegacyRenderer(checked);
+    g_main_frame->UpdatePanel(g_main_frame->GetDefinitionID());
+    UNUSED(w);
+    UNUSED(data);
+}
+#endif
+
 void MainFrame::CreateMenu() noexcept {
     g_main_frame = this;
     uiMenuItem* item;
@@ -243,7 +253,15 @@ void MainFrame::CreateMenu() noexcept {
         }
     }
     menu = uiNewMenu("Debug");
-    m_menu_item = uiMenuAppendCheckItem(menu, "Safe Mode");
+    m_menu_safe_mode = uiMenuAppendCheckItem(menu, "Safe Mode");
+#ifdef _WIN32
+    item = uiMenuAppendCheckItem(menu, "Use Legacy Renderer");
+    if (json_utils::GetBool(m_definition, "legacy_renderer", false)) {
+        uiWindowsSetUseLegacyRenderer(1);
+        uiMenuItemSetChecked(item, 1);
+    }
+    uiMenuItemOnClicked(item, OnUpdateRenderer, NULL);
+#endif
 }
 
 static bool IsValidURL(const noex::string &url) noexcept {

--- a/subprojects/libui.wrap
+++ b/subprojects/libui.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/matyalatte/libui-ng.git
-revision = 288ce2caa340b84cae01d4cf4563b1e5967312d7
+revision = 0b3c7faecef107f7098146b90933591bd97736d8
 depth = 1
 
 [provide]


### PR DESCRIPTION
Related to #129.
Static controls (most of the component labels) now use Direct2D to draw colored emojis on Windows 8.1 or later. Interactive controls (buttons and text entries) still use GDI because they have more complicated event handlers...

<img width="304" height="183" alt="emoji_win11" src="https://github.com/user-attachments/assets/71dd0066-efcd-400d-a009-01dc1884daac" />

```json
{
    "window_name": "Title here!🙂",
    "command": "echo %entry% %check%",
    "button": "Hello!🙂",
    "components": [
        {
            "type": "text",
            "id": "entry",
            "label": "Static controls can draw color emojis! 🙂👏"
        },
        {
            "type": "check",
            "id": "check",
            "label": "Interactive controls still use colorless emojis... 😭"
        }
    ]
}
```

I confirmed that it worked on Windows 10, Windows 8.1, and Windows 7.

Windows 10
<img width="395" height="199" alt="emoji_win10" src="https://github.com/user-attachments/assets/6cb34994-fa5d-4eb6-8d31-e6a992a49222" />

Windows 8.1 (It does not support some emojis.)
<img width="409" height="189" alt="emoji_win8" src="https://github.com/user-attachments/assets/fa896127-bb86-43ae-8a26-46a45163543d" />

Windows 7 (It does not support emojis.)
<img width="401" height="215" alt="emoji_win7" src="https://github.com/user-attachments/assets/f8abc4df-d5fa-4a9a-b4c5-cf2ba548fa4a" />

If you don't like the new renderer, you can use `"legacy_renderer": true` to enable the old (GDI-based) renderer.

<img width="392" height="148" alt="legacy_renderer" src="https://github.com/user-attachments/assets/c9b4f15b-f189-4547-9b40-c25e9dfb1de2" />

```json
{
    "legacy_renderer": true,
    "gui": {
        "command": "echo %entry%",
        "components": [
            {
                "type": "text",
                "id": "entry",
                "label": "The legacy renderer uses colorless emojis. 🙂👏"
            }
        ]
    }
}
```

You can also change the renderer from `Use Legacy Renderer` in the debug menu.

<img width="395" height="149" alt="legacy_renderer_menu" src="https://github.com/user-attachments/assets/5b329927-4ca9-4f36-8b74-581f7556fac2" />
