### PR TITLE
Use ubuntu-slim runner for lightweight jobs

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -11,10 +11,9 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       tag: ${{ steps.check-tag.outputs.tag }}
-      wx_version: ${{ steps.wx-version.outputs.version }}
     steps:
 
       - name: Check tag

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Github Actions now supports `ubuntu-slim` which is a container using 1 vCPU and 5GB RAM. (`ubuntu-latest` is a VM using 4 vCPUs and 16GB RAM)

[1 vCPU Linux runner now available in GitHub Actions in public preview - GitHub Changelog](https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/)

It can reduce power consumption!