### PR TITLE
v0.11.0 release

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,11 @@
+ver 0.11.0
+- All components (except "static_text") now require an "id". (#131)
+- Static controls (most component labels) now render colored emojis on Windows. (#136)
+- Added an error message for large JSON files. (#132)
+- Fixed a bug where tuw ignored help documents when the "gui" key was missing. (#137)
+- Fixed a bug where the error message for unknown codepages did not include line and column numbers. (#133)
+- Various code quality improvements. (#133, #134)
+
 ver 0.10.2
 - Fixed an issue where Tuw could not find the exe path on Windows 8 or older. (#127)
 - Fixed a segmentation fault that occurred when Tuw encountered a memory allocation error. (#124)

--- a/examples/all_keys/gui_definition.json
+++ b/examples/all_keys/gui_definition.json
@@ -1,5 +1,5 @@
 {
-    "recommended": "0.10.2",
+    "recommended": "0.11.0",
     "minimum_required": "0.8.0",
     "gui": [
         {

--- a/include/tuw_constants.h
+++ b/include/tuw_constants.h
@@ -10,8 +10,8 @@ constexpr char LOGO[] =
     "       CLI tools\n";
 constexpr char TOOL_NAME[] = "Tuw";
 constexpr char AUTHOR[] = "matyalatte";
-constexpr char VERSION[] = "0.10.2";
-constexpr int VERSION_INT = 1002;
+constexpr char VERSION[] = "0.11.0";
+constexpr int VERSION_INT = 1100;
 
 #ifdef _WIN32
 #define TUW_CONSTANTS_OS "win"


### PR DESCRIPTION
- All components (except "static_text") now require an "id". (#131)
- Static controls (most component labels) now render colored emojis on Windows. (#136)
- Added an error message for large JSON files. (#132)
- Fixed a bug where tuw ignored help documents when the "gui" key was missing. (#137)
- Fixed a bug where the error message for unknown codepages did not include line and column numbers. (#133)
- Some code quality improvements. (#133, #134)
