### PR TITLE
fix a bug where tuw ignores help documents when missing `"gui"`

### DIFF
--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -639,7 +639,11 @@ void CheckDefinition(noex::string& err_msg, tuwjson::Value& definition) noexcept
     CheckJsonType(err_msg, definition, "legacy_renderer", JsonType::BOOLEAN);
     if (!definition.HasMember("gui")) {
         // definition["gui"] = definition
-        definition.ConvertToObject("gui");
+        tuwjson::Value def;
+        def.CopyFrom(definition);
+        tuwjson::Value& gui = definition["gui"];
+        gui.SetArray();
+        gui.MoveAndPush(def);
     }
     tuwjson::Value* gui_json_ptr =
         CheckJsonType(err_msg, definition, "gui", JsonType::JSON_ARRAY);

--- a/tests/json_check_test.cpp
+++ b/tests/json_check_test.cpp
@@ -115,7 +115,7 @@ TEST(JsonCheckTest, checkGUIFail) {
     tuwjson::Value test_json;
     GetTestJson(test_json);
     test_json.ReplaceKey("gui", "g");
-    CheckGUIError(test_json, "gui definition requires \"components\"");
+    CheckGUIError(test_json, "gui definition requires \"components\" (line: 1, column: 1)");
 }
 
 TEST(JsonCheckTest, checkGUIFail2) {
@@ -344,4 +344,18 @@ TEST(JsonCheckTest, checkGUIMinMax) {
     test_json["gui"][1]["components"][9]["min"].SetDouble(2);
     CheckGUIError(test_json,
         "\"max\" should be greater than \"min\". (line: 251, column: 28)");
+}
+
+TEST(JsonCheckTest, checkHelpWithoutGUI) {
+    tuwjson::Value test_json;
+    GetTestJson(test_json);
+    test_json.ReplaceKey("gui", "gui_");
+    test_json["command"].SetString("echo hello");
+    test_json["components"].SetArray();
+
+    noex::string err_msg;
+    json_utils::CheckDefinition(err_msg, test_json);
+    EXPECT_TRUE(err_msg.empty());
+    EXPECT_TRUE(test_json.HasMember("help"));
+    EXPECT_TRUE(test_json.HasMember("legacy_renderer"));
 }


### PR DESCRIPTION
Related to #135.
Tuw now sets `definition["gui"] = definition` instead of `definition = { "gui": definition }` when `"gui"` is missing.
This fixes a bug where Tuw ignored the `"help"` key if `"gui"` was not present.