### PR TITLE
fix undefined behavior in WM_PAINT event for uiLabel

### DIFF
--- a/subprojects/libui.wrap
+++ b/subprojects/libui.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/matyalatte/libui-ng.git
-revision = 0b3c7faecef107f7098146b90933591bd97736d8
+revision = 1e644446bd429032d6dacecb4c79dd2f9c8d4429
 depth = 1
 
 [provide]


### PR DESCRIPTION
Applied the following commit.
https://github.com/matyalatte/libui-ng/commit/1e644446bd429032d6dacecb4c79dd2f9c8d4429

I don't see any practical issues in v0.11.0 but the undefined behavior should be fixed.